### PR TITLE
Update PURL mappings for conda-forge packages

### DIFF
--- a/mappings/manual.json
+++ b/mappings/manual.json
@@ -1,6 +1,37 @@
 {
   "schema_version": 1,
-  "updated_at": null,
+  "updated_at": "2026-04-27T07:22:34.191Z",
   "description": "Human-curated PURL overrides for conda-forge packages. Editing happens through the web UI which opens a PR against this file.",
-  "packages": {}
+  "packages": {
+    "curl": {
+      "purl": "pkg:github/curl/curl",
+      "type": "github",
+      "namespace": "curl",
+      "pkg_name": "curl",
+      "approved_by": "wolfv",
+      "approved_at": "2026-04-27T07:22:34.191Z"
+    },
+    "numpy": {
+      "purl": "pkg:pypi/numpy",
+      "type": "pypi",
+      "namespace": null,
+      "pkg_name": "numpy",
+      "alternative_purls": [
+        "pkg:github/numpy/numpy"
+      ],
+      "approved_by": "wolfv",
+      "approved_at": "2026-04-27T07:22:34.191Z"
+    },
+    "pyyaml": {
+      "purl": "pkg:pypi/pyyaml",
+      "type": "pypi",
+      "namespace": null,
+      "pkg_name": "pyyaml",
+      "alternative_purls": [
+        "pkg:github/yaml/pyyaml"
+      ],
+      "approved_by": "wolfv",
+      "approved_at": "2026-04-27T07:22:34.191Z"
+    }
+  }
 }


### PR DESCRIPTION
This PR updates PURL mappings for the following conda-forge packages:

- **curl**: `pkg:github/curl/curl` → `pkg:github/curl/curl`
- **numpy**: `pkg:pypi/numpy` → `pkg:pypi/numpy`
- **pyyaml**: `pkg:pypi/pyyaml` → `pkg:pypi/pyyaml`