### PR TITLE
auto-verify through parselmouth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ web/public/cves.json
 .osv_cache/
 osv_cache/
 
+# Local scratch outputs
+.tmp/
+
 # Editor / OS
 .DS_Store
 .vscode/

--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ flowchart TD
 
 `scripts.automap` uses `rattler.repo_data.Gateway` to enumerate package
 records. It partially fetches recipe files from package archives, then
-`scripts.purl_inference` decides the source PURL.
+`scripts.purl_inference` decides the source PURL. For Python packages it also
+checks the public Parselmouth conda-artifact-to-PyPI mapping by package sha256.
+When Parselmouth artifact metadata agrees with an inferred PyPI PURL, the
+mapping is marked `auto-verified` and does not need the normal human approval
+step.
 
 The inference step uses source URLs and recipe context. Recipe context matters
 because source hosting is not always the package ecosystem. For example, a

--- a/pixi.toml
+++ b/pixi.toml
@@ -48,10 +48,141 @@ cve-match = "python -m scripts.cve_match"
 lint = { cmd = "ruff check scripts && ruff format --check scripts", env = {} }
 fmt = "ruff format scripts"
 
-# Frontend (uses system npm/node — pixi just wraps the commands so they're
-# discoverable alongside the python tasks). Run `pixi run -e lite merge`
-# first if you've edited mappings data and want the SPA to see the changes.
-web-install = { cmd = "npm install", cwd = "web" }
-web-dev = { cmd = "npm run dev", cwd = "web" }
-web-build = { cmd = "npm run build", cwd = "web" }
+[tasks.automap-test]
+cmd = "python -m scripts.automap --only {{ packages }} --out {{ auto }} --parallel {{ parallel }} --force && python -m scripts.merge_mappings --auto {{ auto }} --out {{ out }}"
+description = "Test auto-association on a small package set without touching committed outputs"
+args = [
+  { arg = "packages", default = "numpy,ripgrep,pandas" },
+  { arg = "auto", default = ".tmp/auto-test.json" },
+  { arg = "out", default = ".tmp/mappings-test.json" },
+  { arg = "parallel", default = "8" },
+]
+
+# GitHub Actions helpers. Requires `gh auth login` first.
+[tasks.gh-workflows]
+cmd = "gh workflow list"
+description = "List GitHub Actions workflows"
+
+[tasks.gh-runs]
+cmd = "gh run list --limit {{ limit }}"
+description = "List recent GitHub Actions runs"
+args = [
+  { arg = "limit", default = "10" },
+]
+
+[tasks.gh-watch]
+cmd = "gh run watch {{ run }}"
+description = "Watch a GitHub Actions run by run id"
+args = [
+  { arg = "run" },
+]
+
+[tasks.gh-automap]
+cmd = "gh workflow run automap.yml --ref {{ ref }} -f limit='{{ limit }}' -f only='{{ only }}' -f force='{{ force }}'"
+description = "Trigger the Automatic PURL mapping workflow"
+args = [
+  { arg = "only", default = "" },
+  { arg = "limit", default = "" },
+  { arg = "force", default = "false" },
+  { arg = "ref", default = "main" },
+]
+
+[tasks.gh-automap-force]
+cmd = "gh workflow run automap.yml --ref {{ ref }} -f limit='{{ limit }}' -f only='{{ only }}' -f force=true"
+description = "Trigger a forced Automatic PURL mapping workflow run"
+args = [
+  { arg = "only", default = "" },
+  { arg = "limit", default = "" },
+  { arg = "ref", default = "main" },
+]
+
+[tasks.gh-cve-refresh]
+cmd = "gh workflow run cve_refresh.yml --ref {{ ref }} -f only='{{ only }}' -f limit='{{ limit }}' -f force_osv='{{ force_osv }}'"
+description = "Trigger the Refresh CVE assignments workflow"
+args = [
+  { arg = "only", default = "" },
+  { arg = "limit", default = "" },
+  { arg = "force_osv", default = "false" },
+  { arg = "ref", default = "main" },
+]
+
+[tasks.gh-pages]
+cmd = "gh workflow run pages.yml --ref {{ ref }}"
+description = "Trigger the GitHub Pages deployment workflow"
+args = [
+  { arg = "ref", default = "main" },
+]
+
+[tasks.gh-ai-vet]
+cmd = "gh workflow run ai_vet.yml --ref {{ ref }} -f mode='{{ mode }}' -f limit='{{ limit }}' -f skip_vetted='{{ skip_vetted }}' -f only='{{ only }}' -f ai_batch_size='{{ ai_batch_size }}' -f commit_every='{{ commit_every }}'"
+description = "Trigger the AI vet PURL mappings workflow"
+args = [
+  { arg = "ref", default = "main" },
+  { arg = "mode", default = "realtime" },
+  { arg = "limit", default = "200" },
+  { arg = "skip_vetted", default = "true" },
+  { arg = "only", default = "" },
+  { arg = "ai_batch_size", default = "15" },
+  { arg = "commit_every", default = "16" },
+]
+
+# Local app/Worker helpers.
+[tasks.install]
+depends-on = ["web-install", "worker-install"]
+description = "Install web and Worker npm dependencies"
+
+[tasks.check-local]
+depends-on = ["validate", "web-build", "worker-typecheck"]
+description = "Validate data, build the web app, and typecheck the Worker"
+
+[tasks.web-install]
+cmd = "npm install"
+cwd = "web"
+description = "Install frontend npm dependencies"
+
+[tasks.web-dev]
+cmd = "npm run dev -- --host {{ host }} --port {{ port }}"
+cwd = "web"
+depends-on = ["web-install"]
+description = "Run the frontend Vite dev server"
+args = [
+  { arg = "host", default = "127.0.0.1" },
+  { arg = "port", default = "5173" },
+]
+
+[tasks.web-build]
+cmd = "npm run build"
+cwd = "web"
+depends-on = ["web-install"]
+description = "Build the frontend"
+
+[tasks.web-preview]
+cmd = "npm run preview -- --host {{ host }} --port {{ port }}"
+cwd = "web"
+depends-on = ["web-build"]
+description = "Serve the built frontend locally"
+args = [
+  { arg = "host", default = "127.0.0.1" },
+  { arg = "port", default = "4173" },
+]
+
+[tasks.worker-install]
+cmd = "npm install"
+cwd = "worker"
+description = "Install Worker npm dependencies"
+
+[tasks.worker-dev]
+cmd = "npm run dev -- --port {{ port }}"
+cwd = "worker"
+depends-on = ["worker-install"]
+description = "Run the Cloudflare Worker locally with Wrangler"
+args = [
+  { arg = "port", default = "8787" },
+]
+
+[tasks.worker-typecheck]
+cmd = "npm run typecheck"
+cwd = "worker"
+depends-on = ["worker-install"]
+description = "Typecheck the Cloudflare Worker"
 

--- a/scripts/automap.py
+++ b/scripts/automap.py
@@ -20,6 +20,7 @@ from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
+import httpx
 import typer
 import yaml
 from rattler.networking import Client
@@ -37,6 +38,7 @@ from rich.progress import (
     TimeElapsedColumn,
 )
 
+from scripts.parselmouth_lookup import fetch_mapping_by_hash
 from scripts.purl_inference import (
     PurlGuess,
     derive_recipe_context,
@@ -83,6 +85,8 @@ class AutoEntry:
     summary: str | None
     source_url: str | None = None
     alternative_purls: list[dict] | None = None
+    auto_verified: bool = False
+    verification_sources: list[str] | None = None
     note: str | None = None
     fetched_at: str | None = None
     # Lifetime download count on prefix.dev (Package.totalCount), backfilled
@@ -278,6 +282,8 @@ async def _process_record(
     record: RepoDataRecord,
     *,
     semaphore: asyncio.Semaphore,
+    parselmouth_client: httpx.AsyncClient,
+    channel: str,
 ) -> AutoEntry:
     name = record.name.normalized
     url = str(record.url)
@@ -320,6 +326,56 @@ async def _process_record(
     )
     candidates: list[PurlGuess] = infer_all(candidate_urls, context=context)
     primary: PurlGuess | None = candidates[0] if candidates else None
+
+    parselmouth = await fetch_mapping_by_hash(
+        parselmouth_client,
+        sha256=getattr(record, "sha256", None),
+        channel=channel,
+    )
+    parselmouth_purls = set(parselmouth.pypi_purls if parselmouth else [])
+    agreeing_candidates = [
+        c for c in candidates if c.type == "pypi" and c.purl in parselmouth_purls
+    ]
+    auto_verified = bool(agreeing_candidates)
+    verification_sources = (
+        ["recipe-inference", "parselmouth-artifact"] if auto_verified else None
+    )
+
+    if agreeing_candidates:
+        # Independent agreement promotes the PyPI candidate to primary, even if
+        # URL-only ranking would otherwise prefer a GitHub source archive.
+        matched = max(agreeing_candidates, key=lambda c: c.confidence)
+        primary = PurlGuess(
+            purl=matched.purl,
+            type=matched.type,
+            namespace=matched.namespace,
+            pkg_name=matched.pkg_name,
+            confidence=0.99,
+            source=matched.source,
+        )
+        candidates = [primary] + [c for c in candidates if c.purl != primary.purl]
+
+    # Surface Parselmouth-discovered PyPI names as alternatives when they do not
+    # duplicate the primary/URL-inferred candidates.
+    seen_purls = {c.purl for c in candidates}
+    if parselmouth:
+        for purl, pypi_name in zip(
+            parselmouth.pypi_purls, parselmouth.pypi_normalized_names
+        ):
+            if purl in seen_purls:
+                continue
+            candidates.append(
+                PurlGuess(
+                    purl=purl,
+                    type="pypi",
+                    namespace=None,
+                    pkg_name=pypi_name,
+                    confidence=0.99,
+                    source="parselmouth-artifact",
+                )
+            )
+            seen_purls.add(purl)
+
     alternates = [
         {
             "purl": c.purl,
@@ -337,6 +393,15 @@ async def _process_record(
         note_parts.append(
             "No automatic match — heuristics did not recognise any source URL."
         )
+    if (
+        parselmouth_purls
+        and primary
+        and primary.type == "pypi"
+        and primary.purl not in parselmouth_purls
+    ):
+        note_parts.append(
+            "Parselmouth artifact metadata suggests a different PyPI package."
+        )
     note_parts.extend(recipe_context_hints(context, primary.type if primary else None))
     note: str | None = " ".join(note_parts) if note_parts else None
 
@@ -352,13 +417,19 @@ async def _process_record(
         namespace=primary.namespace if primary else None,
         pkg_name=primary.pkg_name if primary else None,
         confidence=primary.confidence if primary else 0.0,
-        sources=[primary.source] if primary else [],
+        sources=(
+            [primary.source, "parselmouth-artifact"]
+            if auto_verified and primary
+            else ([primary.source] if primary else [])
+        ),
         homepage=homepage,
         repo=repo_url,
         recipe_url=f"https://github.com/conda-forge/{name}-feedstock/blob/main/recipe/meta.yaml",
         summary=facts.summary,
         source_url=primary_source,
         alternative_purls=alternates if alternates else None,
+        auto_verified=auto_verified,
+        verification_sources=verification_sources,
         note=note,
         fetched_at=datetime.now(UTC).isoformat(timespec="seconds"),
     )
@@ -521,46 +592,54 @@ async def _async_main(
     )
 
     client = Client()
+    parselmouth_client = httpx.AsyncClient()
     semaphore = asyncio.Semaphore(parallel)
 
     new_entries: dict[str, AutoEntry] = dict(existing)
 
-    if needs_fetch:
-        with Progress(
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(),
-            MofNCompleteColumn(),
-            TimeElapsedColumn(),
-            console=console,
-            transient=False,
-        ) as progress:
-            task = progress.add_task("Fetching recipes…", total=len(needs_fetch))
+    try:
+        if needs_fetch:
+            with Progress(
+                TextColumn("[progress.description]{task.description}"),
+                BarColumn(),
+                MofNCompleteColumn(),
+                TimeElapsedColumn(),
+                console=console,
+                transient=False,
+            ) as progress:
+                task = progress.add_task("Fetching recipes…", total=len(needs_fetch))
 
-            async def runner(record: RepoDataRecord) -> AutoEntry:
-                try:
-                    return await _process_record(client, record, semaphore=semaphore)
-                except Exception as exc:  # noqa: BLE001
-                    return AutoEntry(
-                        name=record.name.normalized,
-                        version=str(record.version),
-                        build=record.build,
-                        subdir=record.subdir,
-                        url=str(record.url),
-                        purl=None,
-                        type=None,
-                        namespace=None,
-                        pkg_name=None,
-                        confidence=0.0,
-                        sources=[],
-                        homepage=None,
-                        repo=None,
-                        recipe_url=None,
-                        summary=None,
-                        note=f"fetch error: {exc}",
-                        fetched_at=datetime.now(UTC).isoformat(timespec="seconds"),
-                    )
-                finally:
-                    progress.advance(task)
+                async def runner(record: RepoDataRecord) -> AutoEntry:
+                    try:
+                        return await _process_record(
+                            client,
+                            record,
+                            semaphore=semaphore,
+                            parselmouth_client=parselmouth_client,
+                            channel=channel,
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        return AutoEntry(
+                            name=record.name.normalized,
+                            version=str(record.version),
+                            build=record.build,
+                            subdir=record.subdir,
+                            url=str(record.url),
+                            purl=None,
+                            type=None,
+                            namespace=None,
+                            pkg_name=None,
+                            confidence=0.0,
+                            sources=[],
+                            homepage=None,
+                            repo=None,
+                            recipe_url=None,
+                            summary=None,
+                            note=f"fetch error: {exc}",
+                            fetched_at=datetime.now(UTC).isoformat(timespec="seconds"),
+                        )
+                    finally:
+                        progress.advance(task)
 
             results = await asyncio.gather(*(runner(r) for r in needs_fetch))
             for entry in results:
@@ -570,6 +649,8 @@ async def _async_main(
                 if prior_entry is not None:
                     entry.download_count = prior_entry.download_count
                 new_entries[entry.name] = entry
+    finally:
+        await parselmouth_client.aclose()
 
     # Drop entries for packages that disappeared from the channel
     if not only and not limit:

--- a/scripts/merge_mappings.py
+++ b/scripts/merge_mappings.py
@@ -106,7 +106,8 @@ def main(
 
     # Layer 1: auto.
     for name, entry in auto_data.get("packages", {}).items():
-        merged[name] = {**entry, "status": "auto-unverified", "source": "auto"}
+        status = "auto-verified" if entry.get("auto_verified") else "auto-unverified"
+        merged[name] = {**entry, "status": status, "source": "auto"}
 
     # Layer 2: manual.json (legacy single-file overrides).
     legacy_attribution = {

--- a/scripts/parselmouth_lookup.py
+++ b/scripts/parselmouth_lookup.py
@@ -1,0 +1,122 @@
+"""Client for consuming public Parselmouth conda→PyPI mappings."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from scripts.purl_inference import normalize_purl, normalize_pypi_name
+
+DEFAULT_BASE_URL = "https://conda-mapping.prefix.dev"
+
+
+@dataclass(frozen=True)
+class ParselmouthMapping:
+    """A single Parselmouth hash-v0 mapping entry."""
+
+    pypi_normalized_names: list[str]
+    versions: dict[str, str]
+    conda_name: str | None = None
+    package_name: str | None = None
+    direct_url: list[str] | None = None
+
+    @property
+    def pypi_purls(self) -> list[str]:
+        return [
+            normalize_purl(f"pkg:pypi/{name}") for name in self.pypi_normalized_names
+        ]
+
+
+def _clean_base_url(base_url: str | None = None) -> str:
+    return (
+        base_url or os.getenv("PARSELMOUTH_MAPPING_BASE_URL") or DEFAULT_BASE_URL
+    ).rstrip("/")
+
+
+def _parse_mapping(data: Any) -> ParselmouthMapping | None:
+    if not isinstance(data, dict):
+        return None
+
+    names = data.get("pypi_normalized_names")
+    if not isinstance(names, list):
+        return None
+
+    clean_names = sorted(
+        {
+            normalize_pypi_name(str(name).strip())
+            for name in names
+            if isinstance(name, str) and name.strip()
+        }
+    )
+    if not clean_names:
+        return None
+
+    raw_versions = data.get("versions")
+    versions = (
+        {
+            str(k): str(v)
+            for k, v in raw_versions.items()
+            if isinstance(k, str) and isinstance(v, str)
+        }
+        if isinstance(raw_versions, dict)
+        else {}
+    )
+
+    raw_direct_url = data.get("direct_url")
+    direct_url = (
+        [str(u) for u in raw_direct_url if isinstance(u, str)]
+        if isinstance(raw_direct_url, list)
+        else None
+    )
+
+    return ParselmouthMapping(
+        pypi_normalized_names=clean_names,
+        versions=versions,
+        conda_name=data.get("conda_name")
+        if isinstance(data.get("conda_name"), str)
+        else None,
+        package_name=data.get("package_name")
+        if isinstance(data.get("package_name"), str)
+        else None,
+        direct_url=direct_url,
+    )
+
+
+async def fetch_mapping_by_hash(
+    client: httpx.AsyncClient,
+    *,
+    sha256: str | None,
+    channel: str,
+    base_url: str | None = None,
+) -> ParselmouthMapping | None:
+    """Fetch a public Parselmouth hash-v0 entry.
+
+    Parselmouth stores hash entries at ``/hash-v0/{sha256}``; older docs also
+    mention a channel-prefixed form, so we try that as a fallback.
+    """
+    if not sha256:
+        return None
+
+    base = _clean_base_url(base_url)
+    paths = (
+        f"/hash-v0/{sha256}",
+        f"/{channel}/hash-v0/{sha256}",
+    )
+
+    for path in paths:
+        try:
+            resp = await client.get(f"{base}{path}", timeout=15.0)
+        except httpx.HTTPError:
+            continue
+        if resp.status_code == 404:
+            continue
+        if resp.status_code != 200:
+            continue
+        try:
+            return _parse_mapping(resp.json())
+        except ValueError:
+            return None
+    return None

--- a/web/src/components/BulkPanel.tsx
+++ b/web/src/components/BulkPanel.tsx
@@ -228,7 +228,14 @@ export function BulkPanel({
                   <PurlChip purl={purl} theme={theme} edited={!!e} />
                 </span>
                 <StatusPill
-                  status={status as "verified" | "auto-unverified" | "unmapped" | "edited"}
+                  status={
+                    status as
+                      | "verified"
+                      | "auto-verified"
+                      | "auto-unverified"
+                      | "unmapped"
+                      | "edited"
+                  }
                   theme={theme}
                 />
               </div>

--- a/web/src/components/MappingEditor.tsx
+++ b/web/src/components/MappingEditor.tsx
@@ -97,7 +97,8 @@ export function MappingEditor({
   };
 
   const isEdited = !!edit;
-  const isVerified = p.status === "verified" && !isEdited;
+  const isVerified =
+    (p.status === "verified" || p.status === "auto-verified") && !isEdited;
 
   function updatePart(patch: Partial<Edit>): void {
     const next: Edit = { ...eff, ...patch };

--- a/web/src/components/PackageTable.tsx
+++ b/web/src/components/PackageTable.tsx
@@ -51,7 +51,8 @@ const STATUS_RANK: Record<string, number> = {
   edited: 0,
   unmapped: 1,
   "auto-unverified": 2,
-  verified: 3,
+  "auto-verified": 3,
+  verified: 4,
 };
 
 export function PackageTable({
@@ -84,7 +85,7 @@ export function PackageTable({
         return false;
       if (
         filters.unverifiedOnly &&
-        p.status === "verified" &&
+        (p.status === "verified" || p.status === "auto-verified") &&
         !edits[p.name]
       )
         return false;
@@ -144,7 +145,7 @@ export function PackageTable({
     for (const p of packages) {
       if (p.status === "unmapped" || p.purl === null) c.unmapped++;
       else if (p.status === "auto-unverified") c.unverified++;
-      else if (p.status === "verified") c.verified++;
+      else if (p.status === "verified" || p.status === "auto-verified") c.verified++;
     }
     return c;
   }, [packages, edits]);
@@ -614,6 +615,7 @@ export function PackageTable({
                       status={
                         status as
                           | "verified"
+                          | "auto-verified"
                           | "auto-unverified"
                           | "unmapped"
                           | "edited"

--- a/web/src/components/Primitives.tsx
+++ b/web/src/components/Primitives.tsx
@@ -149,7 +149,7 @@ export function StatusPill({
   status,
   theme,
 }: {
-  status: "verified" | "auto-unverified" | "unmapped" | "edited";
+  status: "verified" | "auto-verified" | "auto-unverified" | "unmapped" | "edited";
   theme: Theme;
 }) {
   const map = {
@@ -157,6 +157,11 @@ export function StatusPill({
       label: "Verified",
       bg: theme.dark ? "#1a2a18" : "#eef7e3",
       fg: theme.dark ? "#9adf6d" : "#5b9b2c",
+    },
+    "auto-verified": {
+      label: "Auto-verified",
+      bg: theme.dark ? "#162726" : "#dff8f4",
+      fg: theme.dark ? "#69d7c8" : "#15776d",
     },
     "auto-unverified": {
       label: "Unverified",

--- a/web/src/data/types.ts
+++ b/web/src/data/types.ts
@@ -48,12 +48,14 @@ export type PackageEntry = {
   source_url: string | null;
   note: string | null;
   fetched_at: string | null;
-  status: "auto-unverified" | "verified" | "unmapped" | "edited";
+  status: "auto-unverified" | "auto-verified" | "verified" | "unmapped" | "edited";
   source: "auto" | "manual";
   unmapped?: boolean;
   approved_by?: string;
   approved_at?: string;
   alternative_purls?: PurlAlternative[] | null;
+  auto_verified?: boolean;
+  verification_sources?: string[] | null;
   /** the original auto guess, kept for diff display when an override exists */
   auto?: AutoMapping;
   /** total downloads on prefix.dev for this package (null if not ranked) */


### PR DESCRIPTION
This adds auto-verification through parselmouth. We basically look at the guess and the parselmouth source and if there are entries we auto-verify if there is a consensus between the two.

It also adds a lot of pixi task to spawn up things locally and trigger github actions.