### PR TITLE
fix Parselmouth sha256 lookup

### DIFF
--- a/scripts/automap.py
+++ b/scripts/automap.py
@@ -554,7 +554,8 @@ async def _async_main(
     force: bool,
 ) -> None:
     started = time.monotonic()
-    existing = {} if force else _load_existing(out)
+    subset_run = bool(only) or limit is not None or top_downloads is not None
+    existing = {} if force and not subset_run else _load_existing(out)
     console.log(f"Loaded {len(existing):,} cached entries from {out}")
 
     if top_downloads is not None:

--- a/scripts/hydrate_downloads.py
+++ b/scripts/hydrate_downloads.py
@@ -48,9 +48,7 @@ async def _hydrate(
     data = json.loads(auto.read_text())
     packages = data.get("packages", {})
     if not isinstance(packages, dict) or not packages:
-        raise typer.BadParameter(
-            f"{auto} has no packages — run automap first."
-        )
+        raise typer.BadParameter(f"{auto} has no packages — run automap first.")
 
     hits = misses = changed = 0
     for name, entry in packages.items():
@@ -78,14 +76,10 @@ def main(
     auto: Path = typer.Option(DEFAULT_AUTO, help="auto.json path"),
     channel: str = typer.Option(DEFAULT_CHANNEL, help="prefix.dev channel"),
     endpoint: str = typer.Option(DEFAULT_ENDPOINT, help="GraphQL endpoint"),
-    concurrency: int = typer.Option(
-        16, help="Max concurrent GraphQL page requests"
-    ),
+    concurrency: int = typer.Option(16, help="Max concurrent GraphQL page requests"),
 ) -> None:
     asyncio.run(
-        _hydrate(
-            auto=auto, channel=channel, endpoint=endpoint, concurrency=concurrency
-        )
+        _hydrate(auto=auto, channel=channel, endpoint=endpoint, concurrency=concurrency)
     )
 
 

--- a/scripts/parselmouth_lookup.py
+++ b/scripts/parselmouth_lookup.py
@@ -85,10 +85,22 @@ def _parse_mapping(data: Any) -> ParselmouthMapping | None:
     )
 
 
+def _normalize_sha256(sha256: str | bytes | bytearray | None) -> str | None:
+    """Return a lowercase hex sha256 string suitable for Parselmouth URLs."""
+    if sha256 is None:
+        return None
+    if isinstance(sha256, (bytes, bytearray)):
+        return bytes(sha256).hex()
+    value = str(sha256).strip().lower()
+    if value.startswith("sha256:"):
+        value = value[len("sha256:") :]
+    return value or None
+
+
 async def fetch_mapping_by_hash(
     client: httpx.AsyncClient,
     *,
-    sha256: str | None,
+    sha256: str | bytes | bytearray | None,
     channel: str,
     base_url: str | None = None,
 ) -> ParselmouthMapping | None:
@@ -97,13 +109,14 @@ async def fetch_mapping_by_hash(
     Parselmouth stores hash entries at ``/hash-v0/{sha256}``; older docs also
     mention a channel-prefixed form, so we try that as a fallback.
     """
-    if not sha256:
+    sha256_hex = _normalize_sha256(sha256)
+    if not sha256_hex:
         return None
 
     base = _clean_base_url(base_url)
     paths = (
-        f"/hash-v0/{sha256}",
-        f"/{channel}/hash-v0/{sha256}",
+        f"/hash-v0/{sha256_hex}",
+        f"/{channel}/hash-v0/{sha256_hex}",
     )
 
     for path in paths:

--- a/scripts/top_downloads.py
+++ b/scripts/top_downloads.py
@@ -88,11 +88,11 @@ async def fetch_page(
     return pkgs["pages"], pkgs["totalCount"], rows
 
 
-async def fetch_all(
-    endpoint: str, channel: str, concurrency: int
-) -> list[PackageRank]:
+async def fetch_all(endpoint: str, channel: str, concurrency: int) -> list[PackageRank]:
     timeout = httpx.Timeout(connect=15.0, read=60.0, write=15.0, pool=15.0)
-    limits = httpx.Limits(max_connections=concurrency, max_keepalive_connections=concurrency)
+    limits = httpx.Limits(
+        max_connections=concurrency, max_keepalive_connections=concurrency
+    )
     async with httpx.AsyncClient(timeout=timeout, limits=limits, http2=False) as client:
         total_pages, total_packages, first_rows = await fetch_page(
             client, endpoint, channel, page=0
@@ -116,9 +116,7 @@ async def fetch_all(
             console=console,
             transient=False,
         ) as progress:
-            task = progress.add_task(
-                "Paging prefix.dev…", total=total_pages - 1
-            )
+            task = progress.add_task("Paging prefix.dev…", total=total_pages - 1)
 
             async def runner(page: int) -> list[PackageRank]:
                 async with semaphore:
@@ -138,9 +136,7 @@ async def fetch_all(
                             )
                     return []
 
-            results = await asyncio.gather(
-                *(runner(p) for p in range(1, total_pages))
-            )
+            results = await asyncio.gather(*(runner(p) for p in range(1, total_pages)))
 
         for rows in results:
             all_rows.extend(rows)
@@ -172,9 +168,7 @@ def _write_names(out: Path, channel: str, picked: list[PackageRank]) -> None:
         "channel": channel,
         "source": "prefix.dev GraphQL (Package.totalCount)",
         "limit": len(picked),
-        "packages": [
-            {"name": r.name, "total_count": r.total_count} for r in picked
-        ],
+        "packages": [{"name": r.name, "total_count": r.total_count} for r in picked],
     }
     out.write_text(json.dumps(payload, indent=2) + "\n")
 
@@ -201,9 +195,7 @@ def _prune_auto(auto_path: Path, keep: set[str]) -> tuple[int, int]:
     data = json.loads(auto_path.read_text())
     packages = data.get("packages", {})
     before = len(packages)
-    data["packages"] = {
-        name: entry for name, entry in packages.items() if name in keep
-    }
+    data["packages"] = {name: entry for name, entry in packages.items() if name in keep}
     data["package_count"] = len(data["packages"])
     auto_path.write_text(json.dumps(data, indent=2) + "\n")
     return before, len(data["packages"])
@@ -214,16 +206,12 @@ def main(
     limit: int = typer.Option(1000, help="How many top packages to keep"),
     channel: str = typer.Option(DEFAULT_CHANNEL, help="prefix.dev channel"),
     endpoint: str = typer.Option(DEFAULT_ENDPOINT, help="GraphQL endpoint"),
-    concurrency: int = typer.Option(
-        16, help="Max concurrent GraphQL page requests"
-    ),
+    concurrency: int = typer.Option(16, help="Max concurrent GraphQL page requests"),
     names_out: Path = typer.Option(
         DEFAULT_NAMES_OUT,
         help="Where to write the ranked top-N list (audit artifact)",
     ),
-    auto: Path = typer.Option(
-        DEFAULT_AUTO, help="auto.json path to refresh + prune"
-    ),
+    auto: Path = typer.Option(DEFAULT_AUTO, help="auto.json path to refresh + prune"),
     skip_automap: bool = typer.Option(
         False,
         "--skip-automap",


### PR DESCRIPTION
Fix Parselmouth hash lookups by converting rattler's byte-valued sha256 to hex before querying the mapping service. Also preserve existing automap entries during forced subset/top-download runs so targeted workflow dispatches don't truncate mappings/auto.json.\n\nValidation:\n- pixi run -e dev lint\n- targeted automap test for airflow-common and airflow-dbt