### PR TITLE
download-counts: add weekly refresh workflow

### DIFF
--- a/.github/workflows/download_counts.yml
+++ b/.github/workflows/download_counts.yml
@@ -1,0 +1,129 @@
+name: Refresh download counts
+
+on:
+  workflow_dispatch:
+    inputs:
+      concurrency:
+        description: "Max concurrent prefix.dev GraphQL page requests"
+        required: false
+        default: "16"
+      channel:
+        description: "prefix.dev channel"
+        required: false
+        default: "conda-forge"
+  schedule:
+    # Weekly on Wednesday at 05:17 UTC. Kept separate from automap so natural
+    # download-count churn does not get mixed into PURL mapping refresh PRs.
+    - cron: "17 5 * * 3"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: download-counts
+  cancel-in-progress: false
+
+jobs:
+  download-counts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: prefix-dev/setup-pixi@v0.9.5
+        with:
+          pixi-version: latest
+          cache: true
+
+      - name: Snapshot baseline counts
+        run: |
+          mkdir -p /tmp/download_counts_baseline
+          git show HEAD:mappings/auto.json > /tmp/download_counts_baseline/auto.json 2>/dev/null \
+            || echo '{"packages":{}}' > /tmp/download_counts_baseline/auto.json
+
+      - name: Hydrate download counts
+        run: |
+          set -euo pipefail
+          CONCURRENCY="${{ inputs.concurrency || '16' }}"
+          CHANNEL="${{ inputs.channel || 'conda-forge' }}"
+          pixi run python -m scripts.hydrate_downloads \
+            --concurrency "$CONCURRENCY" \
+            --channel "$CHANNEL"
+
+      - name: Merge mappings for the SPA
+        run: pixi run python -m scripts.merge_mappings
+
+      - name: Generate PR body
+        run: |
+          python - <<'PY' > /tmp/download_counts_pr_body.md
+          import json
+          from pathlib import Path
+
+          before = json.loads(Path('/tmp/download_counts_baseline/auto.json').read_text()).get('packages', {})
+          after = json.loads(Path('mappings/auto.json').read_text()).get('packages', {})
+
+          changed = []
+          added = removed = became_unknown = became_known = 0
+          for name, entry in after.items():
+              old = before.get(name, {}).get('download_count')
+              new = entry.get('download_count')
+              if old == new:
+                  continue
+              changed.append((name, old, new))
+              if old is None and new is not None:
+                  became_known += 1
+              elif old is not None and new is None:
+                  became_unknown += 1
+              elif old is None:
+                  added += 1
+              else:
+                  # Both known and changed.
+                  pass
+
+          for name in before.keys() - after.keys():
+              if before[name].get('download_count') is not None:
+                  removed += 1
+
+          known_after = sum(1 for entry in after.values() if entry.get('download_count') is not None)
+
+          print('Refreshes prefix.dev lifetime download counts (`Package.totalCount`) in `mappings/auto.json`.')
+          print()
+          print(f'- packages: **{len(after):,}**')
+          print(f'- packages with known counts: **{known_after:,}**')
+          print(f'- count fields changed: **{len(changed):,}**')
+          print(f'- newly known: **{became_known:,}**')
+          print(f'- became unknown: **{became_unknown:,}**')
+          if removed:
+              print(f'- removed packages with prior counts: **{removed:,}**')
+          print()
+          print('Top changed entries by absolute delta:')
+          rows = []
+          for name, old, new in changed:
+              if isinstance(old, int) and isinstance(new, int):
+                  rows.append((abs(new - old), name, old, new))
+          rows.sort(reverse=True)
+          if rows:
+              print()
+              print('| package | before | after | delta |')
+              print('| --- | ---: | ---: | ---: |')
+              for _, name, old, new in rows[:20]:
+                  print(f'| `{name}` | {old:,} | {new:,} | {new - old:+,} |')
+          else:
+              print()
+              print('_No known-to-known count deltas._')
+          PY
+          echo "----- PR body preview -----"
+          cat /tmp/download_counts_pr_body.md
+
+      - name: Open / update PR if counts changed
+        uses: peter-evans/create-pull-request@v8
+        with:
+          add-paths: |
+            mappings/auto.json
+            web/public/mappings.json
+          branch: download-counts/refresh
+          base: main
+          title: "download-counts: refresh prefix.dev totals"
+          body-path: /tmp/download_counts_pr_body.md
+          commit-message: "download-counts: refresh prefix.dev totals"
+          delete-branch: true

--- a/pixi.toml
+++ b/pixi.toml
@@ -42,6 +42,7 @@ automap = "python -m scripts.automap"
 top-downloads = "python -m scripts.top_downloads"
 hydrate-downloads = "python -m scripts.hydrate_downloads"
 merge = "python -m scripts.merge_mappings"
+download-counts-refresh = { cmd = "python -m scripts.hydrate_downloads --concurrency {{ concurrency }} --channel {{ channel }} && python -m scripts.merge_mappings", description = "Refresh prefix.dev download counts locally and rebuild the frontend mappings payload", args = [{ arg = "concurrency", default = "16" }, { arg = "channel", default = "conda-forge" }] }
 ai-vet = "python -m scripts.ai_vet"
 osv-fetch = "python -m scripts.osv_fetch"
 cve-match = "python -m scripts.cve_match"
@@ -111,6 +112,15 @@ cmd = "gh workflow run pages.yml --ref {{ ref }}"
 description = "Trigger the GitHub Pages deployment workflow"
 args = [
   { arg = "ref", default = "main" },
+]
+
+[tasks.gh-download-counts]
+cmd = "gh workflow run download_counts.yml --ref {{ ref }} -f concurrency='{{ concurrency }}' -f channel='{{ channel }}'"
+description = "Trigger the weekly download-count refresh workflow"
+args = [
+  { arg = "ref", default = "main" },
+  { arg = "concurrency", default = "16" },
+  { arg = "channel", default = "conda-forge" },
 ]
 
 [tasks.gh-ai-vet]

--- a/scripts/automap.py
+++ b/scripts/automap.py
@@ -478,12 +478,33 @@ def _load_existing(out_path: Path) -> dict[str, AutoEntry]:
     except json.JSONDecodeError:
         return {}
     entries: dict[str, AutoEntry] = {}
+    field_names = set(AutoEntry.__dataclass_fields__)
     for name, raw in payload.get("packages", {}).items():
+        if not isinstance(raw, dict):
+            continue
+        # Be tolerant of older/newer auto.json payloads carrying extra keys so
+        # cached metadata such as download_count survives schema churn.
+        filtered = {k: v for k, v in raw.items() if k in field_names}
         try:
-            entries[name] = AutoEntry(**raw)
+            entries[name] = AutoEntry(**filtered)
         except TypeError:
             continue
     return entries
+
+
+def _load_existing_download_counts(out_path: Path) -> dict[str, int]:
+    """Load preserved prefix.dev counts even when a forced automap run skips cache."""
+    if not out_path.exists():
+        return {}
+    try:
+        payload = json.loads(out_path.read_text())
+    except json.JSONDecodeError:
+        return {}
+    counts: dict[str, int] = {}
+    for name, raw in payload.get("packages", {}).items():
+        if isinstance(raw, dict) and isinstance(raw.get("download_count"), int):
+            counts[name] = raw["download_count"]
+    return counts
 
 
 def _write_out(out_path: Path, entries: dict[str, AutoEntry]) -> None:
@@ -555,8 +576,13 @@ async def _async_main(
 ) -> None:
     started = time.monotonic()
     subset_run = bool(only) or limit is not None or top_downloads is not None
+    existing_counts = _load_existing_download_counts(out)
     existing = {} if force and not subset_run else _load_existing(out)
     console.log(f"Loaded {len(existing):,} cached entries from {out}")
+    if existing_counts:
+        console.log(
+            f"Loaded {len(existing_counts):,} preserved download counts from {out}"
+        )
 
     if top_downloads is not None:
         console.log(
@@ -649,6 +675,8 @@ async def _async_main(
                 prior_entry = existing.get(entry.name)
                 if prior_entry is not None:
                     entry.download_count = prior_entry.download_count
+                elif entry.name in existing_counts:
+                    entry.download_count = existing_counts[entry.name]
                 new_entries[entry.name] = entry
     finally:
         await parselmouth_client.aclose()


### PR DESCRIPTION
## Summary
- preserve hydrated prefix.dev download counts across automap refreshes
- restore existing download counts in `mappings/auto.json`
- add a weekly/manual download-count refresh workflow
- add Pixi tasks for local refresh and manually triggering the workflow

## Validation
- `pixi run -e dev lint`
- `pixi run validate`
- `cd web && npm run build`