### PR TITLE
fix: cve score computation

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -52,6 +52,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.13-py313hd8ed1ab_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cvss-3.6-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
@@ -102,6 +103,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.13-py313hd8ed1ab_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cvss-3.6-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
@@ -177,6 +179,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.13-py313hd8ed1ab_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cvss-3.6-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
@@ -252,6 +255,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyh6dadd2b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.13-py313hd8ed1ab_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cvss-3.6-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
@@ -360,6 +364,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.13-py313hd8ed1ab_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cvss-3.6-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
@@ -406,6 +411,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.13-py313hd8ed1ab_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cvss-3.6-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
@@ -477,6 +483,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.13-py313hd8ed1ab_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cvss-3.6-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
@@ -548,6 +555,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyh6dadd2b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.13-py313hd8ed1ab_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cvss-3.6-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
@@ -1296,6 +1304,16 @@ packages:
   license: Python-2.0
   size: 48530
   timestamp: 1775613723457
+- conda: https://conda.anaconda.org/conda-forge/noarch/cvss-3.6-pyhe01879c_0.conda
+  sha256: 0701663a70bfff4b55f9096ea983bc64e8172a9ccff4520a9fe51d425d92f510
+  md5: 4975bc7d36dbf6d46c6065541ebd1c11
+  depends:
+  - python >=3.9
+  - python
+  license: LGPL-3.0-only
+  license_family: LGPL
+  size: 31566
+  timestamp: 1754417484547
 - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
   sha256: 5603c7d0321963bb9b4030eadabc3fd7ca6103a38475b4e0ed13ed6d97c86f4e
   md5: 0a2014fd9860f8b1eaa0b1f3d3771a08

--- a/pixi.toml
+++ b/pixi.toml
@@ -14,6 +14,7 @@ httpx = ">=0.28,<0.29"
 rich = ">=13"
 anthropic = ">=0.88,<1"
 packageurl-python = ">=0.17.6, <0.18"
+cvss = ">=3.6,<4"
 
 [feature.dev.dependencies]
 ruff = "*"

--- a/scripts/cve_match.py
+++ b/scripts/cve_match.py
@@ -34,6 +34,8 @@ import json
 import re
 import sys
 import time
+
+from cvss import CVSS2, CVSS3, CVSS4, CVSSError
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -314,6 +316,33 @@ def _repair_osv_record(record: dict) -> dict:
     return record
 
 
+_CVSS_PARSERS = {"CVSS_V2": CVSS2, "CVSS_V3": CVSS3, "CVSS_V4": CVSS4}
+
+
+def _enrich_severity_scores(record: dict) -> None:
+    """Compute numeric base scores for each CVSS severity entry, in place.
+
+    OSV stores the CVSS vector string under ``severity[].score``; the UI's
+    severity band depends on the numeric base score, not the vector. We
+    precompute it here so the SPA doesn't have to ship a CVSS parser. The
+    extra ``score_num`` field is allowed by the OSV schema (severity items
+    don't restrict additional properties)."""
+    severities = record.get("severity")
+    if not isinstance(severities, list):
+        return
+    for entry in severities:
+        if not isinstance(entry, dict):
+            continue
+        parser = _CVSS_PARSERS.get(entry.get("type"))
+        vector = entry.get("score")
+        if parser is None or not isinstance(vector, str):
+            continue
+        try:
+            entry["score_num"] = float(parser(vector).base_score)
+        except (CVSSError, ValueError, KeyError):
+            continue
+
+
 def _build_osv_record(
     adv: Advisory,
     affected_versions: list[str],
@@ -325,13 +354,15 @@ def _build_osv_record(
 ) -> dict:
     """Re-emit the OSV record with the conda-forge match attached.
 
-    Apart from minimal schema repairs for malformed upstream range events, the
-    record follows the advisory OSV published. Our derived data — which
-    conda-forge versions are affected, the conda PURL, which source PURL the
-    match came through — goes into ``database_specific["conda-forge"]``, the
-    OSV-sanctioned extension slot for database-specific fields. ``conda-forge``
-    is not an OSV ecosystem, so it cannot be a real ``affected[]`` entry."""
+    Apart from minimal schema repairs for malformed upstream range events and
+    a precomputed ``severity[].score_num``, the record follows the advisory
+    OSV published. Our derived data — which conda-forge versions are affected,
+    the conda PURL, which source PURL the match came through — goes into
+    ``database_specific["conda-forge"]``, the OSV-sanctioned extension slot
+    for database-specific fields. ``conda-forge`` is not an OSV ecosystem, so
+    it cannot be a real ``affected[]`` entry."""
     record = _repair_osv_record(copy.deepcopy(adv.raw))
+    _enrich_severity_scores(record)
     db = record.get("database_specific")
     if not isinstance(db, dict):
         db = {}

--- a/web/src/components/CveDetail.tsx
+++ b/web/src/components/CveDetail.tsx
@@ -32,17 +32,11 @@ type Props = {
   onRequestLogin: () => void;
 };
 
-function severityLevel(score: string): {
+function severityLevel(v: number): {
   label: string;
   color: string;
   bg: string;
 } | null {
-  // Pull the base CVSS score out of a vector string. The "base" segment is
-  // formatted differently across V3/V4 — for our purposes we just look for
-  // the trailing "/X.Y" pattern or any single number, mapping to a band.
-  const m = score.match(/(\d+\.\d+)/);
-  if (!m) return null;
-  const v = parseFloat(m[1]);
   if (v >= 9.0) return { label: `${v.toFixed(1)} critical`, color: "#fff", bg: "#a8201f" };
   if (v >= 7.0) return { label: `${v.toFixed(1)} high`, color: "#fff", bg: "#d94e1f" };
   if (v >= 4.0) return { label: `${v.toFixed(1)} medium`, color: "#001d38", bg: "#ffd432" };
@@ -52,8 +46,8 @@ function severityLevel(score: string): {
 
 function SeverityPill({ adv }: { adv: Advisory }) {
   const severity = bestSeverity(adv);
-  if (!severity?.score) return null;
-  const lvl = severityLevel(severity.score);
+  if (!severity?.score || severity.score_num == null) return null;
+  const lvl = severityLevel(severity.score_num);
   if (!lvl) return null;
   return (
     <span

--- a/web/src/components/CvePRDrawer.tsx
+++ b/web/src/components/CvePRDrawer.tsx
@@ -116,11 +116,8 @@ export function CvePRDrawer({
     }
     lines.push("");
 
-    function severityText(score: string | null | undefined): string {
-      if (!score) return "";
-      const m = score.match(/(\d+\.\d+)/);
-      if (!m) return "";
-      const v = parseFloat(m[1]);
+    function severityText(v: number | null | undefined): string {
+      if (v == null) return "";
       if (v >= 9.0) return ` · ${v.toFixed(1)} critical`;
       if (v >= 7.0) return ` · ${v.toFixed(1)} high`;
       if (v >= 4.0) return ` · ${v.toFixed(1)} medium`;
@@ -148,7 +145,7 @@ export function CvePRDrawer({
         const adv = pkg?.advisories.find((a) => a.id === advisoryId);
         const label = adv ? primaryId(adv) : advisoryId;
         const status = STATUS_LABELS[edit.status] || edit.status;
-        const sev = severityText(adv ? bestSeverity(adv)?.score : undefined);
+        const sev = severityText(adv ? bestSeverity(adv)?.score_num : undefined);
         const prior = adv ? advisoryVex(adv) : undefined;
         const priorStatus = prior?.status;
         const transition =

--- a/web/src/data/cves.ts
+++ b/web/src/data/cves.ts
@@ -9,7 +9,7 @@
 
 /* ---- OSV record shape (https://ossf.github.io/osv-schema/) ---- */
 
-export type OsvSeverity = { type: string; score: string };
+export type OsvSeverity = { type: string; score: string; score_num?: number };
 export type OsvReference = { type: string; url: string };
 export type OsvEvent = {
   introduced?: string;


### PR DESCRIPTION
We had a regex that grabbed some numbers from the CVE score text string. To properly compute it we need to use `cvss`. Usign the official redhat python package for it.