### PR TITLE
cves: add "active on latest" triage view

### DIFF
--- a/schemas/cve-package.schema.json
+++ b/schemas/cve-package.schema.json
@@ -12,6 +12,7 @@
     "purls": { "type": "array", "items": { "type": "string" } },
     "generated_at": { "type": "string" },
     "conda_versions_total": { "type": "integer", "minimum": 0 },
+    "latest_version": { "type": ["string", "null"] },
     "advisories": {
       "type": "array",
       "items": {

--- a/schemas/cve-package.schema.json
+++ b/schemas/cve-package.schema.json
@@ -32,6 +32,7 @@
                   "purl": { "type": "string", "pattern": "^pkg:conda/" },
                   "source_purls": { "type": "array", "items": { "type": "string" } },
                   "affected_versions": { "type": "array", "items": { "type": "string" } },
+                  "affects_future": { "type": "boolean" },
                   "conda_versions_total": { "type": "integer", "minimum": 0 },
                   "derived_by": { "type": "string" },
                   "generated_at": { "type": "string" }

--- a/schemas/cves-bundle.schema.json
+++ b/schemas/cves-bundle.schema.json
@@ -56,6 +56,7 @@
                           "type": "array",
                           "items": { "type": "string" }
                         },
+                        "affects_future": { "type": "boolean" },
                         "conda_versions_total": {
                           "type": "integer",
                           "minimum": 0

--- a/schemas/cves-bundle.schema.json
+++ b/schemas/cves-bundle.schema.json
@@ -30,6 +30,7 @@
           "purls": { "type": "array", "items": { "type": "string" } },
           "generated_at": { "type": "string" },
           "conda_versions_total": { "type": "integer", "minimum": 0 },
+          "latest_version": { "type": ["string", "null"] },
           "advisories": {
             "type": "array",
             "items": {

--- a/scripts/cve_match.py
+++ b/scripts/cve_match.py
@@ -615,12 +615,17 @@ async def _async_main(
                     not r["database_specific"]["conda-forge"]["affected_versions"]
                 )
             )
+            # versions is sorted ascending by rattler.Version; the last entry
+            # is the newest conda-forge release. The frontend uses this to
+            # surface "active on latest" advisories for triage prioritization.
+            latest_version = versions[-1].version if versions else None
             payload = {
                 "schema_version": 1,
                 "package": name,
                 "purls": source_purls,
                 "generated_at": generated_at,
                 "conda_versions_total": len(versions),
+                "latest_version": latest_version,
                 "advisories": advisories,
             }
             written.append(_write_file(out_dir, name, payload))

--- a/scripts/cve_match.py
+++ b/scripts/cve_match.py
@@ -314,6 +314,46 @@ def _repair_osv_record(record: dict) -> dict:
     return record
 
 
+def _affects_future_version(adv: Advisory, latest: Version | None) -> bool:
+    """True iff some upstream-affected version is strictly newer than the
+    latest conda-forge version of the package.
+
+    This is the "we lag behind upstream" signal: the advisory's affected set
+    includes a version conda-forge hasn't shipped yet, so a future release
+    will be vulnerable on arrival. Treat it as a triage priority — gives
+    maintainers a chance to block the upload or patch before it lands.
+
+    Sources checked:
+    * Explicit ``affected[].versions`` list (e.g. mistralai's
+      ``GHSA-wx9m-wx4f-4cmg`` which enumerates ``["2.4.6"]``).
+    * Range events with ``introduced > latest`` — the bug is introduced at a
+      version we don't have yet, so all conda-forge releases that catch up
+      to it will be vulnerable.
+
+    Returns False when ``latest`` is unknown or every reachable affected
+    version is at/below it (the standard "active on latest" case is handled
+    separately)."""
+    if latest is None:
+        return False
+    entry = adv.raw_affected
+    for v in entry.get("versions") or []:
+        parsed = _safe_version(v)
+        if parsed is not None and parsed > latest:
+            return True
+    for rng in entry.get("ranges") or []:
+        if not isinstance(rng, dict) or rng.get("type") == "GIT":
+            continue
+        for ev in rng.get("events") or []:
+            if not isinstance(ev, dict):
+                continue
+            introduced = ev.get("introduced")
+            if isinstance(introduced, str):
+                parsed = _safe_version(introduced)
+                if parsed is not None and parsed > latest:
+                    return True
+    return False
+
+
 def _build_osv_record(
     adv: Advisory,
     affected_versions: list[str],
@@ -321,6 +361,7 @@ def _build_osv_record(
     conda_package: str,
     source_purls: list[str],
     conda_versions_total: int,
+    latest_version: Version | None,
     generated_at: str,
 ) -> dict:
     """Re-emit the OSV record with the conda-forge match attached.
@@ -328,7 +369,8 @@ def _build_osv_record(
     Apart from minimal schema repairs for malformed upstream range events, the
     record follows the advisory OSV published. Our derived data — which
     conda-forge versions are affected, the conda PURL, which source PURL the
-    match came through — goes into ``database_specific["conda-forge"]``, the
+    match came through, whether the advisory targets a future version we
+    don't ship yet — goes into ``database_specific["conda-forge"]``, the
     OSV-sanctioned extension slot for database-specific fields. ``conda-forge``
     is not an OSV ecosystem, so it cannot be a real ``affected[]`` entry."""
     record = _repair_osv_record(copy.deepcopy(adv.raw))
@@ -341,6 +383,7 @@ def _build_osv_record(
         "source_purls": source_purls,
         "affected_versions": affected_versions,
         "conda_versions_total": conda_versions_total,
+        "affects_future": _affects_future_version(adv, latest_version),
         "derived_by": "purl-associator/scripts.cve_match",
         "generated_at": generated_at,
     }
@@ -598,6 +641,7 @@ async def _async_main(
                 progress.advance(task)
                 continue
             source_purls = [p.to_string() for p in purls]
+            latest_parsed = versions[-1].parsed if versions else None
             advisories = [
                 _build_osv_record(
                     adv,
@@ -605,6 +649,7 @@ async def _async_main(
                     conda_package=name,
                     source_purls=source_purls,
                     conda_versions_total=len(versions),
+                    latest_version=latest_parsed,
                     generated_at=generated_at,
                 )
                 for adv, affected in matched.values()
@@ -616,8 +661,9 @@ async def _async_main(
                 )
             )
             # versions is sorted ascending by rattler.Version; the last entry
-            # is the newest conda-forge release. The frontend uses this to
-            # surface "active on latest" advisories for triage prioritization.
+            # is the newest conda-forge release. The frontend uses
+            # latest_version (raw string) to surface "active on latest"
+            # advisories for triage prioritization.
             latest_version = versions[-1].version if versions else None
             payload = {
                 "schema_version": 1,

--- a/web/src/CveApp.tsx
+++ b/web/src/CveApp.tsx
@@ -9,6 +9,7 @@ import {
 import { LoginModal } from "./components/LoginModal";
 import { Btn, Glyph, useTheme } from "./components/Primitives";
 import { CvePackageList } from "./components/CvePackageList";
+import { CveActiveList } from "./components/CveActiveList";
 import { CveDetail } from "./components/CveDetail";
 import { CvePRDrawer } from "./components/CvePRDrawer";
 import { config, repoFullName } from "./config";
@@ -34,6 +35,7 @@ export function CveApp() {
   const [statusFilter, setStatusFilter] = useState<"all" | "unreviewed" | "reviewed">(
     "all",
   );
+  const [view, setView] = useState<"browse" | "active">("browse");
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [loginOpen, setLoginOpen] = useState(false);
   const [token, setToken] = useState<string | null>(null);
@@ -390,31 +392,85 @@ export function CveApp() {
       )}
 
       <div style={{ flex: 1, display: "flex", minHeight: 0 }}>
-        <div style={{ flex: "0 0 38%", minWidth: 0 }}>
-          {payload ? (
-            <CvePackageList
+        <div
+          style={{
+            flex: "0 0 38%",
+            minWidth: 0,
+            display: "flex",
+            flexDirection: "column",
+            background: t.surface,
+            borderRight: `1px solid ${t.border}`,
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              gap: 2,
+              padding: "8px 10px 0 10px",
+              borderBottom: `1px solid ${t.border}`,
+              background: t.surface,
+              flexShrink: 0,
+            }}
+          >
+            <ViewTab
               theme={theme}
-              packages={packages}
-              edits={edits}
-              focusedId={focusedPkg}
-              setFocusedId={setFocusedPkg}
-              q={q}
-              setQ={setQ}
-              statusFilter={statusFilter}
-              setStatusFilter={setStatusFilter}
-            />
-          ) : (
-            <div
-              style={{
-                padding: 30,
-                color: t.fg2,
-                textAlign: "center",
-                fontSize: 13,
-              }}
+              active={view === "browse"}
+              onClick={() => setView("browse")}
             >
-              Loading advisories…
-            </div>
-          )}
+              All packages
+            </ViewTab>
+            <ViewTab
+              theme={theme}
+              active={view === "active"}
+              onClick={() => setView("active")}
+              accent
+            >
+              <Glyph name="alert" size={11} /> Active on latest
+            </ViewTab>
+          </div>
+          <div style={{ flex: 1, minHeight: 0 }}>
+            {payload ? (
+              view === "browse" ? (
+                <CvePackageList
+                  theme={theme}
+                  packages={packages}
+                  edits={edits}
+                  focusedId={focusedPkg}
+                  setFocusedId={setFocusedPkg}
+                  q={q}
+                  setQ={setQ}
+                  statusFilter={statusFilter}
+                  setStatusFilter={setStatusFilter}
+                />
+              ) : (
+                <CveActiveList
+                  theme={theme}
+                  packages={packages}
+                  edits={edits}
+                  focusedPkg={focusedPkg}
+                  onSelect={(pkgName, advisoryId) => {
+                    setFocusedPkg(pkgName);
+                    requestAnimationFrame(() => {
+                      const el = document.getElementById(`adv-${advisoryId}`);
+                      if (el)
+                        el.scrollIntoView({ behavior: "smooth", block: "center" });
+                    });
+                  }}
+                />
+              )
+            ) : (
+              <div
+                style={{
+                  padding: 30,
+                  color: t.fg2,
+                  textAlign: "center",
+                  fontSize: 13,
+                }}
+              >
+                Loading advisories…
+              </div>
+            )}
+          </div>
         </div>
 
         <div style={{ flex: 1, minWidth: 0, display: "flex" }}>
@@ -470,5 +526,42 @@ export function CveApp() {
 
       {loginOpen && <LoginModal theme={theme} onClose={() => setLoginOpen(false)} />}
     </div>
+  );
+}
+
+function ViewTab({
+  theme,
+  active,
+  accent,
+  onClick,
+  children,
+}: {
+  theme: ReturnType<typeof useTheme>;
+  active: boolean;
+  accent?: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  const t = theme.t;
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 5,
+        background: active ? t.surface2 : "transparent",
+        border: 0,
+        borderBottom: `2px solid ${active ? (accent ? "#a8201f" : t.accent) : "transparent"}`,
+        color: active ? t.fg1 : t.fg2,
+        padding: "8px 12px 6px 12px",
+        fontSize: 12,
+        fontWeight: 600,
+        cursor: "pointer",
+        fontFamily: "Inter, sans-serif",
+      }}
+    >
+      {children}
+    </button>
   );
 }

--- a/web/src/components/CveActiveList.tsx
+++ b/web/src/components/CveActiveList.tsx
@@ -1,0 +1,468 @@
+import { useMemo, useRef, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import {
+  advisoryVex,
+  bestSeverity,
+  cveIds,
+  isActiveOnLatest,
+  primaryId,
+} from "../data/cves";
+import type { Advisory, CvePackage, ReviewEdit } from "../data/cves";
+import { Glyph, Theme } from "./Primitives";
+
+type Props = {
+  theme: Theme;
+  packages: CvePackage[];
+  edits: Record<string, ReviewEdit>;
+  focusedPkg: string | null;
+  onSelect: (pkgName: string, advisoryId: string) => void;
+};
+
+type Row = {
+  pkg: CvePackage;
+  adv: Advisory;
+  score: number; // CVSS base score (0 when unknown)
+  reviewed: boolean; // has a real VEX status other than under_investigation
+};
+
+const SEVERITY_BAND = (
+  v: number,
+): { label: string; bg: string; fg: string } | null => {
+  if (v >= 9.0) return { label: "critical", bg: "#a8201f", fg: "#fff" };
+  if (v >= 7.0) return { label: "high", bg: "#d94e1f", fg: "#fff" };
+  if (v >= 4.0) return { label: "medium", bg: "#ffd432", fg: "#001d38" };
+  if (v > 0) return { label: "low", bg: "#5b9b2c", fg: "#fff" };
+  return null;
+};
+
+type SeverityFilter = "all" | "critical" | "high+";
+
+export function CveActiveList({
+  theme,
+  packages,
+  edits,
+  focusedPkg,
+  onSelect,
+}: Props) {
+  const t = theme.t;
+  const [q, setQ] = useState("");
+  const [sev, setSev] = useState<SeverityFilter>("all");
+  const [onlyUnreviewed, setOnlyUnreviewed] = useState(true);
+
+  const rows = useMemo<Row[]>(() => {
+    const out: Row[] = [];
+    for (const pkg of packages) {
+      for (const adv of pkg.advisories) {
+        if (!isActiveOnLatest(pkg, adv)) continue;
+        // Editing in-memory takes precedence over the persisted VEX status, so
+        // a row the user has already triaged in this session drops out of
+        // "unreviewed" immediately.
+        const key = `${pkg.package}::${adv.id}`;
+        const editStatus = edits[key]?.status;
+        const persisted = advisoryVex(adv)?.status;
+        const effective = editStatus ?? persisted;
+        const reviewed = !!effective && effective !== "under_investigation";
+        out.push({
+          pkg,
+          adv,
+          score: bestSeverity(adv)?.score_num ?? 0,
+          reviewed,
+        });
+      }
+    }
+    // Highest severity first; within a tie, unreviewed first; then by package
+    // name for stable ordering.
+    out.sort((a, b) => {
+      if (a.score !== b.score) return b.score - a.score;
+      if (a.reviewed !== b.reviewed) return a.reviewed ? 1 : -1;
+      return a.pkg.package.localeCompare(b.pkg.package);
+    });
+    return out;
+  }, [packages, edits]);
+
+  const counts = useMemo(() => {
+    let critical = 0;
+    let high = 0;
+    let unreviewed = 0;
+    for (const r of rows) {
+      if (r.score >= 9.0) critical++;
+      if (r.score >= 7.0) high++;
+      if (!r.reviewed) unreviewed++;
+    }
+    return { total: rows.length, critical, high, unreviewed };
+  }, [rows]);
+
+  const filtered = useMemo(() => {
+    const ql = q.trim().toLowerCase();
+    return rows.filter((r) => {
+      if (sev === "critical" && r.score < 9.0) return false;
+      if (sev === "high+" && r.score < 7.0) return false;
+      if (onlyUnreviewed && r.reviewed) return false;
+      if (ql) {
+        const inName = r.pkg.package.toLowerCase().includes(ql);
+        const inCve =
+          cveIds(r.adv).some((id) => id.toLowerCase().includes(ql)) ||
+          r.adv.id.toLowerCase().includes(ql);
+        const inSummary = (r.adv.summary || "").toLowerCase().includes(ql);
+        if (!inName && !inCve && !inSummary) return false;
+      }
+      return true;
+    });
+  }, [rows, q, sev, onlyUnreviewed]);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const ROW_H = 68;
+  const virtualizer = useVirtualizer({
+    count: filtered.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => ROW_H,
+    overscan: 8,
+  });
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+        background: t.surface,
+        borderRight: `1px solid ${t.border}`,
+        minWidth: 0,
+      }}
+    >
+      <div
+        style={{
+          padding: "12px 14px",
+          borderBottom: `1px solid ${t.border}`,
+          display: "flex",
+          flexDirection: "column",
+          gap: 10,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <Glyph name="alert" size={15} />
+          <div style={{ fontSize: 13, fontWeight: 600, color: t.fg1 }}>
+            Active on latest conda-forge
+          </div>
+          <div
+            style={{
+              fontSize: 11,
+              color: t.fg2,
+              fontVariantNumeric: "tabular-nums",
+            }}
+          >
+            {filtered.length.toLocaleString()}{" "}
+            <span style={{ color: t.fg3 }}>
+              / {counts.total.toLocaleString()}
+            </span>
+          </div>
+        </div>
+        <div style={{ fontSize: 11, color: t.fg3, lineHeight: 1.45 }}>
+          Advisories still affecting the newest published conda-forge build —
+          the priority list for triage.
+        </div>
+
+        <div style={{ position: "relative" }}>
+          <span
+            style={{
+              position: "absolute",
+              left: 10,
+              top: "50%",
+              transform: "translateY(-50%)",
+              color: t.fg3,
+              display: "flex",
+            }}
+          >
+            <Glyph name="search" size={13} />
+          </span>
+          <input
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search by name, CVE id, or summary…"
+            style={{
+              width: "100%",
+              background: t.surface2,
+              border: `1px solid ${t.border}`,
+              borderRadius: 8,
+              padding: "7px 10px 7px 30px",
+              fontSize: 13,
+              fontFamily: "Inter, sans-serif",
+              color: t.fg1,
+              outline: "none",
+            }}
+          />
+          {q && (
+            <button
+              onClick={() => setQ("")}
+              style={{
+                position: "absolute",
+                right: 6,
+                top: "50%",
+                transform: "translateY(-50%)",
+                background: "transparent",
+                border: 0,
+                cursor: "pointer",
+                color: t.fg3,
+                padding: 4,
+              }}
+            >
+              <Glyph name="close" size={12} />
+            </button>
+          )}
+        </div>
+
+        <div style={{ display: "flex", gap: 5, flexWrap: "wrap" }}>
+          <Chip theme={theme} active={sev === "all"} onClick={() => setSev("all")}>
+            All <CountTag active={sev === "all"} theme={theme}>{counts.total}</CountTag>
+          </Chip>
+          <Chip theme={theme} active={sev === "high+"} onClick={() => setSev("high+")}>
+            High+ <CountTag active={sev === "high+"} theme={theme}>{counts.high}</CountTag>
+          </Chip>
+          <Chip
+            theme={theme}
+            active={sev === "critical"}
+            onClick={() => setSev("critical")}
+          >
+            Critical{" "}
+            <CountTag active={sev === "critical"} theme={theme}>{counts.critical}</CountTag>
+          </Chip>
+          <Chip
+            theme={theme}
+            active={onlyUnreviewed}
+            onClick={() => setOnlyUnreviewed(!onlyUnreviewed)}
+          >
+            Unreviewed only{" "}
+            <CountTag active={onlyUnreviewed} theme={theme}>{counts.unreviewed}</CountTag>
+          </Chip>
+        </div>
+      </div>
+
+      <div ref={scrollRef} style={{ flex: 1, overflowY: "auto" }}>
+        {filtered.length === 0 ? (
+          <div
+            style={{
+              padding: 30,
+              textAlign: "center",
+              color: t.fg3,
+              fontSize: 12,
+            }}
+          >
+            Nothing to triage.
+          </div>
+        ) : (
+          <div
+            style={{
+              height: virtualizer.getTotalSize(),
+              position: "relative",
+              width: "100%",
+            }}
+          >
+            {virtualizer.getVirtualItems().map((vi) => {
+              const r = filtered[vi.index];
+              const focused =
+                focusedPkg === r.pkg.package;
+              const band = SEVERITY_BAND(r.score);
+              return (
+                <div
+                  key={`${r.pkg.package}::${r.adv.id}`}
+                  onClick={() => onSelect(r.pkg.package, r.adv.id)}
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    width: "100%",
+                    height: ROW_H,
+                    transform: `translateY(${vi.start}px)`,
+                    display: "flex",
+                    flexDirection: "column",
+                    justifyContent: "center",
+                    gap: 4,
+                    padding: "8px 14px",
+                    borderBottom: `1px solid ${t.border}`,
+                    background: focused ? t.rowSelected : "transparent",
+                    cursor: "pointer",
+                    borderLeft: focused
+                      ? `3px solid ${t.accent}`
+                      : "3px solid transparent",
+                  }}
+                >
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      minWidth: 0,
+                    }}
+                  >
+                    {band ? (
+                      <span
+                        style={{
+                          display: "inline-flex",
+                          alignItems: "center",
+                          gap: 4,
+                          fontSize: 10.5,
+                          fontWeight: 700,
+                          padding: "2px 7px",
+                          borderRadius: 4,
+                          background: band.bg,
+                          color: band.fg,
+                          letterSpacing: ".02em",
+                          textTransform: "uppercase",
+                          minWidth: 88,
+                          justifyContent: "center",
+                        }}
+                      >
+                        {r.score.toFixed(1)} {band.label}
+                      </span>
+                    ) : (
+                      <span
+                        style={{
+                          fontSize: 10.5,
+                          color: t.fg3,
+                          minWidth: 88,
+                          textAlign: "center",
+                        }}
+                      >
+                        no score
+                      </span>
+                    )}
+                    <code
+                      style={{
+                        fontFamily: "JetBrains Mono, monospace",
+                        fontSize: 13,
+                        fontWeight: 600,
+                        color: t.fg1,
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {r.pkg.package}
+                    </code>
+                    <span
+                      style={{
+                        fontFamily: "JetBrains Mono, monospace",
+                        fontSize: 10.5,
+                        color: t.fg3,
+                        background: t.inset,
+                        padding: "1px 6px",
+                        borderRadius: 3,
+                      }}
+                      title="Latest conda-forge version"
+                    >
+                      {r.pkg.latest_version}
+                    </span>
+                    <code
+                      style={{
+                        fontFamily: "JetBrains Mono, monospace",
+                        fontSize: 11,
+                        color: t.fg2,
+                        marginLeft: "auto",
+                      }}
+                    >
+                      {primaryId(r.adv)}
+                    </code>
+                    {!r.reviewed && (
+                      <span
+                        style={{
+                          fontSize: 10,
+                          fontWeight: 700,
+                          padding: "1px 6px",
+                          borderRadius: 3,
+                          background: theme.dark ? "#2a2616" : "#fff4d2",
+                          color: theme.dark ? "#f5c542" : "#866400",
+                          textTransform: "uppercase",
+                          letterSpacing: ".02em",
+                        }}
+                      >
+                        Unreviewed
+                      </span>
+                    )}
+                  </div>
+                  {r.adv.summary && (
+                    <div
+                      style={{
+                        fontSize: 11.5,
+                        color: t.fg2,
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {r.adv.summary}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Chip({
+  theme,
+  active,
+  onClick,
+  children,
+}: {
+  theme: Theme;
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  const t = theme.t;
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        background: active ? t.accent : t.surface2,
+        color: active ? t.accentFg : t.fg1,
+        border: `1px solid ${active ? t.accent : t.border}`,
+        borderRadius: 6,
+        padding: "3px 8px",
+        fontSize: 11.5,
+        fontWeight: 600,
+        cursor: "pointer",
+        fontFamily: "Inter, sans-serif",
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function CountTag({
+  theme,
+  active,
+  children,
+}: {
+  theme: Theme;
+  active: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <span
+      style={{
+        fontSize: 10,
+        fontWeight: 700,
+        fontVariantNumeric: "tabular-nums",
+        background: active
+          ? "rgba(0,29,56,.15)"
+          : theme.dark
+            ? "#0a0d11"
+            : "#ece8df",
+        color: active ? "#001d38" : theme.t.fg2,
+        padding: "0 5px",
+        borderRadius: 3,
+      }}
+    >
+      {children}
+    </span>
+  );
+}

--- a/web/src/components/CveActiveList.tsx
+++ b/web/src/components/CveActiveList.tsx
@@ -5,6 +5,7 @@ import {
   bestSeverity,
   cveIds,
   isActiveOnLatest,
+  isFutureAffected,
   primaryId,
 } from "../data/cves";
 import type { Advisory, CvePackage, ReviewEdit } from "../data/cves";
@@ -18,9 +19,12 @@ type Props = {
   onSelect: (pkgName: string, advisoryId: string) => void;
 };
 
+type Kind = "now" | "future";
+
 type Row = {
   pkg: CvePackage;
   adv: Advisory;
+  kind: Kind;
   score: number; // CVSS base score (0 when unknown)
   reviewed: boolean; // has a real VEX status other than under_investigation
 };
@@ -36,6 +40,7 @@ const SEVERITY_BAND = (
 };
 
 type SeverityFilter = "all" | "critical" | "high+";
+type KindFilter = "all" | "now" | "future";
 
 export function CveActiveList({
   theme,
@@ -47,13 +52,17 @@ export function CveActiveList({
   const t = theme.t;
   const [q, setQ] = useState("");
   const [sev, setSev] = useState<SeverityFilter>("all");
+  const [kindFilter, setKindFilter] = useState<KindFilter>("all");
   const [onlyUnreviewed, setOnlyUnreviewed] = useState(true);
 
   const rows = useMemo<Row[]>(() => {
     const out: Row[] = [];
     for (const pkg of packages) {
       for (const adv of pkg.advisories) {
-        if (!isActiveOnLatest(pkg, adv)) continue;
+        let kind: Kind | null = null;
+        if (isActiveOnLatest(pkg, adv)) kind = "now";
+        else if (isFutureAffected(pkg, adv)) kind = "future";
+        if (!kind) continue;
         // Editing in-memory takes precedence over the persisted VEX status, so
         // a row the user has already triaged in this session drops out of
         // "unreviewed" immediately.
@@ -65,15 +74,17 @@ export function CveActiveList({
         out.push({
           pkg,
           adv,
+          kind,
           score: bestSeverity(adv)?.score_num ?? 0,
           reviewed,
         });
       }
     }
-    // Highest severity first; within a tie, unreviewed first; then by package
-    // name for stable ordering.
+    // Highest severity first; within a tie: shipping now > future > tied;
+    // then unreviewed first; then by package name for stable ordering.
     out.sort((a, b) => {
       if (a.score !== b.score) return b.score - a.score;
+      if (a.kind !== b.kind) return a.kind === "now" ? -1 : 1;
       if (a.reviewed !== b.reviewed) return a.reviewed ? 1 : -1;
       return a.pkg.package.localeCompare(b.pkg.package);
     });
@@ -84,12 +95,16 @@ export function CveActiveList({
     let critical = 0;
     let high = 0;
     let unreviewed = 0;
+    let now = 0;
+    let future = 0;
     for (const r of rows) {
       if (r.score >= 9.0) critical++;
       if (r.score >= 7.0) high++;
       if (!r.reviewed) unreviewed++;
+      if (r.kind === "now") now++;
+      else future++;
     }
-    return { total: rows.length, critical, high, unreviewed };
+    return { total: rows.length, critical, high, unreviewed, now, future };
   }, [rows]);
 
   const filtered = useMemo(() => {
@@ -97,6 +112,7 @@ export function CveActiveList({
     return rows.filter((r) => {
       if (sev === "critical" && r.score < 9.0) return false;
       if (sev === "high+" && r.score < 7.0) return false;
+      if (kindFilter !== "all" && r.kind !== kindFilter) return false;
       if (onlyUnreviewed && r.reviewed) return false;
       if (ql) {
         const inName = r.pkg.package.toLowerCase().includes(ql);
@@ -108,7 +124,7 @@ export function CveActiveList({
       }
       return true;
     });
-  }, [rows, q, sev, onlyUnreviewed]);
+  }, [rows, q, sev, kindFilter, onlyUnreviewed]);
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const ROW_H = 68;
@@ -158,8 +174,11 @@ export function CveActiveList({
           </div>
         </div>
         <div style={{ fontSize: 11, color: t.fg3, lineHeight: 1.45 }}>
-          Advisories still affecting the newest published conda-forge build —
-          the priority list for triage.
+          Advisories shipping on the newest conda-forge build (
+          <strong style={{ color: t.fg2 }}>now</strong>) plus ones targeting
+          a future version we don't have yet (
+          <strong style={{ color: t.fg2 }}>future</strong>) — block them
+          before they land.
         </div>
 
         <div style={{ position: "relative" }}>
@@ -226,6 +245,32 @@ export function CveActiveList({
             Critical{" "}
             <CountTag active={sev === "critical"} theme={theme}>{counts.critical}</CountTag>
           </Chip>
+          <span style={{ width: 1, background: t.border, margin: "0 3px" }} />
+          <Chip
+            theme={theme}
+            active={kindFilter === "now"}
+            onClick={() =>
+              setKindFilter(kindFilter === "now" ? "all" : "now")
+            }
+          >
+            Shipping now{" "}
+            <CountTag active={kindFilter === "now"} theme={theme}>
+              {counts.now}
+            </CountTag>
+          </Chip>
+          <Chip
+            theme={theme}
+            active={kindFilter === "future"}
+            onClick={() =>
+              setKindFilter(kindFilter === "future" ? "all" : "future")
+            }
+          >
+            Future version{" "}
+            <CountTag active={kindFilter === "future"} theme={theme}>
+              {counts.future}
+            </CountTag>
+          </Chip>
+          <span style={{ width: 1, background: t.border, margin: "0 3px" }} />
           <Chip
             theme={theme}
             active={onlyUnreviewed}
@@ -339,6 +384,7 @@ export function CveActiveList({
                     >
                       {r.pkg.package}
                     </code>
+                    <KindBadge theme={theme} kind={r.kind} />
                     <span
                       style={{
                         fontFamily: "JetBrains Mono, monospace",
@@ -348,7 +394,11 @@ export function CveActiveList({
                         padding: "1px 6px",
                         borderRadius: 3,
                       }}
-                      title="Latest conda-forge version"
+                      title={
+                        r.kind === "now"
+                          ? "Latest conda-forge version (affected)"
+                          : "Latest conda-forge version (not yet affected — newer version is)"
+                      }
                     >
                       {r.pkg.latest_version}
                     </span>
@@ -399,6 +449,42 @@ export function CveActiveList({
         )}
       </div>
     </div>
+  );
+}
+
+function KindBadge({ theme, kind }: { theme: Theme; kind: Kind }) {
+  const styles =
+    kind === "now"
+      ? {
+          bg: theme.dark ? "#2a1818" : "#ffe1d8",
+          fg: theme.dark ? "#ff8e6a" : "#a8401b",
+          label: "now",
+          title: "Active on the newest conda-forge release",
+        }
+      : {
+          bg: theme.dark ? "#1f2a16" : "#fff4d2",
+          fg: theme.dark ? "#f5c542" : "#866400",
+          label: "future",
+          title:
+            "Affected version is newer than conda-forge's latest — block before it lands",
+        };
+  return (
+    <span
+      title={styles.title}
+      style={{
+        fontSize: 10,
+        fontWeight: 700,
+        padding: "1px 6px",
+        borderRadius: 3,
+        background: styles.bg,
+        color: styles.fg,
+        textTransform: "uppercase",
+        letterSpacing: ".02em",
+        fontFamily: "Inter, sans-serif",
+      }}
+    >
+      {styles.label}
+    </span>
   );
 }
 

--- a/web/src/data/cves.ts
+++ b/web/src/data/cves.ts
@@ -9,7 +9,7 @@
 
 /* ---- OSV record shape (https://ossf.github.io/osv-schema/) ---- */
 
-export type OsvSeverity = { type: string; score: string };
+export type OsvSeverity = { type: string; score: string; score_num?: number };
 export type OsvReference = { type: string; url: string };
 export type OsvEvent = {
   introduced?: string;
@@ -89,6 +89,8 @@ export type CvePackage = {
   purls: string[];
   generated_at: string;
   conda_versions_total: number;
+  /** Newest conda-forge version of this package by rattler version order. */
+  latest_version?: string | null;
   advisories: Advisory[];
 };
 
@@ -148,6 +150,18 @@ export function bestSeverity(adv: Advisory): OsvSeverity | undefined {
     }
   }
   return best;
+}
+
+/** True iff the package's newest conda-forge release is still listed as
+ *  affected by this advisory and no review has marked it not_affected/fixed.
+ *  These are the highest-priority entries for triage — a CVE actively shipping
+ *  to users today. Returns false when latest_version is unknown. */
+export function isActiveOnLatest(pkg: CvePackage, adv: Advisory): boolean {
+  const latest = pkg.latest_version;
+  if (!latest) return false;
+  const status = advisoryVex(adv)?.status;
+  if (status === "not_affected" || status === "fixed") return false;
+  return affectedVersions(adv).includes(latest);
 }
 
 /** Every non-GIT affected range across all affected[] entries. */

--- a/web/src/data/cves.ts
+++ b/web/src/data/cves.ts
@@ -57,6 +57,10 @@ export type CondaForgeBlock = {
   purl: string;
   source_purls?: string[];
   affected_versions: string[];
+  /** True iff the OSV record names a version newer than the package's
+   *  latest conda-forge release as affected. Set by scripts/cve_match.py
+   *  using rattler Version comparison. */
+  affects_future?: boolean;
   conda_versions_total?: number;
   derived_by?: string;
   generated_at?: string;
@@ -162,6 +166,17 @@ export function isActiveOnLatest(pkg: CvePackage, adv: Advisory): boolean {
   const status = advisoryVex(adv)?.status;
   if (status === "not_affected" || status === "fixed") return false;
   return affectedVersions(adv).includes(latest);
+}
+
+/** True iff the advisory targets a version newer than the package's latest
+ *  conda-forge release. These are CVEs we can BLOCK before they ship —
+ *  e.g. mistralai's malicious 2.4.6 dropper, while conda-forge still has
+ *  2.4.5. Computed in scripts/cve_match.py with rattler.Version semantics. */
+export function isFutureAffected(pkg: CvePackage, adv: Advisory): boolean {
+  if (isActiveOnLatest(pkg, adv)) return false;
+  const status = advisoryVex(adv)?.status;
+  if (status === "not_affected" || status === "fixed") return false;
+  return condaBlock(adv)?.affects_future === true;
 }
 
 /** Every non-GIT affected range across all affected[] entries. */


### PR DESCRIPTION
## Summary
A new top-level lens in the CVE dashboard that answers: _which CVEs are still affecting the newest conda-forge release of each package?_ Those are the highest-priority items to triage — they're shipping to users today.

- **Data** — `cve_match` now records `latest_version` per package using `rattler.Version` order over the conda-forge releases it already enumerates. No new API or dep: it's `versions[-1].version` after the existing `_aggregate_conda_versions` sort. `merge_cves` passes through; both schemas extend to allow the field as nullable string.
- **Helper** — `isActiveOnLatest(pkg, adv)` in `data/cves.ts`: true iff `latest_version ∈ affectedVersions(adv)` and the resolved VEX status isn't `not_affected`/`fixed`. Version-override-aware via the existing `merge_cves._finalize_affected` fold.
- **UI** — `CveApp` grows a tab strip in the left column (`All packages` / `Active on latest`). `CveActiveList` shows a virtualized flat list, sorted by CVSS score (desc), then unreviewed-first, then alphabetical. Each row: severity pill, package name, `latest_version` chip, CVE id, summary. Filters: `All`/`High+`/`Critical` and an `Unreviewed only` toggle (on by default). Clicking a row focuses the package in the existing detail pane and scrolls to the advisory anchor.

## Depends on
- #82 (precomputes `severity[].score_num`). Without it every row falls into the "no score" bucket and prioritization degrades to alphabetical — the data shape is forwards-compatible but the UX is meaningfully worse.

## Test plan
- [x] `pixi run cve-match --only mistralai --limit 1` produces `latest_version: "2.4.5"` and the file validates against the updated `cve-package.schema.json`.
- [x] `npm run build` + `tsc --noEmit` clean.
- [ ] After merge: the next `cve-refresh` workflow regenerates every per-package file with `latest_version` (and once #82 is in, with `score_num`); the "Active on latest" tab shows real priorities.
- [ ] Click-through from a row jumps to the right advisory in the detail pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)