### PR TITLE
add base-metrics for cvss vulnerability scores

### DIFF
--- a/web/src/components/CveDetail.tsx
+++ b/web/src/components/CveDetail.tsx
@@ -20,6 +20,7 @@ import {
   osvUrl,
   primaryId,
 } from "../data/cves";
+import { cvssBaseMetrics } from "../data/cvssMetrics";
 import { Btn, Glyph, Theme } from "./Primitives";
 
 type Props = {
@@ -69,6 +70,53 @@ function SeverityPill({ adv }: { adv: Advisory }) {
     >
       {lvl.label}
     </span>
+  );
+}
+
+function CvssBaseMetricsSection({ adv, theme }: { adv: Advisory; theme: Theme }) {
+  const [showNone, setShowNone] = useState(false);
+  const metrics = cvssBaseMetrics(bestSeverity(adv));
+  if (!metrics) return null;
+
+  const visible = metrics.items.filter((item) => item.value !== "None");
+  const none = metrics.items.filter((item) => item.value === "None");
+  const shown = showNone ? metrics.items : visible;
+  const rows = shown.map((item) => ({
+    key: item.metricCode,
+    label: item.metric,
+    value: item.value,
+  }));
+  const hiddenNone = none.length > 0 && !showNone;
+
+  return (
+    <Section
+      title="CVSS base metrics"
+      theme={theme}
+      hint={metrics.versionLabel}
+      hintHref={metrics.metricsUrl}
+      action={
+        none.length > 0 ? (
+          <button
+            onClick={() => setShowNone(!showNone)}
+            style={{
+              background: "transparent",
+              border: 0,
+              color: theme.t.link,
+              padding: 0,
+              fontSize: 11,
+              fontFamily: "Inter, sans-serif",
+              cursor: "pointer",
+            }}
+          >
+            {hiddenNone
+              ? `Show ${none.length} none metric${none.length === 1 ? "" : "s"}`
+              : `Hide none metric${none.length === 1 ? "" : "s"}`}
+          </button>
+        ) : undefined
+      }
+    >
+      <KeyValueTable theme={theme} rows={rows} />
+    </Section>
   );
 }
 
@@ -646,6 +694,8 @@ function AdvisoryCard({
             </details>
           )}
 
+          <CvssBaseMetricsSection adv={adv} theme={theme} />
+
           {osvRanges(adv).length > 0 && (
             <Section title="Upstream affected ranges" theme={theme}>
               <div
@@ -904,14 +954,56 @@ function AdvisoryCard({
   );
 }
 
+function KeyValueTable({
+  theme,
+  rows,
+}: {
+  theme: Theme;
+  rows: { key: string; label: React.ReactNode; value: React.ReactNode }[];
+}) {
+  const t = theme.t;
+  return (
+    <div
+      style={{
+        border: `1px solid ${t.border}`,
+        borderRadius: 8,
+        overflow: "hidden",
+        background: t.surface2,
+      }}
+    >
+      {rows.map((row, index) => (
+        <div
+          key={row.key}
+          style={{
+            display: "grid",
+            gridTemplateColumns: "minmax(180px, 1fr) minmax(140px, 1fr)",
+            gap: 12,
+            alignItems: "center",
+            padding: "7px 10px",
+            borderTop: index === 0 ? 0 : `1px solid ${t.border}`,
+            fontSize: 12,
+          }}
+        >
+          <div style={{ color: t.fg2 }}>{row.label}</div>
+          <div style={{ color: t.fg1, fontWeight: 600 }}>{row.value}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function Section({
   title,
   hint,
+  hintHref,
+  action,
   theme,
   children,
 }: {
   title: string;
   hint?: string;
+  hintHref?: string;
+  action?: React.ReactNode;
   theme: Theme;
   children: React.ReactNode;
 }) {
@@ -920,29 +1012,57 @@ function Section({
     <div>
       <div
         style={{
-          fontSize: 11,
-          fontWeight: 600,
-          color: t.fg2,
-          letterSpacing: ".04em",
-          textTransform: "uppercase",
+          display: "flex",
+          alignItems: "baseline",
+          gap: 8,
           marginBottom: 6,
         }}
       >
-        {title}
-        {hint && (
-          <span
-            style={{
-              fontWeight: 400,
-              textTransform: "none",
-              letterSpacing: 0,
-              fontSize: 11,
-              color: t.fg3,
-              marginLeft: 8,
-            }}
-          >
-            {hint}
-          </span>
-        )}
+        <div
+          style={{
+            fontSize: 11,
+            fontWeight: 600,
+            color: t.fg2,
+            letterSpacing: ".04em",
+            textTransform: "uppercase",
+          }}
+        >
+          {title}
+          {hint &&
+            (hintHref ? (
+              <a
+                href={hintHref}
+                target="_blank"
+                rel="noreferrer"
+                style={{
+                  fontWeight: 400,
+                  textTransform: "none",
+                  letterSpacing: 0,
+                  fontSize: 11,
+                  color: t.link,
+                  marginLeft: 8,
+                  textDecoration: "none",
+                }}
+                title="Open CVSS base metrics documentation"
+              >
+                {hint}
+              </a>
+            ) : (
+              <span
+                style={{
+                  fontWeight: 400,
+                  textTransform: "none",
+                  letterSpacing: 0,
+                  fontSize: 11,
+                  color: t.fg3,
+                  marginLeft: 8,
+                }}
+              >
+                {hint}
+              </span>
+            ))}
+        </div>
+        {action && <div style={{ marginLeft: "auto" }}>{action}</div>}
       </div>
       {children}
     </div>

--- a/web/src/data/cvssMetrics.ts
+++ b/web/src/data/cvssMetrics.ts
@@ -1,0 +1,186 @@
+import type { OsvSeverity } from "./cves";
+
+export type CvssMetricDisplayItem = {
+  metric: string;
+  value: string;
+  metricCode: string;
+  valueCode: string;
+};
+
+export type CvssBaseMetrics = {
+  versionLabel: string;
+  metricsUrl: string;
+  items: CvssMetricDisplayItem[];
+};
+
+type MetricDefinition = {
+  label: string;
+  values: Record<string, string>;
+};
+
+type CvssDefinition = {
+  versionLabel: string;
+  metricsUrl: string;
+  order: string[];
+  metrics: Record<string, MetricDefinition>;
+};
+
+const CIA_VALUES = {
+  H: "High",
+  L: "Low",
+  N: "None",
+};
+
+const CVSS_V2: CvssDefinition = {
+  versionLabel: "CVSS v2",
+  metricsUrl: "https://www.first.org/cvss/v2/guide#2-1-Base-Metrics",
+  order: ["AV", "AC", "Au", "C", "I", "A"],
+  metrics: {
+    AV: {
+      label: "Access vector",
+      values: { L: "Local", A: "Adjacent network", N: "Network" },
+    },
+    AC: {
+      label: "Access complexity",
+      values: { H: "High", M: "Medium", L: "Low" },
+    },
+    Au: {
+      label: "Authentication",
+      values: { M: "Multiple", S: "Single", N: "None" },
+    },
+    C: {
+      label: "Confidentiality impact",
+      values: { N: "None", P: "Partial", C: "Complete" },
+    },
+    I: {
+      label: "Integrity impact",
+      values: { N: "None", P: "Partial", C: "Complete" },
+    },
+    A: {
+      label: "Availability impact",
+      values: { N: "None", P: "Partial", C: "Complete" },
+    },
+  },
+};
+
+const CVSS_V3: CvssDefinition = {
+  versionLabel: "CVSS v3",
+  metricsUrl: "https://www.first.org/cvss/v3-1/specification-document#Base-Metrics",
+  order: ["AV", "AC", "PR", "UI", "S", "C", "I", "A"],
+  metrics: {
+    AV: {
+      label: "Attack vector",
+      values: { N: "Network", A: "Adjacent", L: "Local", P: "Physical" },
+    },
+    AC: {
+      label: "Attack complexity",
+      values: { L: "Low", H: "High" },
+    },
+    PR: {
+      label: "Privileges required",
+      values: { N: "None", L: "Low", H: "High" },
+    },
+    UI: {
+      label: "User interaction",
+      values: { N: "None", R: "Required" },
+    },
+    S: {
+      label: "Scope",
+      values: { U: "Unchanged", C: "Changed" },
+    },
+    C: { label: "Confidentiality", values: CIA_VALUES },
+    I: { label: "Integrity", values: CIA_VALUES },
+    A: { label: "Availability", values: CIA_VALUES },
+  },
+};
+
+const CVSS_V4: CvssDefinition = {
+  versionLabel: "CVSS v4",
+  metricsUrl: "https://www.first.org/cvss/v4-0/specification-document#Base-Metrics",
+  order: ["AV", "AC", "AT", "PR", "UI", "VC", "VI", "VA", "SC", "SI", "SA"],
+  metrics: {
+    AV: {
+      label: "Attack vector",
+      values: { N: "Network", A: "Adjacent", L: "Local", P: "Physical" },
+    },
+    AC: {
+      label: "Attack complexity",
+      values: { L: "Low", H: "High" },
+    },
+    AT: {
+      label: "Attack requirements",
+      values: { N: "None", P: "Present" },
+    },
+    PR: {
+      label: "Privileges required",
+      values: { N: "None", L: "Low", H: "High" },
+    },
+    UI: {
+      label: "User interaction",
+      values: { N: "None", P: "Passive", A: "Active" },
+    },
+    VC: { label: "Vulnerable system confidentiality", values: CIA_VALUES },
+    VI: { label: "Vulnerable system integrity", values: CIA_VALUES },
+    VA: { label: "Vulnerable system availability", values: CIA_VALUES },
+    SC: { label: "Subsequent system confidentiality", values: CIA_VALUES },
+    SI: {
+      label: "Subsequent system integrity",
+      values: { ...CIA_VALUES, S: "Safety" },
+    },
+    SA: {
+      label: "Subsequent system availability",
+      values: { ...CIA_VALUES, S: "Safety" },
+    },
+  },
+};
+
+function definitionFor(severity: OsvSeverity): CvssDefinition | undefined {
+  if (severity.type === "CVSS_V2") return CVSS_V2;
+  if (severity.type === "CVSS_V3") return CVSS_V3;
+  if (severity.type === "CVSS_V4") return CVSS_V4;
+  return undefined;
+}
+
+function parseVector(score: string): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const part of score.split("/")) {
+    if (part.startsWith("CVSS:")) continue;
+    const [key, value] = part.split(":", 2);
+    if (key && value) out.set(key, value);
+  }
+  return out;
+}
+
+export function cvssBaseMetrics(
+  severity: OsvSeverity | undefined,
+): CvssBaseMetrics | undefined {
+  if (!severity?.score) return undefined;
+  const definition = definitionFor(severity);
+  if (!definition) return undefined;
+
+  const vector = parseVector(severity.score);
+  const items: CvssMetricDisplayItem[] = [];
+  for (const metricCode of definition.order) {
+    const valueCode = vector.get(metricCode);
+    const metric = definition.metrics[metricCode];
+    if (!valueCode || !metric) continue;
+    items.push({
+      metric: metric.label,
+      value: metric.values[valueCode] ?? valueCode,
+      metricCode,
+      valueCode,
+    });
+  }
+  if (items.length === 0) return undefined;
+  return {
+    versionLabel: definition.versionLabel,
+    metricsUrl: definition.metricsUrl,
+    items,
+  };
+}
+
+export function cvssBaseMetricDisplayItems(
+  severity: OsvSeverity | undefined,
+): CvssMetricDisplayItem[] {
+  return cvssBaseMetrics(severity)?.items ?? [];
+}


### PR DESCRIPTION
Adds CVSS base-metrics explained similar to how github is showing it, although I hide the "None" metrics by default. This is essentially what makes up the cvss score:

<img width="2144" height="1504" alt="image" src="https://github.com/user-attachments/assets/95028e25-5f29-461e-b346-566511a8d128" />


