### PR TITLE
Persist local draft edits before login

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,7 +11,8 @@
         "@tanstack/react-virtual": "^3.13.24",
         "lucide-react": "^1.11.0",
         "react": "^19.2.5",
-        "react-dom": "^19.2.5"
+        "react-dom": "^19.2.5",
+        "zustand": "^5.0.13"
       },
       "devDependencies": {
         "@types/react": "^19.2.14",
@@ -390,7 +391,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -436,7 +437,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/detect-libc": {
@@ -1011,6 +1012,35 @@
           "optional": true
         },
         "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
+      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
           "optional": true
         }
       }

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,8 @@
     "@tanstack/react-virtual": "^3.13.24",
     "lucide-react": "^1.11.0",
     "react": "^19.2.5",
-    "react-dom": "^19.2.5"
+    "react-dom": "^19.2.5",
+    "zustand": "^5.0.13"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",
@@ -25,7 +26,9 @@
     "packageRules": [
       {
         "description": "Hold npm updates for a week so brand-new releases bake before we adopt them.",
-        "matchManagers": ["npm"],
+        "matchManagers": [
+          "npm"
+        ],
         "minimumReleaseAge": "7 days"
       }
     ]

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,31 +1,24 @@
 import { useEffect, useMemo, useState } from "react";
-import {
-  consumeOauthCallback,
-  fetchUser,
-  hasOauthCallback,
-  loadStoredToken,
-  logout,
-} from "./auth/github";
+import { useGithubAuth } from "./auth/useGithubAuth";
 import { BulkPanel } from "./components/BulkPanel";
+import { LocalDraftBanner } from "./components/LocalDraftBanner";
 import { LoginModal } from "./components/LoginModal";
 import { MappingEditor } from "./components/MappingEditor";
 import { PackageTable } from "./components/PackageTable";
 import { PRDrawer } from "./components/PRDrawer";
 import { Btn, Glyph, useTheme } from "./components/Primitives";
-import { config, repoFullName } from "./config";
-import { loadMappings, packagesAsList } from "./data/loader";
-import type { Edit, GitHubUser, MappingsPayload, PackageEntry } from "./data/types";
-
-const EDITS_KEY = "purl-associator/staged_edits";
+import { repoFullName } from "./config";
+import type { Edit, PackageEntry } from "./data/types";
+import { useMappingsData } from "./data/useMappingsData";
+import { usePurlEditStore } from "./stores/userState";
 
 export function App() {
   const theme = useTheme();
-  const [payload, setPayload] = useState<MappingsPayload | null>(null);
-  const [loadError, setLoadError] = useState<string | null>(null);
-  const [packages, setPackages] = useState<PackageEntry[]>([]);
+  const { payload, packages, loadError } = useMappingsData();
   const [selectedSet, setSelectedSet] = useState<Set<string>>(new Set());
   const [focusedId, setFocusedId] = useState<string | null>(null);
-  const [edits, setEdits] = useState<Record<string, Edit>>({});
+  const edits = usePurlEditStore((state) => state.edits);
+  const setEdits = usePurlEditStore((state) => state.setEdits);
   const [q, setQ] = useState("");
   const [filters, setFilters] = useState({
     unmappedOnly: false,
@@ -34,66 +27,9 @@ export function App() {
   });
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [loginOpen, setLoginOpen] = useState(false);
-  const [token, setToken] = useState<string | null>(null);
-  const [user, setUser] = useState<GitHubUser | null>(null);
-  const [authError, setAuthError] = useState<string | null>(null);
+  const { token, user, error: authError, isLoggedIn, signOut } = useGithubAuth();
 
   const t = theme.t;
-
-  useEffect(() => {
-    loadMappings(config.mappingsUrl)
-      .then((data) => {
-        setPayload(data);
-        setPackages(packagesAsList(data));
-      })
-      .catch((err) => setLoadError(err instanceof Error ? err.message : String(err)));
-  }, []);
-
-  // Persist staged edits across the OAuth full-page redirect (sessionStorage
-  // is per-tab and survives same-tab navigations).
-  useEffect(() => {
-    try {
-      const stored = sessionStorage.getItem(EDITS_KEY);
-      if (stored) setEdits(JSON.parse(stored));
-    } catch {
-      // ignore
-    }
-  }, []);
-  useEffect(() => {
-    try {
-      if (Object.keys(edits).length === 0) sessionStorage.removeItem(EDITS_KEY);
-      else sessionStorage.setItem(EDITS_KEY, JSON.stringify(edits));
-    } catch {
-      // ignore
-    }
-  }, [edits]);
-
-  useEffect(() => {
-    const stored = loadStoredToken();
-    if (stored) {
-      setToken(stored);
-      fetchUser(stored)
-        .then(setUser)
-        .catch(() => {
-          logout();
-          setToken(null);
-        });
-      return;
-    }
-    if (hasOauthCallback()) {
-      consumeOauthCallback()
-        .then(async (newToken) => {
-          if (!newToken) return;
-          setToken(newToken);
-          try {
-            setUser(await fetchUser(newToken));
-          } catch (err) {
-            setAuthError(err instanceof Error ? err.message : String(err));
-          }
-        })
-        .catch((err) => setAuthError(err instanceof Error ? err.message : String(err)));
-    }
-  }, []);
 
   // Default: when packages first arrive, focus the first row (but don't
   // mark it as selected — selection is the checkbox state).
@@ -114,11 +50,9 @@ export function App() {
   );
 
   const editsCount = Object.keys(edits).length;
-  const isLoggedIn = Boolean(token && user);
   const showBulk = selectedSet.size > 1;
 
   function handleEdit(newEdit: Edit): void {
-    if (!isLoggedIn) setLoginOpen(true);
     if (!focusedPkg) return;
     const auto = focusedPkg.auto ?? {
       purl: focusedPkg.purl,
@@ -173,7 +107,6 @@ export function App() {
   }
 
   function handleApprove(): void {
-    if (!isLoggedIn) setLoginOpen(true);
     if (!focusedPkg) return;
     const e = approveOne(focusedPkg);
     if (!e) return;
@@ -224,12 +157,6 @@ export function App() {
       for (const p of selectedPackages) delete next[p.name];
       return next;
     });
-  }
-
-  function handleSignOut(): void {
-    logout();
-    setToken(null);
-    setUser(null);
   }
 
   return (
@@ -364,7 +291,7 @@ export function App() {
                 @{user.login}
               </span>
               <button
-                onClick={handleSignOut}
+                onClick={signOut}
                 title="Sign out"
                 style={{
                   background: "transparent",
@@ -391,12 +318,24 @@ export function App() {
         </div>
       </header>
 
+      <LocalDraftBanner
+        theme={theme}
+        count={editsCount}
+        noun="change"
+        onReview={() => setDrawerOpen(true)}
+        onDiscard={() => {
+          if (window.confirm("Discard all locally saved staged changes?")) {
+            setEdits({});
+          }
+        }}
+      />
+
       {!isLoggedIn && (
         <div
           style={{
             padding: "7px 18px",
-            background: theme.dark ? "#1f1a0d" : "#fff7d6",
-            borderBottom: `1px solid ${theme.dark ? "#3a3416" : "#f0e2a3"}`,
+            background: theme.dark ? "#151c26" : "#eaf3ff",
+            borderBottom: `1px solid ${theme.dark ? "#26364a" : "#c7daf2"}`,
             fontSize: 12,
             color: t.fg1,
             display: "flex",
@@ -404,8 +343,8 @@ export function App() {
             gap: 8,
           }}
         >
-          <Glyph name="eye" size={13} />
-          You're browsing in read-only mode.
+          <Glyph name="edit" size={13} />
+          You can stage local mapping changes without signing in.
           <button
             onClick={() => setLoginOpen(true)}
             style={{
@@ -420,7 +359,7 @@ export function App() {
           >
             Sign in with GitHub
           </button>
-          to edit mappings.
+          when you're ready to open a PR.
         </div>
       )}
 
@@ -486,8 +425,6 @@ export function App() {
               theme={theme}
               selectedPackages={selectedPackages}
               edits={edits}
-              isLoggedIn={isLoggedIn}
-              onRequestLogin={() => setLoginOpen(true)}
               onApproveAll={handleBulkApprove}
               onMarkUnmappedAll={handleBulkMarkUnmapped}
               onResetSelected={handleBulkResetSelected}
@@ -501,8 +438,6 @@ export function App() {
               onEdit={handleEdit}
               onApprove={handleApprove}
               onResetAuto={handleResetAuto}
-              isLoggedIn={isLoggedIn}
-              onRequestLogin={() => setLoginOpen(true)}
             />
           )}
         </div>

--- a/web/src/CveApp.tsx
+++ b/web/src/CveApp.tsx
@@ -1,36 +1,28 @@
-import { useEffect, useMemo, useState } from "react";
-import {
-  consumeOauthCallback,
-  fetchUser,
-  hasOauthCallback,
-  loadStoredToken,
-  logout,
-} from "./auth/github";
+import { useState } from "react";
+import { useGithubAuth } from "./auth/useGithubAuth";
+import { LocalDraftBanner } from "./components/LocalDraftBanner";
 import { LoginModal } from "./components/LoginModal";
 import { Btn, Glyph, useTheme } from "./components/Primitives";
 import { CvePackageList } from "./components/CvePackageList";
 import { CveActiveList } from "./components/CveActiveList";
 import { CveDetail } from "./components/CveDetail";
 import { CvePRDrawer } from "./components/CvePRDrawer";
-import { config, repoFullName } from "./config";
+import { repoFullName } from "./config";
 import {
   advisoryVex,
   editFromVex,
   isEditNonEmpty,
-  loadCves,
-  type CvePayload,
   type ReviewEdit,
 } from "./data/cves";
-import type { GitHubUser } from "./data/types";
-
-const EDITS_KEY = "purl-associator/staged_cve_edits";
+import { useCveData } from "./data/useCveData";
+import { useCveEditStore } from "./stores/userState";
 
 export function CveApp() {
   const theme = useTheme();
-  const [payload, setPayload] = useState<CvePayload | null>(null);
-  const [loadError, setLoadError] = useState<string | null>(null);
-  const [focusedPkg, setFocusedPkg] = useState<string | null>(null);
-  const [edits, setEdits] = useState<Record<string, ReviewEdit>>({});
+  const { payload, loadError, focusedPkg, setFocusedPkg, packages, focusedPackage } =
+    useCveData();
+  const edits = useCveEditStore((state) => state.edits);
+  const setEdits = useCveEditStore((state) => state.setEdits);
   const [q, setQ] = useState("");
   const [statusFilter, setStatusFilter] = useState<"all" | "unreviewed" | "reviewed">(
     "all",
@@ -38,81 +30,11 @@ export function CveApp() {
   const [view, setView] = useState<"browse" | "active">("browse");
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [loginOpen, setLoginOpen] = useState(false);
-  const [token, setToken] = useState<string | null>(null);
-  const [user, setUser] = useState<GitHubUser | null>(null);
-  const [authError, setAuthError] = useState<string | null>(null);
+  const { token, user, error: authError, isLoggedIn, signOut } = useGithubAuth();
 
   const t = theme.t;
 
-  useEffect(() => {
-    loadCves(config.cvesUrl)
-      .then((data) => {
-        setPayload(data);
-        const first = Object.keys(data.packages).sort()[0];
-        if (first) setFocusedPkg(first);
-      })
-      .catch((err) => setLoadError(err instanceof Error ? err.message : String(err)));
-  }, []);
-
-  useEffect(() => {
-    try {
-      const stored = sessionStorage.getItem(EDITS_KEY);
-      if (stored) setEdits(JSON.parse(stored));
-    } catch {
-      // ignore
-    }
-  }, []);
-  useEffect(() => {
-    try {
-      if (Object.keys(edits).length === 0) sessionStorage.removeItem(EDITS_KEY);
-      else sessionStorage.setItem(EDITS_KEY, JSON.stringify(edits));
-    } catch {
-      // ignore
-    }
-  }, [edits]);
-
-  useEffect(() => {
-    const stored = loadStoredToken();
-    if (stored) {
-      setToken(stored);
-      fetchUser(stored)
-        .then(setUser)
-        .catch(() => {
-          logout();
-          setToken(null);
-        });
-      return;
-    }
-    if (hasOauthCallback()) {
-      consumeOauthCallback()
-        .then(async (newToken) => {
-          if (!newToken) return;
-          setToken(newToken);
-          try {
-            setUser(await fetchUser(newToken));
-          } catch (err) {
-            setAuthError(err instanceof Error ? err.message : String(err));
-          }
-        })
-        .catch((err) => setAuthError(err instanceof Error ? err.message : String(err)));
-    }
-  }, []);
-
-  const packages = useMemo(() => {
-    if (!payload) return [];
-    return Object.values(payload.packages).sort((a, b) =>
-      a.package.localeCompare(b.package),
-    );
-  }, [payload]);
-
-  const focusedPackage = useMemo(
-    () =>
-      focusedPkg && payload ? payload.packages[focusedPkg] ?? null : null,
-    [focusedPkg, payload],
-  );
-
   const editsCount = Object.keys(edits).length;
-  const isLoggedIn = Boolean(token && user);
 
   function editKey(pkg: string, advisoryId: string): string {
     return `${pkg}::${advisoryId}`;
@@ -124,7 +46,6 @@ export function CveApp() {
     next: ReviewEdit,
     base: ReviewEdit,
   ): void {
-    if (!isLoggedIn) setLoginOpen(true);
     const key = editKey(pkg, advisoryId);
     setEdits((prev) => {
       const out = { ...prev };
@@ -153,12 +74,6 @@ export function CveApp() {
       delete out[key];
       return out;
     });
-  }
-
-  function handleSignOut(): void {
-    logout();
-    setToken(null);
-    setUser(null);
   }
 
   return (
@@ -305,7 +220,7 @@ export function CveApp() {
                 @{user.login}
               </span>
               <button
-                onClick={handleSignOut}
+                onClick={signOut}
                 title="Sign out"
                 style={{
                   background: "transparent",
@@ -332,12 +247,24 @@ export function CveApp() {
         </div>
       </header>
 
+      <LocalDraftBanner
+        theme={theme}
+        count={editsCount}
+        noun="review"
+        onReview={() => setDrawerOpen(true)}
+        onDiscard={() => {
+          if (window.confirm("Discard all locally saved staged reviews?")) {
+            setEdits({});
+          }
+        }}
+      />
+
       {!isLoggedIn && (
         <div
           style={{
             padding: "7px 18px",
-            background: theme.dark ? "#1f1a0d" : "#fff7d6",
-            borderBottom: `1px solid ${theme.dark ? "#3a3416" : "#f0e2a3"}`,
+            background: theme.dark ? "#151c26" : "#eaf3ff",
+            borderBottom: `1px solid ${theme.dark ? "#26364a" : "#c7daf2"}`,
             fontSize: 12,
             color: t.fg1,
             display: "flex",
@@ -345,8 +272,8 @@ export function CveApp() {
             gap: 8,
           }}
         >
-          <Glyph name="eye" size={13} />
-          You're browsing in read-only mode.
+          <Glyph name="edit" size={13} />
+          You can stage local CVE reviews without signing in.
           <button
             onClick={() => setLoginOpen(true)}
             style={{
@@ -361,7 +288,7 @@ export function CveApp() {
           >
             Sign in with GitHub
           </button>
-          to submit reviews.
+          when you're ready to open a PR.
         </div>
       )}
 
@@ -492,8 +419,6 @@ export function CveApp() {
               if (!focusedPackage) return;
               handleResetEdit(focusedPackage.package, advisoryId);
             }}
-            isLoggedIn={isLoggedIn}
-            onRequestLogin={() => setLoginOpen(true)}
           />
         </div>
       </div>

--- a/web/src/auth/github.ts
+++ b/web/src/auth/github.ts
@@ -7,14 +7,12 @@
  * 3. Frontend POSTs the code to a tiny Cloudflare Worker which holds the
  *    client_secret and calls https://github.com/login/oauth/access_token.
  * 4. Worker returns { access_token, token_type, scope }; we cache it in
- *    sessionStorage. The token is used directly against api.github.com (which
- *    is CORS-enabled, unlike the OAuth endpoints).
+ *    tab-local browser storage. The token is used directly against
+ *    api.github.com (which is CORS-enabled, unlike the OAuth endpoints).
  */
 import { config } from "../config";
 import type { GitHubUser } from "../data/types";
-
-const TOKEN_KEY = "purl-associator/gh_token";
-const STATE_KEY = "purl-associator/oauth_state";
+import { browserStorage } from "../storage/browserStorage";
 // GitHub Apps don't use OAuth scopes — permissions are configured at App
 // registration. Leaving this empty makes the consent screen narrow:
 // "PURL Associator wants to: Read your public profile".
@@ -26,27 +24,15 @@ export type AuthState =
   | { kind: "configuring"; reason: string };
 
 export function loadStoredToken(): string | null {
-  try {
-    return sessionStorage.getItem(TOKEN_KEY);
-  } catch {
-    return null;
-  }
+  return browserStorage.loadGithubToken();
 }
 
 export function clearStoredToken(): void {
-  try {
-    sessionStorage.removeItem(TOKEN_KEY);
-  } catch {
-    // ignore
-  }
+  browserStorage.clearGithubToken();
 }
 
 function storeToken(token: string): void {
-  try {
-    sessionStorage.setItem(TOKEN_KEY, token);
-  } catch {
-    // ignore
-  }
+  browserStorage.saveGithubToken(token);
 }
 
 export function isOauthConfigured(): boolean {
@@ -58,7 +44,7 @@ export function startLogin(): void {
     throw new Error("GitHub client ID not configured");
   }
   const state = crypto.randomUUID();
-  sessionStorage.setItem(STATE_KEY, state);
+  browserStorage.saveOauthState(state);
   const redirectUri = `${location.origin}${location.pathname}`;
   const url = new URL("https://github.com/login/oauth/authorize");
   url.searchParams.set("client_id", config.githubClientId);
@@ -88,11 +74,11 @@ export async function consumeOauthCallback(): Promise<string | null> {
   const cleanUrl = `${location.origin}${location.pathname}`;
   history.replaceState({}, "", cleanUrl);
 
-  const expected = sessionStorage.getItem(STATE_KEY);
+  const expected = browserStorage.loadOauthState();
   if (expected && expected !== state) {
     throw new Error("OAuth state mismatch — possible CSRF, refusing to continue.");
   }
-  sessionStorage.removeItem(STATE_KEY);
+  browserStorage.clearOauthState();
 
   if (!config.oauthWorkerUrl) {
     throw new Error("OAuth worker URL not configured");

--- a/web/src/auth/useGithubAuth.ts
+++ b/web/src/auth/useGithubAuth.ts
@@ -1,0 +1,75 @@
+import { useEffect, useState } from "react";
+import type { GitHubUser } from "../data/types";
+import {
+  consumeOauthCallback,
+  fetchUser,
+  hasOauthCallback,
+  loadStoredToken,
+  logout,
+} from "./github";
+
+export type GithubAuthState = {
+  token: string | null;
+  user: GitHubUser | null;
+  error: string | null;
+  isLoggedIn: boolean;
+  signOut: () => void;
+};
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Owns GitHub session bootstrap for the SPA.
+ *
+ * Apps should not duplicate OAuth callback/session handling. Editing is local
+ * and auth-agnostic; this hook is only consumed by sign-in UI and PR drawers.
+ */
+export function useGithubAuth(): GithubAuthState {
+  const [token, setToken] = useState<string | null>(null);
+  const [user, setUser] = useState<GitHubUser | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const stored = loadStoredToken();
+    if (stored) {
+      setToken(stored);
+      fetchUser(stored)
+        .then(setUser)
+        .catch(() => {
+          logout();
+          setToken(null);
+        });
+      return;
+    }
+
+    if (!hasOauthCallback()) return;
+
+    consumeOauthCallback()
+      .then(async (newToken) => {
+        if (!newToken) return;
+        setToken(newToken);
+        try {
+          setUser(await fetchUser(newToken));
+        } catch (err) {
+          setError(errorMessage(err));
+        }
+      })
+      .catch((err) => setError(errorMessage(err)));
+  }, []);
+
+  function signOut(): void {
+    logout();
+    setToken(null);
+    setUser(null);
+  }
+
+  return {
+    token,
+    user,
+    error,
+    isLoggedIn: Boolean(token && user),
+    signOut,
+  };
+}

--- a/web/src/components/BulkPanel.tsx
+++ b/web/src/components/BulkPanel.tsx
@@ -5,8 +5,6 @@ type Props = {
   theme: Theme;
   selectedPackages: PackageEntry[];
   edits: Record<string, Edit>;
-  isLoggedIn: boolean;
-  onRequestLogin: () => void;
   onApproveAll: () => void;
   onMarkUnmappedAll: () => void;
   onResetSelected: () => void;
@@ -17,8 +15,6 @@ export function BulkPanel({
   theme,
   selectedPackages,
   edits,
-  isLoggedIn,
-  onRequestLogin,
   onApproveAll,
   onMarkUnmappedAll,
   onResetSelected,
@@ -32,14 +28,6 @@ export function BulkPanel({
     (p) => p.purl !== null && !edits[p.name]?.unmapped,
   );
   const unmappable = selectedPackages.filter((p) => p.purl === null);
-
-  const requireLogin = (fn: () => void) => () => {
-    if (!isLoggedIn) {
-      onRequestLogin();
-      return;
-    }
-    fn();
-  };
 
   return (
     <div
@@ -132,7 +120,7 @@ export function BulkPanel({
             variant="primary"
             icon="check"
             disabled={approveable.length === 0}
-            onClick={requireLogin(onApproveAll)}
+            onClick={onApproveAll}
             style={{ width: "100%", justifyContent: "center" }}
           >
             Approve {approveable.length} mapping{approveable.length === 1 ? "" : "s"}
@@ -141,7 +129,7 @@ export function BulkPanel({
             theme={theme}
             variant="ghost"
             icon="alert"
-            onClick={requireLogin(onMarkUnmappedAll)}
+            onClick={onMarkUnmappedAll}
             style={{ width: "100%", justifyContent: "center" }}
           >
             Mark all {n} as no-PURL (unmapped)

--- a/web/src/components/CveDetail.tsx
+++ b/web/src/components/CveDetail.tsx
@@ -20,6 +20,13 @@ import {
   osvUrl,
   primaryId,
 } from "../data/cves";
+import {
+  DraftSelect,
+  DraftTextArea,
+  DraftTextInput,
+  draftClick,
+  handleDraftSubmit,
+} from "./DraftFields";
 import { Btn, Glyph, Theme } from "./Primitives";
 
 type Props = {
@@ -28,8 +35,6 @@ type Props = {
   edits: Record<string, ReviewEdit>;
   onEdit: (advisoryId: string, next: ReviewEdit) => void;
   onResetEdit: (advisoryId: string) => void;
-  isLoggedIn: boolean;
-  onRequestLogin: () => void;
 };
 
 function severityLevel(v: number): {
@@ -249,8 +254,6 @@ export function CveDetail({
   edits,
   onEdit,
   onResetEdit,
-  isLoggedIn,
-  onRequestLogin,
 }: Props) {
   const t = theme.t;
 
@@ -395,8 +398,6 @@ export function CveDetail({
               edit={edits[`${pkg.package}::${adv.id}`]}
               onEdit={(next) => onEdit(adv.id, next)}
               onReset={() => onResetEdit(adv.id)}
-              isLoggedIn={isLoggedIn}
-              onRequestLogin={onRequestLogin}
             />
           ))}
         </div>
@@ -412,8 +413,6 @@ function AdvisoryCard({
   edit,
   onEdit,
   onReset,
-  isLoggedIn,
-  onRequestLogin,
 }: {
   theme: Theme;
   pkgName: string;
@@ -421,8 +420,6 @@ function AdvisoryCard({
   edit: ReviewEdit | undefined;
   onEdit: (next: ReviewEdit) => void;
   onReset: () => void;
-  isLoggedIn: boolean;
-  onRequestLogin: () => void;
 }) {
   const t = theme.t;
   const [expanded, setExpanded] = useState(true);
@@ -433,14 +430,10 @@ function AdvisoryCard({
   const status: VexStatus | undefined = edit?.status ?? baseVex?.status;
 
   function setField<K extends keyof ReviewEdit>(key: K, value: ReviewEdit[K]): void {
-    if (!isLoggedIn && !edit) {
-      onRequestLogin();
-    }
     onEdit({ ...eff, [key]: value });
   }
 
   function toggleNotAffected(version: string): void {
-    if (!isLoggedIn && !edit) onRequestLogin();
     const cur = new Set(eff.version_overrides.not_affected);
     const aff = new Set(eff.version_overrides.affected);
     if (cur.has(version)) cur.delete(version);
@@ -458,7 +451,6 @@ function AdvisoryCard({
   }
 
   function toggleManuallyAffected(version: string): void {
-    if (!isLoggedIn && !edit) onRequestLogin();
     const cur = new Set(eff.version_overrides.affected);
     const not = new Set(eff.version_overrides.not_affected);
     if (cur.has(version)) cur.delete(version);
@@ -709,7 +701,7 @@ function AdvisoryCard({
                     theme={theme}
                     version={v}
                     state={removed ? "removed" : "affected"}
-                    onClick={() => toggleNotAffected(v)}
+                    onClick={draftClick(() => toggleNotAffected(v))}
                     title={
                       removed
                         ? `Override: not affected. Click to undo.`
@@ -726,7 +718,7 @@ function AdvisoryCard({
                     theme={theme}
                     version={v}
                     state="added"
-                    onClick={() => toggleManuallyAffected(v)}
+                    onClick={draftClick(() => toggleManuallyAffected(v))}
                     title="Manually added. Click to remove."
                   />
                 ))}
@@ -744,7 +736,7 @@ function AdvisoryCard({
               {VEX_STATUSES.map((s) => (
                 <button
                   key={s.id}
-                  onClick={() => setField("status", s.id)}
+                  onClick={draftClick(() => setField("status", s.id))}
                   style={{
                     background: eff.status === s.id ? t.accent : t.surface2,
                     color: eff.status === s.id ? t.accentFg : t.fg1,
@@ -769,13 +761,10 @@ function AdvisoryCard({
                     — required for a “not affected” claim
                   </span>
                 </div>
-                <select
+                <DraftSelect
                   value={eff.justification}
-                  onChange={(e) =>
-                    setField(
-                      "justification",
-                      e.target.value as VexJustification,
-                    )
+                  onDraftChange={(justification) =>
+                    setField("justification", justification as VexJustification)
                   }
                   style={{
                     width: "100%",
@@ -794,47 +783,26 @@ function AdvisoryCard({
                       {j.label}
                     </option>
                   ))}
-                </select>
+                </DraftSelect>
               </div>
             )}
             {eff.status === "affected" && (
-              <input
+              <DraftTextInput
                 value={eff.action_statement}
-                onChange={(e) => setField("action_statement", e.target.value)}
+                onDraftChange={(action) => setField("action_statement", action)}
                 placeholder="Action statement — e.g. 'Upgrade to requests ≥ 2.32.4.'"
-                style={{
-                  width: "100%",
-                  background: t.surface2,
-                  color: t.fg1,
-                  border: `1px solid ${t.border}`,
-                  borderRadius: 8,
-                  padding: "8px 10px",
-                  fontSize: 13,
-                  fontFamily: "Inter, sans-serif",
-                  outline: "none",
-                  marginBottom: 10,
-                }}
+                theme={theme}
+                style={{ background: t.surface2, marginBottom: 10 }}
               />
             )}
-            <textarea
+            <DraftTextArea
               value={eff.notes}
-              onChange={(e) => setField("notes", e.target.value)}
+              onDraftChange={(notes) => setField("notes", notes)}
               placeholder={
                 "Optional status note. e.g. 'Conda patches CVE-XXXX in build 1.21.5-py39_2.'"
               }
-              style={{
-                width: "100%",
-                background: t.surface2,
-                color: t.fg1,
-                border: `1px solid ${t.border}`,
-                borderRadius: 8,
-                padding: "8px 10px",
-                fontSize: 13,
-                fontFamily: "Inter, sans-serif",
-                outline: "none",
-                minHeight: 56,
-                resize: "vertical",
-              }}
+              theme={theme}
+              style={{ background: t.surface2, minHeight: 56 }}
             />
             {baseVex?.author && (
               <div
@@ -960,29 +928,29 @@ function AddVersionInline({
   const [draft, setDraft] = useState("");
   return (
     <form
-      onSubmit={(e) => {
-        e.preventDefault();
-        const v = draft.trim();
-        if (v) {
-          onAdd(v);
-          setDraft("");
-        }
-      }}
+      onSubmit={(e) =>
+        handleDraftSubmit(e, () => {
+          const v = draft.trim();
+          if (v) {
+            onAdd(v);
+            setDraft("");
+          }
+        })
+      }
       style={{ display: "inline-flex", alignItems: "center", gap: 4 }}
     >
-      <input
+      <DraftTextInput
         value={draft}
-        onChange={(e) => setDraft(e.target.value)}
+        onDraftChange={setDraft}
         placeholder="+ add version"
-        style={{
+        theme={theme}
+        mono
+        style={{ 
           background: "transparent",
-          color: t.fg1,
           border: `1px dashed ${t.border}`,
           borderRadius: 4,
           padding: "2px 7px",
           fontSize: 11,
-          fontFamily: "JetBrains Mono, monospace",
-          outline: "none",
           width: 110,
         }}
       />

--- a/web/src/components/DraftFields.tsx
+++ b/web/src/components/DraftFields.tsx
@@ -1,0 +1,175 @@
+import type { ChangeEvent, CSSProperties, FormEvent, ReactNode } from "react";
+import { Btn, TextInput, type Theme } from "./Primitives";
+
+/**
+ * Local draft editing primitives.
+ *
+ * Components in this file are deliberately auth-agnostic: editing always writes
+ * to the local persisted draft store. Authentication is only a submit concern
+ * and must stay in the PR drawers. When adding a new editable field, prefer one
+ * of these wrappers instead of wiring DOM events inline; that keeps the
+ * anonymous-drafting behavior consistent.
+ */
+export type DraftChange<T> = (value: T) => void;
+export type DraftAction = () => void;
+
+export function draftClick(onDraft: DraftAction): DraftAction {
+  return onDraft;
+}
+
+export function DraftTextInput({
+  value,
+  onDraftChange,
+  placeholder,
+  theme,
+  mono,
+  style,
+}: {
+  value: string;
+  onDraftChange: DraftChange<string>;
+  placeholder?: string;
+  theme: Theme;
+  mono?: boolean;
+  style?: CSSProperties;
+}) {
+  return (
+    <TextInput
+      value={value}
+      onChange={onDraftChange}
+      placeholder={placeholder}
+      theme={theme}
+      mono={mono}
+      style={style}
+    />
+  );
+}
+
+export function DraftTextArea({
+  value,
+  onDraftChange,
+  placeholder,
+  theme,
+  rows,
+  mono,
+  style,
+}: {
+  value: string;
+  onDraftChange: DraftChange<string>;
+  placeholder?: string;
+  theme: Theme;
+  rows?: number;
+  mono?: boolean;
+  style?: CSSProperties;
+}) {
+  const t = theme.t;
+  return (
+    <textarea
+      value={value}
+      onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
+        onDraftChange(e.target.value)
+      }
+      placeholder={placeholder}
+      rows={rows}
+      style={{
+        width: "100%",
+        resize: "vertical",
+        background: t.surface,
+        color: t.fg1,
+        border: `1px solid ${t.border}`,
+        borderRadius: 8,
+        padding: 10,
+        fontSize: 12.5,
+        lineHeight: 1.5,
+        fontFamily: mono ? "JetBrains Mono, monospace" : "Inter, sans-serif",
+        outline: "none",
+        ...style,
+      }}
+    />
+  );
+}
+
+export function DraftCheckbox({
+  checked,
+  onDraftChange,
+  style,
+}: {
+  checked: boolean;
+  onDraftChange: DraftChange<boolean>;
+  style?: CSSProperties;
+}) {
+  return (
+    <input
+      type="checkbox"
+      checked={checked}
+      onChange={(e) => onDraftChange(e.target.checked)}
+      style={style}
+    />
+  );
+}
+
+export function DraftSelect<T extends string>({
+  value,
+  onDraftChange,
+  children,
+  style,
+}: {
+  value: T;
+  onDraftChange: DraftChange<T>;
+  children: ReactNode;
+  style?: CSSProperties;
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onDraftChange(e.target.value as T)}
+      style={style}
+    >
+      {children}
+    </select>
+  );
+}
+
+export function DraftButton({
+  theme,
+  onDraft,
+  children,
+  variant = "ghost",
+  size,
+  icon,
+  disabled,
+  title,
+  style,
+}: {
+  theme: Theme;
+  onDraft: () => void;
+  children: ReactNode;
+  variant?: "primary" | "secondary" | "ghost";
+  size?: "sm" | "lg";
+  icon?: string;
+  disabled?: boolean;
+  title?: string;
+  style?: CSSProperties;
+}) {
+  return (
+    <Btn
+      theme={theme}
+      variant={variant}
+      size={size}
+      icon={icon}
+      disabled={disabled}
+      title={title}
+      style={style}
+      onClick={onDraft}
+    >
+      {children}
+    </Btn>
+  );
+}
+
+export function handleDraftSubmit(
+  event: FormEvent<HTMLFormElement>,
+  onDraft: () => void,
+): void {
+  event.preventDefault();
+  onDraft();
+}

--- a/web/src/components/LocalDraftBanner.tsx
+++ b/web/src/components/LocalDraftBanner.tsx
@@ -1,0 +1,65 @@
+import { Btn, Glyph, type Theme } from "./Primitives";
+
+type Props = {
+  theme: Theme;
+  count: number;
+  noun: string;
+  onReview: () => void;
+  onDiscard: () => void;
+};
+
+export function LocalDraftBanner({
+  theme,
+  count,
+  noun,
+  onReview,
+  onDiscard,
+}: Props) {
+  if (count === 0) return null;
+
+  const t = theme.t;
+  const plural = count === 1 ? noun : `${noun}s`;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 14,
+        padding: "8px 18px",
+        borderBottom: `1px solid ${theme.dark ? "#4a3b15" : "#e6cf8e"}`,
+        background: theme.dark ? "#211a08" : "#fff7d6",
+        color: theme.dark ? "#ffe9a3" : "#5f4700",
+        flexShrink: 0,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 12 }}>
+        <Glyph name="edit" size={13} />
+        <span>
+          You have <strong>{count}</strong> locally saved staged {plural}.
+        </span>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <Btn theme={theme} variant="ghost" icon="pr" onClick={onReview}>
+          Review
+        </Btn>
+        <button
+          onClick={onDiscard}
+          style={{
+            background: "transparent",
+            border: `1px solid ${theme.dark ? "#5e4a18" : "#dcc277"}`,
+            borderRadius: 8,
+            color: t.fg1,
+            fontSize: 11,
+            fontWeight: 700,
+            padding: "6px 10px",
+            cursor: "pointer",
+          }}
+        >
+          Discard all
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/LoginModal.tsx
+++ b/web/src/components/LoginModal.tsx
@@ -72,7 +72,7 @@ export function LoginModal({
             margin: "0 0 6px",
           }}
         >
-          Sign in to edit
+          Sign in to open a PR
         </h3>
         <div
           style={{
@@ -157,7 +157,7 @@ export function LoginModal({
             fontWeight: 500,
           }}
         >
-          Keep browsing read-only
+          Keep drafting locally
         </button>
       </div>
     </>

--- a/web/src/components/MappingEditor.tsx
+++ b/web/src/components/MappingEditor.tsx
@@ -2,13 +2,19 @@ import { ReactNode, useState } from "react";
 import { PURL_TYPES } from "../data/loader";
 import type { Edit, PackageEntry } from "../data/types";
 import {
-  Btn,
+  DraftButton,
+  DraftCheckbox,
+  DraftSelect,
+  DraftTextArea,
+  DraftTextInput,
+  handleDraftSubmit,
+} from "./DraftFields";
+import {
   ConfidenceBar,
   Glyph,
   PurlChip,
   SourceTag,
   StatusPill,
-  TextInput,
   Theme,
 } from "./Primitives";
 
@@ -19,8 +25,6 @@ type Props = {
   onEdit: (e: Edit) => void;
   onApprove: () => void;
   onResetAuto: () => void;
-  isLoggedIn: boolean;
-  onRequestLogin: () => void;
 };
 
 function buildPurl(type: string, ns: string, name: string): string {
@@ -35,8 +39,6 @@ export function MappingEditor({
   onEdit,
   onApprove,
   onResetAuto,
-  isLoggedIn,
-  onRequestLogin,
 }: Props) {
   const t = theme.t;
   if (!pkg) {
@@ -101,7 +103,10 @@ export function MappingEditor({
     (p.status === "verified" || p.status === "auto-verified") && !isEdited;
 
   function updatePart(patch: Partial<Edit>): void {
+    const editsMapping =
+      "type" in patch || "namespace" in patch || "pkgName" in patch || "purl" in patch;
     const next: Edit = { ...eff, ...patch };
+    if (editsMapping && !("unmapped" in patch)) next.unmapped = false;
     if (!("purl" in patch)) next.purl = buildPurl(next.type, next.namespace, next.pkgName);
     onEdit(next);
   }
@@ -124,6 +129,7 @@ export function MappingEditor({
       namespace: alt.namespace ?? "",
       pkgName: alt.pkg_name,
       alternative_purls: newAlternates,
+      unmapped: false,
     });
   }
 
@@ -137,12 +143,16 @@ export function MappingEditor({
   function addAlt(purl: string): void {
     if (!purl.startsWith("pkg:")) return;
     if (eff.alternative_purls.includes(purl) || eff.purl === purl) return;
-    onEdit({ ...eff, alternative_purls: [...eff.alternative_purls, purl] });
+    onEdit({
+      ...eff,
+      alternative_purls: [...eff.alternative_purls, purl],
+      unmapped: false,
+    });
   }
 
   function updatePurlString(str: string): void {
     const m = str.match(/^pkg:([^/]+)\/(?:([^/]+)\/)?(.+)$/);
-    const next: Edit = { ...eff, purl: str };
+    const next: Edit = { ...eff, purl: str, unmapped: false };
     if (m) {
       next.type = m[1];
       next.namespace = m[2] ?? "";
@@ -257,25 +267,25 @@ export function MappingEditor({
 
           <div style={{ display: "flex", gap: 8, flexShrink: 0 }}>
             {isEdited && (
-              <Btn
+              <DraftButton
                 theme={theme}
                 variant="ghost"
                 size="sm"
                 icon="undo"
-                onClick={onResetAuto}
+                onDraft={onResetAuto}
               >
                 Reset
-              </Btn>
+              </DraftButton>
             )}
             {!isVerified && !eff.unmapped && (
-              <Btn
+              <DraftButton
                 theme={theme}
                 variant="primary"
                 icon="check"
-                onClick={isLoggedIn ? onApprove : onRequestLogin}
+                onDraft={onApprove}
               >
                 Approve mapping
-              </Btn>
+              </DraftButton>
             )}
           </div>
         </div>
@@ -412,9 +422,9 @@ export function MappingEditor({
             }}
           >
             <Field label="Type">
-              <select
+              <DraftSelect
                 value={eff.type}
-                onChange={(e) => updatePart({ type: e.target.value })}
+                onDraftChange={(type) => updatePart({ type })}
                 style={selectStyle(theme)}
               >
                 {PURL_TYPES.map((p) => (
@@ -422,24 +432,24 @@ export function MappingEditor({
                     {p.label}
                   </option>
                 ))}
-              </select>
+              </DraftSelect>
             </Field>
             <Field
               label="Namespace"
               hint="Optional. e.g. owner for github, scope for npm."
             >
-              <TextInput
+              <DraftTextInput
                 value={eff.namespace}
-                onChange={(v) => updatePart({ namespace: v })}
+                onDraftChange={(namespace) => updatePart({ namespace })}
                 theme={theme}
                 mono
                 placeholder="(none)"
               />
             </Field>
             <Field label="Package name">
-              <TextInput
+              <DraftTextInput
                 value={eff.pkgName}
-                onChange={(v) => updatePart({ pkgName: v })}
+                onDraftChange={(pkgName) => updatePart({ pkgName })}
                 theme={theme}
                 mono
                 placeholder={p.name}
@@ -449,9 +459,9 @@ export function MappingEditor({
 
           <div style={{ marginTop: 14 }}>
             <Field label="Raw PURL" hint="Edit directly — fields above will sync.">
-              <TextInput
+              <DraftTextInput
                 value={eff.purl}
-                onChange={updatePurlString}
+                onDraftChange={updatePurlString}
                 theme={theme}
                 mono
                 placeholder="pkg:type/namespace/name"
@@ -473,10 +483,9 @@ export function MappingEditor({
               userSelect: "none",
             }}
           >
-            <input
-              type="checkbox"
+            <DraftCheckbox
               checked={eff.unmapped}
-              onChange={(e) => onEdit({ ...eff, unmapped: e.target.checked })}
+              onDraftChange={(unmapped) => onEdit({ ...eff, unmapped })}
               style={{ accentColor: t.accent, width: 14, height: 14 }}
             />
             <span style={{ fontSize: 13, color: t.fg1 }}>
@@ -491,23 +500,12 @@ export function MappingEditor({
 
           <div style={{ marginTop: 14 }}>
             <Field label="Note" hint="Optional context — shown on the PR.">
-              <textarea
+              <DraftTextArea
                 value={eff.note}
-                onChange={(e) => onEdit({ ...eff, note: e.target.value })}
+                onDraftChange={(note) => onEdit({ ...eff, note })}
                 placeholder="e.g. 'Upstream uses fossil, not git — mapping to pkg:generic.'"
-                style={{
-                  background: t.surface,
-                  color: t.fg1,
-                  border: `1px solid ${t.border}`,
-                  borderRadius: 8,
-                  padding: "8px 10px",
-                  fontSize: 13,
-                  width: "100%",
-                  fontFamily: "Inter, sans-serif",
-                  outline: "none",
-                  minHeight: 64,
-                  resize: "vertical",
-                }}
+                theme={theme}
+                style={{ minHeight: 64 }}
               />
             </Field>
           </div>
@@ -853,13 +851,14 @@ function ResultingPurls({
         ))}
 
         <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            if (draft.trim()) {
-              onAdd(draft.trim());
-              setDraft("");
-            }
-          }}
+          onSubmit={(e) =>
+            handleDraftSubmit(e, () => {
+              if (draft.trim()) {
+                onAdd(draft.trim());
+                setDraft("");
+              }
+            })
+          }
           style={{ display: "flex", gap: 6, marginTop: 4 }}
         >
           <input

--- a/web/src/data/useCveData.ts
+++ b/web/src/data/useCveData.ts
@@ -1,0 +1,38 @@
+import { useEffect, useMemo, useState } from "react";
+import { config } from "../config";
+import { loadCves, type CvePayload } from "./cves";
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export function useCveData() {
+  const [payload, setPayload] = useState<CvePayload | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [focusedPkg, setFocusedPkg] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadCves(config.cvesUrl)
+      .then((data) => {
+        setPayload(data);
+        const first = Object.keys(data.packages).sort()[0];
+        if (first) setFocusedPkg(first);
+      })
+      .catch((err) => setLoadError(errorMessage(err)));
+  }, []);
+
+  const packages = useMemo(() => {
+    if (!payload) return [];
+    return Object.values(payload.packages).sort((a, b) =>
+      a.package.localeCompare(b.package),
+    );
+  }, [payload]);
+
+  const focusedPackage = useMemo(
+    () =>
+      focusedPkg && payload ? payload.packages[focusedPkg] ?? null : null,
+    [focusedPkg, payload],
+  );
+
+  return { payload, loadError, focusedPkg, setFocusedPkg, packages, focusedPackage };
+}

--- a/web/src/data/useMappingsData.ts
+++ b/web/src/data/useMappingsData.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+import { config } from "../config";
+import { loadMappings, packagesAsList } from "./loader";
+import type { MappingsPayload, PackageEntry } from "./types";
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export function useMappingsData() {
+  const [payload, setPayload] = useState<MappingsPayload | null>(null);
+  const [packages, setPackages] = useState<PackageEntry[]>([]);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadMappings(config.mappingsUrl)
+      .then((data) => {
+        setPayload(data);
+        setPackages(packagesAsList(data));
+      })
+      .catch((err) => setLoadError(errorMessage(err)));
+  }, []);
+
+  return { payload, packages, loadError };
+}

--- a/web/src/storage/browserStorage.ts
+++ b/web/src/storage/browserStorage.ts
@@ -1,3 +1,5 @@
+import { storageKey } from "./namespace";
+
 /**
  * Centralized low-level browser storage for auth/session data.
  *
@@ -7,9 +9,9 @@
  */
 const STORAGE_KEYS = {
   /** GitHub OAuth access token. Tab-local auth cache. */
-  githubToken: "purl-associator/gh_token",
+  githubToken: storageKey("gh_token"),
   /** GitHub OAuth state nonce. Tab-local CSRF protection for the redirect. */
-  oauthState: "purl-associator/oauth_state",
+  oauthState: storageKey("oauth_state"),
 } as const;
 
 class BrowserStorage {

--- a/web/src/storage/browserStorage.ts
+++ b/web/src/storage/browserStorage.ts
@@ -1,0 +1,67 @@
+/**
+ * Centralized low-level browser storage for auth/session data.
+ *
+ * User-owned draft state lives in `stores/userState.ts` and is persisted via
+ * Zustand. OAuth data stays here because it is short-lived, redirect-driven,
+ * and intentionally scoped to the current tab/session.
+ */
+const STORAGE_KEYS = {
+  /** GitHub OAuth access token. Tab-local auth cache. */
+  githubToken: "purl-associator/gh_token",
+  /** GitHub OAuth state nonce. Tab-local CSRF protection for the redirect. */
+  oauthState: "purl-associator/oauth_state",
+} as const;
+
+class BrowserStorage {
+  readonly keys = STORAGE_KEYS;
+
+  loadGithubToken(): string | null {
+    return this.getString(sessionStorage, this.keys.githubToken);
+  }
+
+  saveGithubToken(token: string): void {
+    this.setString(sessionStorage, this.keys.githubToken, token);
+  }
+
+  clearGithubToken(): void {
+    this.remove(sessionStorage, this.keys.githubToken);
+  }
+
+  saveOauthState(state: string): void {
+    this.setString(sessionStorage, this.keys.oauthState, state);
+  }
+
+  loadOauthState(): string | null {
+    return this.getString(sessionStorage, this.keys.oauthState);
+  }
+
+  clearOauthState(): void {
+    this.remove(sessionStorage, this.keys.oauthState);
+  }
+
+  private getString(storage: Storage, key: string): string | null {
+    try {
+      return storage.getItem(key);
+    } catch {
+      return null;
+    }
+  }
+
+  private setString(storage: Storage, key: string, value: string): void {
+    try {
+      storage.setItem(key, value);
+    } catch {
+      // Ignore unavailable/quota-limited storage. The app still works in-memory.
+    }
+  }
+
+  private remove(storage: Storage, key: string): void {
+    try {
+      storage.removeItem(key);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+export const browserStorage = new BrowserStorage();

--- a/web/src/storage/namespace.ts
+++ b/web/src/storage/namespace.ts
@@ -1,0 +1,9 @@
+/**
+ * Namespace used to prefix all browser storage keys for this app. Centralized
+ * here so renaming the project only requires changing one constant.
+ */
+export const STORAGE_NAMESPACE = "purl-associator";
+
+export function storageKey(name: string): string {
+  return `${STORAGE_NAMESPACE}/${name}`;
+}

--- a/web/src/stores/userState.ts
+++ b/web/src/stores/userState.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { persist, type PersistStorage, type StorageValue } from "zustand/middleware";
 import type { ReviewEdit } from "../data/cves";
 import type { Edit } from "../data/types";
+import { storageKey } from "../storage/namespace";
 
 /**
  * Persisted user-owned draft state.
@@ -11,8 +12,8 @@ import type { Edit } from "../data/types";
  * should survive accidental tab/window/browser closes until submitted or reset.
  */
 const STORAGE_KEYS = {
-  stagedPurlEdits: "purl-associator/staged_edits",
-  stagedCveEdits: "purl-associator/staged_cve_edits",
+  stagedPurlEdits: storageKey("staged_edits"),
+  stagedCveEdits: storageKey("staged_cve_edits"),
 } as const;
 
 type PersistedEdits<T> = { edits: Record<string, T> };

--- a/web/src/stores/userState.ts
+++ b/web/src/stores/userState.ts
@@ -1,0 +1,110 @@
+import { create } from "zustand";
+import { persist, type PersistStorage, type StorageValue } from "zustand/middleware";
+import type { ReviewEdit } from "../data/cves";
+import type { Edit } from "../data/types";
+
+/**
+ * Persisted user-owned draft state.
+ *
+ * These stores use Zustand's persist middleware, which writes JSON to
+ * localStorage by default. That is intentional: staged edits are user work that
+ * should survive accidental tab/window/browser closes until submitted or reset.
+ */
+const STORAGE_KEYS = {
+  stagedPurlEdits: "purl-associator/staged_edits",
+  stagedCveEdits: "purl-associator/staged_cve_edits",
+} as const;
+
+type PersistedEdits<T> = { edits: Record<string, T> };
+
+function persistedEditStorage<T>(): PersistStorage<PersistedEdits<T>> {
+  return {
+    getItem: (name) => {
+      try {
+        const raw = localStorage.getItem(name);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw) as
+          | StorageValue<PersistedEdits<T>>
+          | Record<string, T>;
+        if (parsed && typeof parsed === "object" && "state" in parsed) {
+          return parsed as StorageValue<PersistedEdits<T>>;
+        }
+        // Migration path for the pre-Zustand format, where the storage value was
+        // the raw edits object under the same key.
+        return { state: { edits: parsed as Record<string, T> }, version: 0 };
+      } catch {
+        return null;
+      }
+    },
+    setItem: (name, value) => {
+      try {
+        localStorage.setItem(name, JSON.stringify(value));
+      } catch {
+        // Ignore unavailable/quota-limited storage. The app still works in-memory.
+      }
+    },
+    removeItem: (name) => {
+      try {
+        localStorage.removeItem(name);
+      } catch {
+        // ignore
+      }
+    },
+  };
+}
+
+type PurlEditState = {
+  edits: Record<string, Edit>;
+  setEdits: (
+    next:
+      | Record<string, Edit>
+      | ((previous: Record<string, Edit>) => Record<string, Edit>),
+  ) => void;
+  clearEdits: () => void;
+};
+
+export const usePurlEditStore = create<PurlEditState>()(
+  persist(
+    (set) => ({
+      edits: {},
+      setEdits: (next) =>
+        set((state) => ({
+          edits: typeof next === "function" ? next(state.edits) : next,
+        })),
+      clearEdits: () => set({ edits: {} }),
+    }),
+    {
+      name: STORAGE_KEYS.stagedPurlEdits,
+      storage: persistedEditStorage<Edit>(),
+      partialize: (state) => ({ edits: state.edits }),
+    },
+  ),
+);
+
+type CveEditState = {
+  edits: Record<string, ReviewEdit>;
+  setEdits: (
+    next:
+      | Record<string, ReviewEdit>
+      | ((previous: Record<string, ReviewEdit>) => Record<string, ReviewEdit>),
+  ) => void;
+  clearEdits: () => void;
+};
+
+export const useCveEditStore = create<CveEditState>()(
+  persist(
+    (set) => ({
+      edits: {},
+      setEdits: (next) =>
+        set((state) => ({
+          edits: typeof next === "function" ? next(state.edits) : next,
+        })),
+      clearEdits: () => set({ edits: {} }),
+    }),
+    {
+      name: STORAGE_KEYS.stagedCveEdits,
+      storage: persistedEditStorage<ReviewEdit>(),
+      partialize: (state) => ({ edits: state.edits }),
+    },
+  ),
+);


### PR DESCRIPTION
Fixes #60.

Additionally, I found out that we were saving in sessionStorage instead of localStorage. This should persist across sessions and tab closing. So I made it use that. But at that point I was unhappy with the workflow so I chnaged it to:

- Persist staged PURL/CVE draft edits in localStorage via Zustand stores
- Allow users to draft edits while signed out; require login only when opening a PR
- Add a local draft banner with review/discard actions
- Centralize auth session storage separately from user draft storage

This means we now have a zustand store that syncs automatically in localStorage. Also, you don't need to login until you are ready to make PR's this makes testing it locally a lot easier.

<img width="3448" height="1504" alt="image" src="https://github.com/user-attachments/assets/2fbb18a7-172c-4a9d-be3d-893ef47436fb" />

