### PR TITLE
nvd: add CPE-based CVE matching via NVD nightly feeds

### DIFF
--- a/.github/workflows/cve_refresh.yml
+++ b/.github/workflows/cve_refresh.yml
@@ -70,6 +70,18 @@ jobs:
           fi
           pixi run python -m scripts.cve_match "${ARGS[@]}"
 
+      - name: Match NVD CVEs for CPE-mapped packages
+        # Runs AFTER cve_match because cve_match's --clean-stale would prune
+        # CPE-only CVE files if it ran second. CPE-mapped packages
+        # (manual.json entries with a ``cpes`` list) don't carry an
+        # OSV-indexed PURL, so cve_match never sees them; nvd_prototype
+        # fills in those gaps from NVD by CPE.
+        run: |
+          set -euo pipefail
+          ARGS=()
+          if [ -n "${{ inputs.only }}" ]; then ARGS+=(--only "${{ inputs.only }}"); fi
+          pixi run python -m scripts.nvd_prototype "${ARGS[@]}"
+
       - name: Merge CVEs + reviewer contributions for the SPA
         run: pixi run python -m scripts.merge_cves
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ web/public/cves.json
 .osv_cache/
 osv_cache/
 
+# NVD feed cache (refreshed daily by cve_refresh workflow).
+.nvd_cache/
+nvd_cache/
+
 # Local scratch outputs
 .tmp/
 

--- a/mappings/cves/ncurses.json
+++ b/mappings/cves/ncurses.json
@@ -2,11 +2,14 @@
   "schema_version": 1,
   "package": "ncurses",
   "purls": [
+    "pkg:github/ThomasDickey/ncurses-snapshots"
+  ],
+  "cpes": [
     "cpe:2.3:a:gnu:ncurses",
     "cpe:2.3:a:invisible-island:ncurses",
     "cpe:2.3:a:invisible-island:ncurse"
   ],
-  "generated_at": "2026-05-25T12:22:54+00:00",
+  "generated_at": "2026-05-25T13:00:46+00:00",
   "conda_versions_total": 8,
   "latest_version": "6.6",
   "advisories": [
@@ -63,7 +66,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -131,7 +134,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -242,7 +245,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -353,7 +356,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -473,7 +476,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -593,7 +596,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -713,7 +716,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -833,7 +836,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -961,7 +964,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -1081,7 +1084,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -1249,7 +1252,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -1369,7 +1372,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -1530,7 +1533,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -1624,7 +1627,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -1720,7 +1723,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -1816,7 +1819,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -1906,7 +1909,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -1980,7 +1983,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -2054,7 +2057,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -2128,7 +2131,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -2218,7 +2221,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -2308,7 +2311,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -2398,7 +2401,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -2488,7 +2491,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -2578,7 +2581,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -2668,7 +2671,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -2742,7 +2745,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -2848,7 +2851,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [
@@ -2938,7 +2941,7 @@
           "conda_versions_total": 8,
           "affects_future": false,
           "derived_by": "purl-associator/scripts.nvd_prototype",
-          "generated_at": "2026-05-25T12:22:54+00:00"
+          "generated_at": "2026-05-25T13:00:46+00:00"
         },
         "nvd": {
           "cpes": [

--- a/mappings/cves/ncurses.json
+++ b/mappings/cves/ncurses.json
@@ -1,0 +1,2957 @@
+{
+  "schema_version": 1,
+  "package": "ncurses",
+  "purls": [
+    "cpe:2.3:a:gnu:ncurses",
+    "cpe:2.3:a:invisible-island:ncurses",
+    "cpe:2.3:a:invisible-island:ncurse"
+  ],
+  "generated_at": "2026-05-25T12:22:54+00:00",
+  "conda_versions_total": 8,
+  "latest_version": "6.6",
+  "advisories": [
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2018-19211",
+      "published": "2018-11-12T19:29:00.347Z",
+      "modified": "2024-11-21T03:57:34.107Z",
+      "aliases": [],
+      "summary": "In ncurses 6.1, there is a NULL pointer dereference at function _nc_parse_entry in parse_entry.c that will lead to a denial of service attack.",
+      "details": "In ncurses 6.1, there is a NULL pointer dereference at function _nc_parse_entry in parse_entry.c that will lead to a denial of service attack. The product proceeds to the dereference code path even after a \"dubious character `*' in name or alias field\" detection.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "versions": [
+            "6.1"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1643754"
+        },
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1643754"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+        },
+        {
+          "type": "CVSS_V2",
+          "score": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [
+            "6.1"
+          ],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2018-19217",
+      "published": "2018-11-12T19:29:00.597Z",
+      "modified": "2024-11-21T03:57:35.047Z",
+      "aliases": [],
+      "summary": "In ncurses, possibly a 6.x version, there is a NULL pointer dereference at the function _nc_name_match that will lead to a denial of service attack.",
+      "details": "In ncurses, possibly a 6.x version, there is a NULL pointer dereference at the function _nc_name_match that will lead to a denial of service attack. NOTE: the original report stated version 6.1, but the issue did not reproduce for that version according to the maintainer or a reliable third-party",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "versions": [
+            "6.1"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1643753"
+        },
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1643753"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+        },
+        {
+          "type": "CVSS_V2",
+          "score": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [
+            "6.1"
+          ],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2019-17594",
+      "published": "2019-10-14T21:15:11.347Z",
+      "modified": "2024-11-21T04:32:36.180Z",
+      "aliases": [],
+      "summary": "There is a heap-based buffer over-read in the _nc_find_entry function in tinfo/comp_hash.c in the terminfo library in ncurses before 6.1-20191012.",
+      "details": "There is a heap-based buffer over-read in the _nc_find_entry function in tinfo/comp_hash.c in the terminfo library in ncurses before 6.1-20191012.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "ranges": [
+            {
+              "type": "ECOSYSTEM",
+              "events": [
+                {
+                  "introduced": "0"
+                },
+                {
+                  "fixed": "6.2"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "http://lists.opensuse.org/opensuse-security-announce/2019-11/msg00059.html"
+        },
+        {
+          "type": "WEB",
+          "url": "http://lists.opensuse.org/opensuse-security-announce/2019-11/msg00061.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.gnu.org/archive/html/bug-ncurses/2019-10/msg00017.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.gnu.org/archive/html/bug-ncurses/2019-10/msg00045.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/202101-28"
+        },
+        {
+          "type": "WEB",
+          "url": "http://lists.opensuse.org/opensuse-security-announce/2019-11/msg00059.html"
+        },
+        {
+          "type": "WEB",
+          "url": "http://lists.opensuse.org/opensuse-security-announce/2019-11/msg00061.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.gnu.org/archive/html/bug-ncurses/2019-10/msg00017.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.gnu.org/archive/html/bug-ncurses/2019-10/msg00045.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/202101-28"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L"
+        },
+        {
+          "type": "CVSS_V2",
+          "score": "AV:L/AC:L/Au:N/C:P/I:P/A:P"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [
+            "5.9",
+            "6.1"
+          ],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2019-17595",
+      "published": "2019-10-14T21:15:11.427Z",
+      "modified": "2024-11-21T04:32:36.323Z",
+      "aliases": [],
+      "summary": "There is a heap-based buffer over-read in the fmt_entry function in tinfo/comp_hash.c in the terminfo library in ncurses before 6.1-20191012.",
+      "details": "There is a heap-based buffer over-read in the fmt_entry function in tinfo/comp_hash.c in the terminfo library in ncurses before 6.1-20191012.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "ranges": [
+            {
+              "type": "ECOSYSTEM",
+              "events": [
+                {
+                  "introduced": "0"
+                },
+                {
+                  "fixed": "6.2"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "http://lists.opensuse.org/opensuse-security-announce/2019-11/msg00059.html"
+        },
+        {
+          "type": "WEB",
+          "url": "http://lists.opensuse.org/opensuse-security-announce/2019-11/msg00061.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.gnu.org/archive/html/bug-ncurses/2019-10/msg00013.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.gnu.org/archive/html/bug-ncurses/2019-10/msg00045.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/202101-28"
+        },
+        {
+          "type": "WEB",
+          "url": "http://lists.opensuse.org/opensuse-security-announce/2019-11/msg00059.html"
+        },
+        {
+          "type": "WEB",
+          "url": "http://lists.opensuse.org/opensuse-security-announce/2019-11/msg00061.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.gnu.org/archive/html/bug-ncurses/2019-10/msg00013.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.gnu.org/archive/html/bug-ncurses/2019-10/msg00045.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/202101-28"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:L"
+        },
+        {
+          "type": "CVSS_V2",
+          "score": "AV:N/AC:M/Au:N/C:P/I:N/A:P"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [
+            "5.9",
+            "6.1"
+          ],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2020-19185",
+      "published": "2023-08-22T19:15:57.233Z",
+      "modified": "2024-11-21T05:09:00.280Z",
+      "aliases": [],
+      "summary": "Buffer Overflow vulnerability in one_one_mapping function in progs/dump_entry.c:1373 in ncurses 6.1 allows remote attackers to cause a denial of service via crafted command.",
+      "details": "Buffer Overflow vulnerability in one_one_mapping function in progs/dump_entry.c:1373 in ncurses 6.1 allows remote attackers to cause a denial of service via crafted command.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "versions": [
+            "6.1"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/10"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/11"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/9"
+        },
+        {
+          "type": "WEB",
+          "url": "https://github.com/zjuchenyuan/fuzzpoc/blob/master/infotocap_poc1.md"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.netapp.com/advisory/ntap-20231006-0005/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214036"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214037"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214038"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/10"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/11"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/9"
+        },
+        {
+          "type": "WEB",
+          "url": "https://github.com/zjuchenyuan/fuzzpoc/blob/master/infotocap_poc1.md"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.netapp.com/advisory/ntap-20231006-0005/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214036"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214037"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214038"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [
+            "6.1"
+          ],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2020-19186",
+      "published": "2023-08-22T19:15:58.247Z",
+      "modified": "2024-11-21T05:09:00.470Z",
+      "aliases": [],
+      "summary": "Buffer Overflow vulnerability in _nc_find_entry function in tinfo/comp_hash.c:66 in ncurses 6.1 allows remote attackers to cause a denial of service via crafted command.",
+      "details": "Buffer Overflow vulnerability in _nc_find_entry function in tinfo/comp_hash.c:66 in ncurses 6.1 allows remote attackers to cause a denial of service via crafted command.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "versions": [
+            "6.1"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/10"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/11"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/9"
+        },
+        {
+          "type": "WEB",
+          "url": "https://github.com/zjuchenyuan/fuzzpoc/blob/master/infotocap_poc2.md"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.netapp.com/advisory/ntap-20231006-0005/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214036"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214037"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214038"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/10"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/11"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/9"
+        },
+        {
+          "type": "WEB",
+          "url": "https://github.com/zjuchenyuan/fuzzpoc/blob/master/infotocap_poc2.md"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.netapp.com/advisory/ntap-20231006-0005/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214036"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214037"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214038"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [
+            "6.1"
+          ],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2020-19187",
+      "published": "2023-08-22T19:15:59.317Z",
+      "modified": "2024-11-21T05:09:00.630Z",
+      "aliases": [],
+      "summary": "Buffer Overflow vulnerability in fmt_entry function in progs/dump_entry.c:1100 in ncurses 6.1 allows remote attackers to cause a denial of service via crafted command.",
+      "details": "Buffer Overflow vulnerability in fmt_entry function in progs/dump_entry.c:1100 in ncurses 6.1 allows remote attackers to cause a denial of service via crafted command.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "versions": [
+            "6.1"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/10"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/11"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/9"
+        },
+        {
+          "type": "WEB",
+          "url": "https://github.com/zjuchenyuan/fuzzpoc/blob/master/infotocap_poc3.md"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.netapp.com/advisory/ntap-20231006-0005/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214036"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214037"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214038"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/10"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/11"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/9"
+        },
+        {
+          "type": "WEB",
+          "url": "https://github.com/zjuchenyuan/fuzzpoc/blob/master/infotocap_poc3.md"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.netapp.com/advisory/ntap-20231006-0005/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214036"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214037"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214038"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [
+            "6.1"
+          ],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2020-19188",
+      "published": "2023-08-22T19:16:00.380Z",
+      "modified": "2024-11-21T05:09:00.790Z",
+      "aliases": [],
+      "summary": "Buffer Overflow vulnerability in fmt_entry function in progs/dump_entry.c:1116 in ncurses 6.1 allows remote attackers to cause a denial of service via crafted command.",
+      "details": "Buffer Overflow vulnerability in fmt_entry function in progs/dump_entry.c:1116 in ncurses 6.1 allows remote attackers to cause a denial of service via crafted command.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "versions": [
+            "6.1"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/10"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/11"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/9"
+        },
+        {
+          "type": "WEB",
+          "url": "https://github.com/zjuchenyuan/fuzzpoc/blob/master/infotocap_poc4.md"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.netapp.com/advisory/ntap-20231006-0005/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214036"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214037"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214038"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/10"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/11"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/9"
+        },
+        {
+          "type": "WEB",
+          "url": "https://github.com/zjuchenyuan/fuzzpoc/blob/master/infotocap_poc4.md"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.netapp.com/advisory/ntap-20231006-0005/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214036"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214037"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214038"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [
+            "6.1"
+          ],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2020-19189",
+      "published": "2023-08-22T19:16:01.020Z",
+      "modified": "2024-11-21T05:09:00.950Z",
+      "aliases": [],
+      "summary": "Buffer Overflow vulnerability in postprocess_terminfo function in tinfo/parse_entry.c:997 in ncurses 6.1 allows remote attackers to cause a denial of service via crafted command.",
+      "details": "Buffer Overflow vulnerability in postprocess_terminfo function in tinfo/parse_entry.c:997 in ncurses 6.1 allows remote attackers to cause a denial of service via crafted command.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "versions": [
+            "6.1"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/10"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/11"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/9"
+        },
+        {
+          "type": "WEB",
+          "url": "https://github.com/zjuchenyuan/fuzzpoc/blob/master/infotocap_poc5.md"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.debian.org/debian-lts-announce/2023/09/msg00033.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.netapp.com/advisory/ntap-20231006-0005/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214036"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214037"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214038"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/10"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/11"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/9"
+        },
+        {
+          "type": "WEB",
+          "url": "https://github.com/zjuchenyuan/fuzzpoc/blob/master/infotocap_poc5.md"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.debian.org/debian-lts-announce/2023/09/msg00033.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.netapp.com/advisory/ntap-20231006-0005/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214036"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214037"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214038"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [
+            "6.1"
+          ],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2020-19190",
+      "published": "2023-08-22T19:16:01.803Z",
+      "modified": "2024-11-21T05:09:01.117Z",
+      "aliases": [],
+      "summary": "Buffer Overflow vulnerability in _nc_find_entry in tinfo/comp_hash.c:70 in ncurses 6.1 allows remote attackers to cause a denial of service via crafted command.",
+      "details": "Buffer Overflow vulnerability in _nc_find_entry in tinfo/comp_hash.c:70 in ncurses 6.1 allows remote attackers to cause a denial of service via crafted command.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "versions": [
+            "6.1"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/10"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/11"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/9"
+        },
+        {
+          "type": "WEB",
+          "url": "https://github.com/zjuchenyuan/fuzzpoc/blob/master/infotocap_poc6.md"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.netapp.com/advisory/ntap-20231006-0005/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214036"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214037"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214038"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/10"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/11"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2023/Dec/9"
+        },
+        {
+          "type": "WEB",
+          "url": "https://github.com/zjuchenyuan/fuzzpoc/blob/master/infotocap_poc6.md"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.netapp.com/advisory/ntap-20231006-0005/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214036"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214037"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT214038"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [
+            "6.1"
+          ],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2021-39537",
+      "published": "2021-09-20T16:15:12.477Z",
+      "modified": "2024-11-21T06:19:38.517Z",
+      "aliases": [],
+      "summary": "An issue was discovered in ncurses through v6.2-1.",
+      "details": "An issue was discovered in ncurses through v6.2-1. _nc_captoinfo in captoinfo.c has a heap-based buffer overflow.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "ranges": [
+            {
+              "type": "ECOSYSTEM",
+              "events": [
+                {
+                  "introduced": "0"
+                },
+                {
+                  "last_affected": "6.2.1"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/devel/ncurses/patches/patch-ncurses_tinfo_captoinfo.c?rev=1.1&content-type=text/x-cvsweb-markup"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2022/Oct/28"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2022/Oct/41"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2022/Oct/43"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2022/Oct/45"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.debian.org/debian-lts-announce/2023/12/msg00004.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.gnu.org/archive/html/bug-ncurses/2020-08/msg00006.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.gnu.org/archive/html/bug-ncurses/2021-10/msg00023.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.netapp.com/advisory/ntap-20230427-0012/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT213443"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT213444"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT213488"
+        },
+        {
+          "type": "WEB",
+          "url": "http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/devel/ncurses/patches/patch-ncurses_tinfo_captoinfo.c?rev=1.1&content-type=text/x-cvsweb-markup"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2022/Oct/28"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2022/Oct/41"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2022/Oct/43"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2022/Oct/45"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.debian.org/debian-lts-announce/2023/12/msg00004.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.gnu.org/archive/html/bug-ncurses/2020-08/msg00006.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.gnu.org/archive/html/bug-ncurses/2021-10/msg00023.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.netapp.com/advisory/ntap-20230427-0012/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT213443"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT213444"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT213488"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        {
+          "type": "CVSS_V2",
+          "score": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [
+            "5.9",
+            "6.1",
+            "6.2"
+          ],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2022-29458",
+      "published": "2022-04-18T21:15:07.600Z",
+      "modified": "2025-06-09T15:15:27.430Z",
+      "aliases": [],
+      "summary": "ncurses 6.3 before patch 20220416 has an out-of-bounds read and segmentation violation in convert_strings in tinfo/read_entry.c in the terminfo library.",
+      "details": "ncurses 6.3 before patch 20220416 has an out-of-bounds read and segmentation violation in convert_strings in tinfo/read_entry.c in the terminfo library.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "ranges": [
+            {
+              "type": "ECOSYSTEM",
+              "events": [
+                {
+                  "introduced": "0"
+                },
+                {
+                  "fixed": "6.3"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2022/Oct/28"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2022/Oct/41"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.debian.org/debian-lts-announce/2022/10/msg00037.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.gnu.org/archive/html/bug-ncurses/2022-04/msg00014.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.gnu.org/archive/html/bug-ncurses/2022-04/msg00016.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT213488"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2022/Oct/28"
+        },
+        {
+          "type": "WEB",
+          "url": "http://seclists.org/fulldisclosure/2022/Oct/41"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.debian.org/debian-lts-announce/2022/10/msg00037.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.gnu.org/archive/html/bug-ncurses/2022-04/msg00014.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.gnu.org/archive/html/bug-ncurses/2022-04/msg00016.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT213488"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:H"
+        },
+        {
+          "type": "CVSS_V2",
+          "score": "AV:N/AC:M/Au:N/C:P/I:N/A:P"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [
+            "5.9",
+            "6.1",
+            "6.2"
+          ],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2023-29491",
+      "published": "2023-04-14T01:15:08.570Z",
+      "modified": "2025-11-04T19:15:42.307Z",
+      "aliases": [],
+      "summary": "ncurses before 6.4 20230408, when used by a setuid application, allows local users to trigger security-relevant memory corruption via malformed data in a terminfo database file that is found in $HOME/",
+      "details": "ncurses before 6.4 20230408, when used by a setuid application, allows local users to trigger security-relevant memory corruption via malformed data in a terminfo database file that is found in $HOME/.terminfo or reached via the TERMINFO or TERM environment variable.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "ranges": [
+            {
+              "type": "ECOSYSTEM",
+              "events": [
+                {
+                  "introduced": "0"
+                },
+                {
+                  "fixed": "6.4"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "http://ncurses.scripts.mit.edu/?p=ncurses.git%3Ba=commit%3Bh=eb51b1ea1f75a0ec17c9c5937cb28df1e8eeec56"
+        },
+        {
+          "type": "WEB",
+          "url": "http://www.openwall.com/lists/oss-security/2023/04/19/10"
+        },
+        {
+          "type": "WEB",
+          "url": "http://www.openwall.com/lists/oss-security/2023/04/19/11"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.debian.org/debian-lts-announce/2023/12/msg00004.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/LU4MYMKFEZQ5VSCVLRIZGDQOUW3T44GT/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.netapp.com/advisory/ntap-20230517-0009/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT213843"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT213844"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT213845"
+        },
+        {
+          "type": "WEB",
+          "url": "https://www.openwall.com/lists/oss-security/2023/04/12/5"
+        },
+        {
+          "type": "WEB",
+          "url": "https://www.openwall.com/lists/oss-security/2023/04/13/4"
+        },
+        {
+          "type": "WEB",
+          "url": "http://ncurses.scripts.mit.edu/?p=ncurses.git%3Ba=commit%3Bh=eb51b1ea1f75a0ec17c9c5937cb28df1e8eeec56"
+        },
+        {
+          "type": "WEB",
+          "url": "http://www.openwall.com/lists/oss-security/2023/04/19/10"
+        },
+        {
+          "type": "WEB",
+          "url": "http://www.openwall.com/lists/oss-security/2023/04/19/11"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.debian.org/debian-lts-announce/2023/12/msg00004.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/LU4MYMKFEZQ5VSCVLRIZGDQOUW3T44GT/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/LU4MYMKFEZQ5VSCVLRIZGDQOUW3T44GT/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.netapp.com/advisory/ntap-20230517-0009/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT213843"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT213844"
+        },
+        {
+          "type": "WEB",
+          "url": "https://support.apple.com/kb/HT213845"
+        },
+        {
+          "type": "WEB",
+          "url": "https://www.openwall.com/lists/oss-security/2023/04/12/5"
+        },
+        {
+          "type": "WEB",
+          "url": "https://www.openwall.com/lists/oss-security/2023/04/13/4"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [
+            "5.9",
+            "6.1",
+            "6.2",
+            "6.3"
+          ],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2025-69720",
+      "published": "2026-03-19T15:16:21.293Z",
+      "modified": "2026-03-26T19:35:10.547Z",
+      "aliases": [],
+      "summary": "The infocmp command-line tool in ncurses before 6.5-20251213 has a stack-based buffer overflow in analyze_string in progs/infocmp.c.",
+      "details": "The infocmp command-line tool in ncurses before 6.5-20251213 has a stack-based buffer overflow in analyze_string in progs/infocmp.c.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "ranges": [
+            {
+              "type": "ECOSYSTEM",
+              "events": [
+                {
+                  "introduced": "0"
+                },
+                {
+                  "last_affected": "6.4"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "https://github.com/Cao-Wuhui/CVE-2025-69720"
+        },
+        {
+          "type": "WEB",
+          "url": "https://invisible-island.net/archives/ncurses/6.5/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://invisible-island.net/ncurses/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://marc.info/?l=ncurses-bug&m=176539968328570&w=2"
+        },
+        {
+          "type": "WEB",
+          "url": "https://marc.info/?l=ncurses-bug&m=176540731801330&w=2"
+        },
+        {
+          "type": "WEB",
+          "url": "https://marc.info/?l=ncurses-bug&m=176545557728083&w=2"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:L"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [
+            "5.9",
+            "6.1",
+            "6.2",
+            "6.3",
+            "6.4"
+          ],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:invisible-island:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2000-0963",
+      "published": "2000-12-19T05:00:00.000Z",
+      "modified": "2026-04-16T00:27:16.627Z",
+      "aliases": [],
+      "summary": "Buffer overflow in ncurses library allows local users to execute arbitrary commands via long environmental information such as TERM or TERMINFO_DIRS.",
+      "details": "Buffer overflow in ncurses library allows local users to execute arbitrary commands via long environmental information such as TERM or TERMINFO_DIRS.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "ranges": [
+            {
+              "type": "ECOSYSTEM",
+              "events": [
+                {
+                  "introduced": "0"
+                },
+                {
+                  "fixed": "5.6"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "http://www.calderasystems.com/support/security/advisories/CSSA-2000-036.0.txt"
+        },
+        {
+          "type": "WEB",
+          "url": "http://www.securityfocus.com/archive/1/138550"
+        },
+        {
+          "type": "WEB",
+          "url": "http://www.securityfocus.com/bid/1142"
+        },
+        {
+          "type": "WEB",
+          "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/44487"
+        },
+        {
+          "type": "WEB",
+          "url": "http://www.calderasystems.com/support/security/advisories/CSSA-2000-036.0.txt"
+        },
+        {
+          "type": "WEB",
+          "url": "http://www.securityfocus.com/archive/1/138550"
+        },
+        {
+          "type": "WEB",
+          "url": "http://www.securityfocus.com/bid/1142"
+        },
+        {
+          "type": "WEB",
+          "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/44487"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V2",
+          "score": "AV:L/AC:L/Au:N/C:C/I:C/A:C"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2002-0062",
+      "published": "2002-03-08T05:00:00.000Z",
+      "modified": "2026-04-16T00:27:16.627Z",
+      "aliases": [],
+      "summary": "Buffer overflow in ncurses 5.0, and the ncurses4 compatibility package as used in Red Hat Linux, allows local users to gain privileges, related to \"routines for moving the physical cursor and scrollin",
+      "details": "Buffer overflow in ncurses 5.0, and the ncurses4 compatibility package as used in Red Hat Linux, allows local users to gain privileges, related to \"routines for moving the physical cursor and scrolling.\"",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "ranges": [
+            {
+              "type": "ECOSYSTEM",
+              "events": [
+                {
+                  "introduced": "0"
+                },
+                {
+                  "fixed": "5.0"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "http://www.debian.org/security/2002/dsa-113"
+        },
+        {
+          "type": "WEB",
+          "url": "http://www.iss.net/security_center/static/8222.php"
+        },
+        {
+          "type": "WEB",
+          "url": "http://www.redhat.com/support/errata/RHSA-2002-020.html"
+        },
+        {
+          "type": "WEB",
+          "url": "http://www.securityfocus.com/bid/2116"
+        },
+        {
+          "type": "WEB",
+          "url": "http://www.debian.org/security/2002/dsa-113"
+        },
+        {
+          "type": "WEB",
+          "url": "http://www.iss.net/security_center/static/8222.php"
+        },
+        {
+          "type": "WEB",
+          "url": "http://www.redhat.com/support/errata/RHSA-2002-020.html"
+        },
+        {
+          "type": "WEB",
+          "url": "http://www.securityfocus.com/bid/2116"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V2",
+          "score": "AV:L/AC:L/Au:N/C:C/I:C/A:C"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2017-10684",
+      "published": "2017-06-29T23:29:00.223Z",
+      "modified": "2026-05-13T00:24:29.033Z",
+      "aliases": [],
+      "summary": "In ncurses 6.0, there is a stack-based buffer overflow in the fmt_entry function.",
+      "details": "In ncurses 6.0, there is a stack-based buffer overflow in the fmt_entry function. A crafted input will lead to a remote arbitrary code execution attack.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "versions": [
+            "6.0"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1464687"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/201804-13"
+        },
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1464687"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/201804-13"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        },
+        {
+          "type": "CVSS_V2",
+          "score": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2017-10685",
+      "published": "2017-06-29T23:29:00.253Z",
+      "modified": "2026-05-13T00:24:29.033Z",
+      "aliases": [],
+      "summary": "In ncurses 6.0, there is a format string vulnerability in the fmt_entry function.",
+      "details": "In ncurses 6.0, there is a format string vulnerability in the fmt_entry function. A crafted input will lead to a remote arbitrary code execution attack.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "versions": [
+            "6.0"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1464692"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/201804-13"
+        },
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1464692"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/201804-13"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        },
+        {
+          "type": "CVSS_V2",
+          "score": "AV:N/AC:L/Au:N/C:P/I:P/A:P"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2017-11112",
+      "published": "2017-07-08T17:29:00.667Z",
+      "modified": "2026-05-13T00:24:29.033Z",
+      "aliases": [],
+      "summary": "In ncurses 6.0, there is an attempted 0xffffffffffffffff access in the append_acs function of tinfo/parse_entry.c.",
+      "details": "In ncurses 6.0, there is an attempted 0xffffffffffffffff access in the append_acs function of tinfo/parse_entry.c. It could lead to a remote denial of service attack if the terminfo library code is used to process untrusted terminfo data.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "versions": [
+            "6.0"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1464686"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/201804-13"
+        },
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1464686"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/201804-13"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        {
+          "type": "CVSS_V2",
+          "score": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2017-11113",
+      "published": "2017-07-08T17:29:00.747Z",
+      "modified": "2026-05-13T00:24:29.033Z",
+      "aliases": [],
+      "summary": "In ncurses 6.0, there is a NULL Pointer Dereference in the _nc_parse_entry function of tinfo/parse_entry.c.",
+      "details": "In ncurses 6.0, there is a NULL Pointer Dereference in the _nc_parse_entry function of tinfo/parse_entry.c. It could lead to a remote denial of service attack if the terminfo library code is used to process untrusted terminfo data.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "versions": [
+            "6.0"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1464691"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/201804-13"
+        },
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1464691"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/201804-13"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        {
+          "type": "CVSS_V2",
+          "score": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2017-13728",
+      "published": "2017-08-29T06:29:00.297Z",
+      "modified": "2026-05-13T00:24:29.033Z",
+      "aliases": [],
+      "summary": "There is an infinite loop in the next_char function in comp_scan.c in ncurses 6.0, related to libtic.",
+      "details": "There is an infinite loop in the next_char function in comp_scan.c in ncurses 6.0, related to libtic. A crafted input will lead to a remote denial of service attack.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "versions": [
+            "6.0"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1484274"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/201804-13"
+        },
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1484274"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/201804-13"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+        },
+        {
+          "type": "CVSS_V2",
+          "score": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2017-13729",
+      "published": "2017-08-29T06:29:00.327Z",
+      "modified": "2026-05-13T00:24:29.033Z",
+      "aliases": [],
+      "summary": "There is an illegal address access in the _nc_save_str function in alloc_entry.c in ncurses 6.0.",
+      "details": "There is an illegal address access in the _nc_save_str function in alloc_entry.c in ncurses 6.0. It will lead to a remote denial of service attack.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "versions": [
+            "6.0"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1484276"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/201804-13"
+        },
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1484276"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/201804-13"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+        },
+        {
+          "type": "CVSS_V2",
+          "score": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2017-13730",
+      "published": "2017-08-29T06:29:00.390Z",
+      "modified": "2026-05-13T00:24:29.033Z",
+      "aliases": [],
+      "summary": "There is an illegal address access in the function _nc_read_entry_source() in progs/tic.c in ncurses 6.0 that might lead to a remote denial of service attack.",
+      "details": "There is an illegal address access in the function _nc_read_entry_source() in progs/tic.c in ncurses 6.0 that might lead to a remote denial of service attack.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "versions": [
+            "6.0"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1484284"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/201804-13"
+        },
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1484284"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/201804-13"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+        },
+        {
+          "type": "CVSS_V2",
+          "score": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2017-13731",
+      "published": "2017-08-29T06:29:00.423Z",
+      "modified": "2026-05-13T00:24:29.033Z",
+      "aliases": [],
+      "summary": "There is an illegal address access in the function postprocess_termcap() in parse_entry.c in ncurses 6.0 that will lead to a remote denial of service attack.",
+      "details": "There is an illegal address access in the function postprocess_termcap() in parse_entry.c in ncurses 6.0 that will lead to a remote denial of service attack.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "versions": [
+            "6.0"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1484285"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/201804-13"
+        },
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1484285"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/201804-13"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+        },
+        {
+          "type": "CVSS_V2",
+          "score": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2017-13732",
+      "published": "2017-08-29T06:29:00.453Z",
+      "modified": "2026-05-13T00:24:29.033Z",
+      "aliases": [],
+      "summary": "There is an illegal address access in the function dump_uses() in progs/dump_entry.c in ncurses 6.0 that might lead to a remote denial of service attack.",
+      "details": "There is an illegal address access in the function dump_uses() in progs/dump_entry.c in ncurses 6.0 that might lead to a remote denial of service attack.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "versions": [
+            "6.0"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1484287"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/201804-13"
+        },
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1484287"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/201804-13"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+        },
+        {
+          "type": "CVSS_V2",
+          "score": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2017-13733",
+      "published": "2017-08-29T06:29:00.487Z",
+      "modified": "2026-05-13T00:24:29.033Z",
+      "aliases": [],
+      "summary": "There is an illegal address access in the fmt_entry function in progs/dump_entry.c in ncurses 6.0 that might lead to a remote denial of service attack.",
+      "details": "There is an illegal address access in the fmt_entry function in progs/dump_entry.c in ncurses 6.0 that might lead to a remote denial of service attack.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "versions": [
+            "6.0"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1484290"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/201804-13"
+        },
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1484290"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/201804-13"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+        },
+        {
+          "type": "CVSS_V2",
+          "score": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2017-13734",
+      "published": "2017-08-29T06:29:00.517Z",
+      "modified": "2026-05-13T00:24:29.033Z",
+      "aliases": [],
+      "summary": "There is an illegal address access in the _nc_safe_strcat function in strings.c in ncurses 6.0 that will lead to a remote denial of service attack.",
+      "details": "There is an illegal address access in the _nc_safe_strcat function in strings.c in ncurses 6.0 that will lead to a remote denial of service attack.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "versions": [
+            "6.0"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1484291"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/201804-13"
+        },
+        {
+          "type": "WEB",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1484291"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/201804-13"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+        },
+        {
+          "type": "CVSS_V2",
+          "score": "AV:N/AC:M/Au:N/C:N/I:N/A:P"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2017-16879",
+      "published": "2017-11-22T22:29:00.223Z",
+      "modified": "2026-05-13T00:24:29.033Z",
+      "aliases": [],
+      "summary": "Stack-based buffer overflow in the _nc_write_entry function in tinfo/write_entry.c in ncurses 6.0 allows attackers to cause a denial of service (application crash) or possibly execute arbitrary code v",
+      "details": "Stack-based buffer overflow in the _nc_write_entry function in tinfo/write_entry.c in ncurses 6.0 allows attackers to cause a denial of service (application crash) or possibly execute arbitrary code via a crafted terminfo file, as demonstrated by tic.",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "versions": [
+            "6.0"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "http://invisible-island.net/ncurses/NEWS.html#t20171125"
+        },
+        {
+          "type": "WEB",
+          "url": "http://packetstormsecurity.com/files/145045/GNU-ncurses-6.0-tic-Denial-Of-Service.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/201804-13"
+        },
+        {
+          "type": "WEB",
+          "url": "https://tools.cisco.com/security/center/viewAlert.x?alertId=57695"
+        },
+        {
+          "type": "WEB",
+          "url": "http://invisible-island.net/ncurses/NEWS.html#t20171125"
+        },
+        {
+          "type": "WEB",
+          "url": "http://packetstormsecurity.com/files/145045/GNU-ncurses-6.0-tic-Denial-Of-Service.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4%40%3Cissues.bookkeeper.apache.org%3E"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.gentoo.org/glsa/201804-13"
+        },
+        {
+          "type": "WEB",
+          "url": "https://tools.cisco.com/security/center/viewAlert.x?alertId=57695"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        },
+        {
+          "type": "CVSS_V2",
+          "score": "AV:N/AC:M/Au:N/C:P/I:P/A:P"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:gnu:ncurses"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    },
+    {
+      "schema_version": "1.6.0",
+      "id": "CVE-2023-50495",
+      "published": "2023-12-12T15:15:07.867Z",
+      "modified": "2025-11-04T19:16:14.450Z",
+      "aliases": [],
+      "summary": "NCurse v6.4-20230418 was discovered to contain a segmentation fault via the component _nc_wrap_entry().",
+      "details": "NCurse v6.4-20230418 was discovered to contain a segmentation fault via the component _nc_wrap_entry().",
+      "affected": [
+        {
+          "package": {
+            "ecosystem": "GIT",
+            "name": "ncurses",
+            "purl": "pkg:generic/gnu/ncurses"
+          },
+          "versions": [
+            "6.4-20230418"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "type": "WEB",
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/LU4MYMKFEZQ5VSCVLRIZGDQOUW3T44GT/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.gnu.org/archive/html/bug-ncurses/2023-04/msg00020.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.gnu.org/archive/html/bug-ncurses/2023-04/msg00029.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.netapp.com/advisory/ntap-20240119-0008/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/LU4MYMKFEZQ5VSCVLRIZGDQOUW3T44GT/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/LU4MYMKFEZQ5VSCVLRIZGDQOUW3T44GT/"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.gnu.org/archive/html/bug-ncurses/2023-04/msg00020.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.gnu.org/archive/html/bug-ncurses/2023-04/msg00029.html"
+        },
+        {
+          "type": "WEB",
+          "url": "https://security.netapp.com/advisory/ntap-20240119-0008/"
+        }
+      ],
+      "severity": [
+        {
+          "type": "CVSS_V3",
+          "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+        }
+      ],
+      "database_specific": {
+        "conda-forge": {
+          "package": "ncurses",
+          "purl": "pkg:conda/ncurses?channel=conda-forge",
+          "source_purls": [
+            "pkg:generic/gnu/ncurses"
+          ],
+          "affected_versions": [],
+          "conda_versions_total": 8,
+          "affects_future": false,
+          "derived_by": "purl-associator/scripts.nvd_prototype",
+          "generated_at": "2026-05-25T12:22:54+00:00"
+        },
+        "nvd": {
+          "cpes": [
+            "cpe:2.3:a:gnu:ncurses",
+            "cpe:2.3:a:invisible-island:ncurses",
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "matched_via": [
+            "cpe:2.3:a:invisible-island:ncurse"
+          ],
+          "source": "nvd-rest-api"
+        }
+      }
+    }
+  ]
+}

--- a/mappings/manual.json
+++ b/mappings/manual.json
@@ -3,6 +3,19 @@
   "updated_at": "2026-04-27T09:33:00.479Z",
   "description": "Human-curated PURL overrides for conda-forge packages. Editing happens through the web UI which opens a PR against this file.",
   "packages": {
+    "ncurses": {
+      "purl": "pkg:github/ThomasDickey/ncurses-snapshots",
+      "type": "github",
+      "namespace": "ThomasDickey",
+      "pkg_name": "ncurses-snapshots",
+      "cpes": [
+        "cpe:2.3:a:gnu:ncurses",
+        "cpe:2.3:a:invisible-island:ncurses",
+        "cpe:2.3:a:invisible-island:ncurse"
+      ],
+      "approved_by": "nichmor",
+      "approved_at": "2026-05-25T00:00:00Z"
+    },
     "xsimd": {
       "purl": "pkg:github/xtensor-stack/xsimd",
       "type": "github",

--- a/pixi.toml
+++ b/pixi.toml
@@ -46,7 +46,9 @@ merge = "python -m scripts.merge_mappings"
 download-counts-refresh = { cmd = "python -m scripts.hydrate_downloads --concurrency {{ concurrency }} --channel {{ channel }} && python -m scripts.merge_mappings", description = "Refresh prefix.dev download counts locally and rebuild the frontend mappings payload", args = [{ arg = "concurrency", default = "16" }, { arg = "channel", default = "conda-forge" }] }
 ai-vet = "python -m scripts.ai_vet"
 osv-fetch = "python -m scripts.osv_fetch"
+nvd-fetch = "python -m scripts.nvd_fetch"
 cve-match = "python -m scripts.cve_match"
+nvd-cve-match = "python -m scripts.nvd_prototype"
 lint = { cmd = "ruff check scripts && ruff format --check scripts", env = {} }
 fmt = "ruff format scripts"
 

--- a/schemas/cve-package.schema.json
+++ b/schemas/cve-package.schema.json
@@ -9,7 +9,14 @@
   "properties": {
     "schema_version": { "type": "integer", "const": 1 },
     "package": { "type": "string", "minLength": 1 },
-    "purls": { "type": "array", "items": { "type": "string" } },
+    "purls": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^pkg:" }
+    },
+    "cpes": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^cpe:2\\.3:" }
+    },
     "generated_at": { "type": "string" },
     "conda_versions_total": { "type": "integer", "minimum": 0 },
     "latest_version": { "type": ["string", "null"] },

--- a/scripts/nvd_fetch.py
+++ b/scripts/nvd_fetch.py
@@ -1,0 +1,414 @@
+"""Download and index NVD's CVE 2.0 JSON feeds.
+
+NVD publishes ``nvdcve-2.0-<year>.json.gz`` files for every year from 2002
+onward, plus a rolling ``nvdcve-2.0-modified.json.gz`` (last 8 days of adds
+and updates). Each archive contains the same shape the REST API returns —
+``{vulnerabilities: [{cve: {...}}, ...]}`` — so the consumer-facing record
+is byte-identical to ``scripts.nvd_prototype._fetch_nvd``'s old output.
+
+This module:
+
+1. Walks the year sequence 2002 → present, fetching each yearly file when
+   the local cache's sha256 doesn't match the published ``.meta`` digest.
+2. Fetches the ``modified`` feed if older than ``max_modified_age_hours``.
+3. Builds an in-memory index keyed by ``(part, vendor, product)`` →
+   ``[cve, ...]``. Each ``cpeMatch`` entry the CVE references contributes
+   one entry to the index, so the same CVE can be reached via several keys.
+4. Exposes :meth:`NvdIndex.for_cpe` for prefix-style lookups
+   (``cpe:2.3:a:gnu:ncurses`` → ``[cve, ...]``).
+
+Used by :mod:`scripts.nvd_prototype`. Can also be run standalone to refresh
+the cache:
+
+    pixi run python -m scripts.nvd_fetch --cache-dir ./nvd_cache
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gzip
+import hashlib
+import json
+import re
+import time
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+import httpx
+import typer
+from rich.console import Console
+from rich.progress import (
+    BarColumn,
+    DownloadColumn,
+    Progress,
+    TextColumn,
+    TimeElapsedColumn,
+    TransferSpeedColumn,
+)
+
+app = typer.Typer(add_completion=False, help=__doc__)
+console = Console()
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_CACHE = ROOT / "nvd_cache"
+
+FEED_BASE = "https://nvd.nist.gov/feeds/json/cve/2.0"
+MODIFIED_FEED = "modified"
+FIRST_YEAR = 2002
+
+# CPE 2.3 strings look like ``cpe:2.3:<part>:<vendor>:<product>:<rest>``.
+# We only need the three identifying segments to key our index.
+_CPE_HEAD = re.compile(r"^cpe:2\.3:([aoh]):([^:]+):([^:]+):")
+
+
+# ---------- cache primitives ----------
+
+
+@dataclass
+class FeedFile:
+    """One yearly or modified feed file on disk."""
+
+    name: str  # e.g. "2024" or "modified"
+    path: Path
+    sha256: str
+    fetched_at: float
+    cve_count: int
+
+
+def _gz_path(cache_dir: Path, name: str) -> Path:
+    return cache_dir / f"nvdcve-2.0-{name}.json.gz"
+
+
+def _meta_path(cache_dir: Path, name: str) -> Path:
+    return cache_dir / f"nvdcve-2.0-{name}.meta"
+
+
+def _sha256_of(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fp:
+        for chunk in iter(lambda: fp.read(1 << 16), b""):
+            h.update(chunk)
+    return h.hexdigest().upper()
+
+
+def _parse_meta(text: str) -> dict[str, str]:
+    """The .meta sidecar is ``key:value`` lines; values like
+    ``sha256:44E247...`` are documented uppercase hex."""
+    out: dict[str, str] = {}
+    for line in text.splitlines():
+        if ":" in line:
+            k, v = line.split(":", 1)
+            out[k.strip()] = v.strip()
+    return out
+
+
+# ---------- download ----------
+
+
+async def _fetch_meta(client: httpx.AsyncClient, name: str) -> dict[str, str] | None:
+    """Pull the .meta sidecar. Returns ``None`` for 404 (used to detect the
+    year-range upper bound: NVD returns 404 for years it hasn't reached)."""
+    url = f"{FEED_BASE}/nvdcve-2.0-{name}.meta"
+    try:
+        resp = await client.get(url)
+    except httpx.HTTPError:
+        return None
+    if resp.status_code == 404:
+        return None
+    if resp.status_code != 200:
+        raise RuntimeError(f"NVD .meta fetch failed for {name}: {resp.status_code}")
+    return _parse_meta(resp.text)
+
+
+async def _download_feed(
+    client: httpx.AsyncClient,
+    name: str,
+    cache_dir: Path,
+    progress: Progress,
+    expected_sha256: str | None,
+) -> Path:
+    """Download ``nvdcve-2.0-<name>.json.gz`` if the local sha256 doesn't
+    match ``expected_sha256``. Otherwise reuse the cached file."""
+    target = _gz_path(cache_dir, name)
+    if (
+        expected_sha256
+        and target.exists()
+        and _sha256_of(target) == expected_sha256
+    ):
+        return target  # cache hit — same content, skip the network
+
+    url = f"{FEED_BASE}/nvdcve-2.0-{name}.json.gz"
+    tmp = target.with_suffix(".gz.partial")
+    task_id = progress.add_task(f"NVD {name}", start=False)
+    async with client.stream("GET", url, follow_redirects=True) as resp:
+        if resp.status_code != 200:
+            progress.update(task_id, visible=False)
+            raise RuntimeError(f"NVD feed download failed for {name}: {resp.status_code}")
+        total = int(resp.headers.get("Content-Length") or 0) or None
+        progress.update(task_id, total=total)
+        progress.start_task(task_id)
+        tmp.parent.mkdir(parents=True, exist_ok=True)
+        with tmp.open("wb") as fp:
+            async for chunk in resp.aiter_bytes(chunk_size=1 << 16):
+                fp.write(chunk)
+                progress.update(task_id, advance=len(chunk))
+    tmp.replace(target)
+    progress.update(task_id, visible=False)
+    return target
+
+
+async def _discover_year_range(client: httpx.AsyncClient) -> list[int]:
+    """Walk forward from FIRST_YEAR until NVD returns 404 — that's the
+    first year with no feed yet. The result is FIRST_YEAR .. last published."""
+    years: list[int] = []
+    year = FIRST_YEAR
+    while True:
+        meta = await _fetch_meta(client, str(year))
+        if meta is None:
+            break
+        years.append(year)
+        year += 1
+        if year > 2100:  # safety: bail rather than loop forever
+            break
+    return years
+
+
+async def fetch_feeds(
+    *,
+    cache_dir: Path = DEFAULT_CACHE,
+    force: bool = False,
+    max_modified_age_hours: float = 2.0,
+) -> list[FeedFile]:
+    """Refresh the local feed cache and return a manifest of files on disk.
+
+    Each call:
+
+    * Fetches every yearly ``.meta`` sidecar.
+    * Re-downloads a yearly ``.json.gz`` only when its sha256 changed.
+    * Re-downloads the ``modified`` feed if its local cache is older than
+      ``max_modified_age_hours``. (NVD's modified feed rolls roughly every
+      2 hours.)
+
+    ``force=True`` bypasses both freshness checks.
+    """
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    timeout = httpx.Timeout(connect=15.0, read=120.0, write=15.0, pool=15.0)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        years = await _discover_year_range(client)
+        names: list[tuple[str, str | None]] = []  # (name, expected_sha256)
+        with Progress(
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            DownloadColumn(),
+            TransferSpeedColumn(),
+            TimeElapsedColumn(),
+            console=console,
+            transient=False,
+        ) as progress:
+            for year in years:
+                meta = await _fetch_meta(client, str(year))
+                expected = (meta or {}).get("sha256") if not force else None
+                names.append((str(year), expected))
+
+            # Modified feed: only re-download when older than max_modified_age_hours.
+            mod_target = _gz_path(cache_dir, MODIFIED_FEED)
+            mod_age_h = (
+                (time.time() - mod_target.stat().st_mtime) / 3600
+                if mod_target.exists()
+                else float("inf")
+            )
+            if force or mod_age_h >= max_modified_age_hours:
+                meta = await _fetch_meta(client, MODIFIED_FEED)
+                expected = (meta or {}).get("sha256") if not force else None
+                names.append((MODIFIED_FEED, expected))
+
+            results: list[FeedFile] = []
+            for name, expected in names:
+                path = await _download_feed(client, name, cache_dir, progress, expected)
+                results.append(
+                    FeedFile(
+                        name=name,
+                        path=path,
+                        sha256=_sha256_of(path),
+                        fetched_at=time.time(),
+                        cve_count=0,  # filled by the index builder
+                    )
+                )
+    # If we skipped the modified feed (cache fresh), still report it so the
+    # index builder doesn't miss recent records.
+    if all(f.name != MODIFIED_FEED for f in results) and mod_target.exists():
+        results.append(
+            FeedFile(
+                name=MODIFIED_FEED,
+                path=mod_target,
+                sha256=_sha256_of(mod_target),
+                fetched_at=mod_target.stat().st_mtime,
+                cve_count=0,
+            )
+        )
+    return results
+
+
+# ---------- indexing ----------
+
+
+def _iter_cves_in_feed(path: Path) -> Iterator[dict]:
+    """Yield each ``cve`` dict from one feed file. The on-disk shape is
+    ``{vulnerabilities: [{cve: {...}}, ...]}`` — the same envelope the
+    REST API returns."""
+    with gzip.open(path, "rb") as fp:
+        # Feed files are <10 MB gzipped (<100 MB uncompressed) — small
+        # enough to slurp in one shot.
+        data = json.loads(fp.read())
+    for entry in data.get("vulnerabilities") or []:
+        cve = entry.get("cve")
+        if isinstance(cve, dict) and isinstance(cve.get("id"), str):
+            yield cve
+
+
+def _cpe_head(criteria: str) -> tuple[str, str, str] | None:
+    """Extract ``(part, vendor, product)`` from a CPE 2.3 string. Used as
+    the index key. Returns ``None`` for malformed CPEs."""
+    m = _CPE_HEAD.match(criteria)
+    return (m.group(1), m.group(2), m.group(3)) if m else None
+
+
+def _cve_cpe_heads(cve: dict) -> set[tuple[str, str, str]]:
+    """All distinct ``(part, vendor, product)`` triples this CVE references.
+
+    A single CVE can carry dozens of cpeMatches (one per affected version
+    snapshot). They usually share the same (part, vendor, product), so the
+    set is much smaller than the cpeMatch count."""
+    heads: set[tuple[str, str, str]] = set()
+    for cfg in cve.get("configurations") or []:
+        for node in cfg.get("nodes") or []:
+            for cm in node.get("cpeMatch") or []:
+                criteria = cm.get("criteria")
+                if not isinstance(criteria, str):
+                    continue
+                head = _cpe_head(criteria)
+                if head is not None:
+                    heads.add(head)
+    return heads
+
+
+@dataclass
+class NvdIndex:
+    """In-memory map ``(part, vendor, product) → [cve, ...]``. Each CVE
+    can appear under multiple keys (e.g. an ncurses CVE that lists both
+    ``gnu:ncurses`` and ``invisible-island:ncurses`` cpeMatches).
+
+    The same CVE id is stored only once across all its keys — duplicates
+    arising from the ``modified`` feed overwriting yearly entries are
+    handled by the builder before insertion."""
+
+    feeds: list[FeedFile]
+    by_pp: dict[tuple[str, str, str], list[dict]] = field(default_factory=dict)
+    by_id: dict[str, dict] = field(default_factory=dict)
+
+    def for_cpe(self, cpe: str) -> list[dict]:
+        """Return all CVEs whose ``cpeMatch.criteria`` shares the
+        ``(part, vendor, product)`` prefix of ``cpe``.
+
+        Accepts both bare prefixes (``cpe:2.3:a:gnu:ncurses``) and fully
+        qualified strings — only the part/vendor/product segments matter."""
+        # Allow trailing segments for either form: tack on `:` so the regex
+        # always finds at least four colons.
+        head = _cpe_head(cpe if cpe.count(":") >= 5 else cpe + ":*:*:*:*:*:*:*")
+        if head is None:
+            return []
+        return list(self.by_pp.get(head, []))
+
+    def total_cves(self) -> int:
+        return len(self.by_id)
+
+
+def _build_index(feeds: list[FeedFile]) -> NvdIndex:
+    """Walk every feed file and bucket each CVE by its CPE heads.
+
+    Order matters: the ``modified`` feed is applied last so its records
+    overwrite older yearly versions of the same CVE id. Re-insertion
+    rebuilds the (part, vendor, product) buckets for that CVE."""
+    yearly = [f for f in feeds if f.name != MODIFIED_FEED]
+    modified = [f for f in feeds if f.name == MODIFIED_FEED]
+
+    by_pp: dict[tuple[str, str, str], list[dict]] = {}
+    by_id: dict[str, dict] = {}
+
+    def _insert(cve: dict) -> None:
+        cid = cve["id"]
+        if cid in by_id:
+            # Drop the older copy from every bucket that holds it.
+            old = by_id[cid]
+            for head in _cve_cpe_heads(old):
+                bucket = by_pp.get(head)
+                if bucket is not None:
+                    bucket[:] = [c for c in bucket if c["id"] != cid]
+        by_id[cid] = cve
+        for head in _cve_cpe_heads(cve):
+            by_pp.setdefault(head, []).append(cve)
+
+    # Yearly first, modified last.
+    for feed in yearly + modified:
+        count = 0
+        for cve in _iter_cves_in_feed(feed.path):
+            _insert(cve)
+            count += 1
+        feed.cve_count = count
+
+    return NvdIndex(feeds=feeds, by_pp=by_pp, by_id=by_id)
+
+
+async def fetch_index(
+    *,
+    cache_dir: Path = DEFAULT_CACHE,
+    force: bool = False,
+    max_modified_age_hours: float = 2.0,
+) -> NvdIndex:
+    """End-to-end: refresh the cache and build a queryable index."""
+    feeds = await fetch_feeds(
+        cache_dir=cache_dir,
+        force=force,
+        max_modified_age_hours=max_modified_age_hours,
+    )
+    index = _build_index(feeds)
+    return index
+
+
+# ---------- CLI ----------
+
+
+@app.command()
+def main(
+    cache_dir: Path = typer.Option(DEFAULT_CACHE, help="Where to store NVD feed files"),
+    force: bool = typer.Option(False, help="Re-download every feed regardless of sha256"),
+    max_modified_age_hours: float = typer.Option(
+        2.0, help="Re-download the modified feed if older than this"
+    ),
+) -> None:
+    """Refresh the NVD feed cache and print a summary."""
+
+    async def _run() -> None:
+        index = await fetch_index(
+            cache_dir=cache_dir,
+            force=force,
+            max_modified_age_hours=max_modified_age_hours,
+        )
+        console.log(
+            f"Indexed [bold]{index.total_cves():,}[/] CVEs across "
+            f"{len(index.feeds)} feed file(s), {len(index.by_pp):,} distinct "
+            f"(part, vendor, product) keys."
+        )
+        # Friendly sample
+        sample = next(iter(index.by_pp.items()), None)
+        if sample:
+            head, cves = sample
+            console.log(f"sample key {head}: {len(cves)} CVE(s)")
+
+    asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    app()

--- a/scripts/nvd_prototype.py
+++ b/scripts/nvd_prototype.py
@@ -51,8 +51,18 @@ DEFAULT_OUT_DIR = ROOT / "mappings" / "cves"
 DEFAULT_MAPPINGS = ROOT / "web" / "public" / "mappings.json"
 
 
-def _load_cpe_mappings(mappings_path: Path) -> dict[str, list[str]]:
-    """Read ``cpes: [...]`` from every package entry in the merged mappings.
+@dataclass(frozen=True)
+class CpeMapping:
+    """A package's CPE coordinates plus the curated PURL (if any) that lives
+    alongside them in ``manual.json``."""
+
+    cpes: list[str]
+    purl: str | None  # the package's primary PURL, copied through into the output file
+
+
+def _load_cpe_mappings(mappings_path: Path) -> dict[str, CpeMapping]:
+    """Read ``cpes: [...]`` (and the sibling ``purl``) from every package
+    entry in the merged mappings.
 
     The CPE list comes from ``mappings/manual.json`` overrides (or
     ``contributions/*.json``) and is passed through verbatim by
@@ -67,13 +77,18 @@ def _load_cpe_mappings(mappings_path: Path) -> dict[str, list[str]]:
     pkgs = payload.get("packages")
     if not isinstance(pkgs, dict):
         raise typer.BadParameter(f"Unexpected mappings shape in {mappings_path}")
-    out: dict[str, list[str]] = {}
+    out: dict[str, CpeMapping] = {}
     for name, entry in pkgs.items():
         cpes = entry.get("cpes") if isinstance(entry, dict) else None
-        if isinstance(cpes, list):
-            valid = [c for c in cpes if isinstance(c, str) and c.startswith("cpe:2.3:")]
-            if valid:
-                out[name] = valid
+        if not isinstance(cpes, list):
+            continue
+        valid = [c for c in cpes if isinstance(c, str) and c.startswith("cpe:2.3:")]
+        if not valid:
+            continue
+        purl = entry.get("purl") if isinstance(entry, dict) else None
+        out[name] = CpeMapping(
+            cpes=valid, purl=purl if isinstance(purl, str) else None
+        )
     return out
 
 
@@ -396,7 +411,7 @@ def main(
 async def _async_main(
     *,
     out_dir: Path,
-    cpe_mappings: dict[str, list[str]],
+    cpe_mappings: dict[str, CpeMapping],
     nvd_cache: Path,
     force_nvd: bool,
     nvd_max_age_hours: float,
@@ -423,7 +438,8 @@ async def _async_main(
         channel="conda-forge", platforms=["linux-64", "noarch"], names=names
     )
 
-    for conda_name, cpes in cpe_mappings.items():
+    for conda_name, mapping in cpe_mappings.items():
+        cpes = mapping.cpes
         # Look up each CPE prefix and union the results. The same CVE can be
         # returned by multiple prefixes (e.g. CVE-2023-29491 surfaces under
         # both gnu:ncurses and invisible-island:ncurses if NVD has both
@@ -477,7 +493,12 @@ async def _async_main(
         payload = {
             "schema_version": 1,
             "package": conda_name,
-            "purls": cpes,  # the source CPE coordinates; not real PURLs
+            # PURLs the package is mapped to (curated in manual.json). For
+            # CPE-only packages this is the upstream-source PURL ncurses
+            # has been assigned by reviewers, kept separate from the CPE
+            # coordinates that surfaced the advisories.
+            "purls": [mapping.purl] if mapping.purl else [],
+            "cpes": cpes,
             "generated_at": generated_at,
             "conda_versions_total": len(versions),
             "latest_version": versions[-1].version,

--- a/scripts/nvd_prototype.py
+++ b/scripts/nvd_prototype.py
@@ -1,0 +1,501 @@
+"""Prototype: pull NVD CVEs for every CPE-keyed conda package and emit
+``mappings/cves/<pkg>.json`` files in the same shape :mod:`scripts.cve_match`
+writes for OSV-sourced advisories.
+
+Reads each package's ``cpes`` field from ``web/public/mappings.json`` (which
+``scripts.merge_mappings`` produces from the ``cpes`` overrides in
+``mappings/manual.json``). Resolves CVEs against the local NVD feed cache
+(:mod:`scripts.nvd_fetch`) — one bulk download per day, then in-memory
+``(part, vendor, product)`` lookups for every CPE prefix. When a package
+carries multiple CPE aliases (NVD sometimes splits the same product across
+several vendor names — e.g. ``gnu:ncurses`` for older records,
+``invisible-island:ncurses`` for new ones) the results are unioned and
+deduped by CVE id.
+
+Synthesizes an OSV-shaped record per CVE so the existing web UI displays
+them identically to OSV-sourced files. ``affected[].package.ecosystem`` is
+set to ``"GIT"`` (OSV's allowlisted slot for source-coordinate records);
+the real CPE coordinates live in ``database_specific.nvd``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+import typer
+from rattler.version import Version
+from rich.console import Console
+
+from scripts.cve_common import conda_purl
+from scripts.cve_match import (
+    _affects_future_version,
+    _aggregate_conda_versions,
+    _gather_records,
+    _safe_version,
+    version_in_affected_entry,
+)
+from scripts.nvd_fetch import NvdIndex, fetch_index
+from scripts.osv_fetch import Advisory
+
+app = typer.Typer(add_completion=False, help=__doc__)
+console = Console()
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OUT_DIR = ROOT / "mappings" / "cves"
+DEFAULT_MAPPINGS = ROOT / "web" / "public" / "mappings.json"
+
+
+def _load_cpe_mappings(mappings_path: Path) -> dict[str, list[str]]:
+    """Read ``cpes: [...]`` from every package entry in the merged mappings.
+
+    The CPE list comes from ``mappings/manual.json`` overrides (or
+    ``contributions/*.json``) and is passed through verbatim by
+    ``scripts.merge_mappings``. Packages without a ``cpes`` list are skipped.
+    """
+    if not mappings_path.exists():
+        raise typer.BadParameter(
+            f"Mappings file not found: {mappings_path}. "
+            "Run `pixi run python -m scripts.merge_mappings` first."
+        )
+    payload = json.loads(mappings_path.read_text())
+    pkgs = payload.get("packages")
+    if not isinstance(pkgs, dict):
+        raise typer.BadParameter(f"Unexpected mappings shape in {mappings_path}")
+    out: dict[str, list[str]] = {}
+    for name, entry in pkgs.items():
+        cpes = entry.get("cpes") if isinstance(entry, dict) else None
+        if isinstance(cpes, list):
+            valid = [c for c in cpes if isinstance(c, str) and c.startswith("cpe:2.3:")]
+            if valid:
+                out[name] = valid
+    return out
+
+
+# ---------- NVD → OSV synthesis ----------
+
+
+def _summary(desc: str) -> str:
+    # Take the first sentence; if there's no period, cap at 200 chars.
+    m = re.match(r"(.{0,200}?[.!?])\s", desc)
+    return (m.group(1) if m else desc[:200]).strip()
+
+
+def _english_description(cve: dict) -> str:
+    for d in cve.get("descriptions") or []:
+        if d.get("lang") == "en" and isinstance(d.get("value"), str):
+            return d["value"]
+    return ""
+
+
+def _normalize_timestamp(ts: object) -> str | None:
+    """OSV schema requires ``...Z`` UTC marker; NVD emits naïve ISO strings.
+
+    Appends ``Z`` if missing. Returns ``None`` for non-string inputs."""
+    if not isinstance(ts, str) or not ts:
+        return None
+    return ts if ts.endswith("Z") else ts + "Z"
+
+
+_CVSS_VERSIONS = [
+    ("cvssMetricV40", "CVSS_V4"),
+    ("cvssMetricV31", "CVSS_V3"),
+    ("cvssMetricV30", "CVSS_V3"),
+    ("cvssMetricV2", "CVSS_V2"),
+]
+
+
+def _severity(cve: dict) -> list[dict]:
+    metrics = cve.get("metrics") or {}
+    out: list[dict] = []
+    seen_types: set[str] = set()
+    for key, osv_type in _CVSS_VERSIONS:
+        for entry in metrics.get(key) or []:
+            vector = (entry.get("cvssData") or {}).get("vectorString")
+            if isinstance(vector, str) and osv_type not in seen_types:
+                out.append({"type": osv_type, "score": vector})
+                seen_types.add(osv_type)
+                break
+    return out
+
+
+def _references(cve: dict) -> list[dict]:
+    return [
+        {"type": "WEB", "url": r["url"]}
+        for r in (cve.get("references") or [])
+        if isinstance(r, dict) and isinstance(r.get("url"), str)
+    ]
+
+
+def _affected_from_cpe_matches(cpe_matches: list[dict]) -> tuple[list[str], list[dict]]:
+    """Convert NVD ``cpeMatch`` entries into OSV ``versions`` + ``ranges``.
+
+    NVD encodes the affected version in two distinct ways:
+
+    1. **Pinned in the CPE string** itself (``cpe:2.3:a:gnu:ncurses:6.0:*:...``).
+       The match applies to that exact version only. We collect these into
+       OSV's ``versions`` exact-list.
+    2. **Range qualifiers as siblings** of ``criteria``: ``versionStartIncluding``,
+       ``versionStartExcluding``, ``versionEndIncluding``, ``versionEndExcluding``.
+       Paired with a wildcarded CPE (``ncurses:*:*:...``). We emit one OSV
+       range per cpeMatch.
+
+    Mapping for case 2:
+    * ``versionStartIncluding`` → ``introduced``
+    * ``versionEndExcluding`` → ``fixed`` (semantics match exactly)
+    * ``versionEndIncluding`` → ``last_affected``
+    * ``versionStartExcluding`` — no exact OSV equivalent. Emitted as
+      ``introduced`` with slight over-reporting at the lower edge (the
+      version immediately above the excluded one will be falsely flagged).
+      Rare in practice.
+
+    A cpeMatch with neither a pinned version nor any range qualifier means
+    "all versions of this product" — emitted as an open-ended range
+    ``{"introduced": "0"}``.
+    """
+    pinned: list[str] = []
+    ranges: list[dict] = []
+    for cm in cpe_matches:
+        if not cm.get("vulnerable", True):
+            continue
+        criteria = cm.get("criteria") or ""
+        parts = criteria.split(":")
+        cpe_version = parts[5] if len(parts) >= 6 else "*"
+        has_range_qualifier = any(
+            cm.get(k)
+            for k in (
+                "versionStartIncluding",
+                "versionStartExcluding",
+                "versionEndIncluding",
+                "versionEndExcluding",
+            )
+        )
+        # Case 1: version pinned in the CPE itself, no qualifier siblings.
+        if cpe_version not in ("*", "-") and not has_range_qualifier:
+            if cpe_version not in pinned:
+                pinned.append(cpe_version)
+            continue
+        # Case 2: range qualifier siblings (CPE version is usually "*").
+        if has_range_qualifier:
+            events: list[dict] = []
+            start = cm.get("versionStartIncluding") or cm.get("versionStartExcluding")
+            events.append({"introduced": start or "0"})
+            if end := cm.get("versionEndExcluding"):
+                events.append({"fixed": end})
+            elif end := cm.get("versionEndIncluding"):
+                events.append({"last_affected": end})
+            ranges.append({"type": "ECOSYSTEM", "events": events})
+            continue
+        # Case 3: wildcard CPE, no qualifiers — "all versions affected".
+        ranges.append({"type": "ECOSYSTEM", "events": [{"introduced": "0"}]})
+    return pinned, ranges
+
+
+def _collect_cpe_matches(cve: dict, products: set[str]) -> list[dict]:
+    """Pull every ``cpeMatch`` entry whose ``criteria`` targets one of our
+    products (the ``product`` segment of the CPE, e.g. ``ncurses``).
+
+    Multiple products are accepted because a single conda package can map to
+    several CPE prefixes — e.g. ncurses is split across ``gnu:ncurses`` and
+    the typo ``invisible-island:ncurse``. Defensive against multi-product
+    CVEs: a CVE that affects both ncurses and some other library carries
+    cpeMatches for both, and we only want the relevant ones."""
+    out: list[dict] = []
+    for cfg in cve.get("configurations") or []:
+        for node in cfg.get("nodes") or []:
+            for cm in node.get("cpeMatch") or []:
+                criteria = cm.get("criteria")
+                if not isinstance(criteria, str):
+                    continue
+                cm_parts = criteria.split(":")
+                if len(cm_parts) >= 5 and cm_parts[4] in products:
+                    out.append(cm)
+    return out
+
+
+def _synthesize_osv_record(
+    cve: dict, *, cpes: list[str], conda_name: str
+) -> dict | None:
+    """Build an OSV-shaped record from one NVD CVE entry.
+
+    ``cpes`` is the full list of CPE prefixes a package maps to. The
+    synthesizer pulls every cpeMatch whose product matches any prefix in
+    the list and folds them into a single OSV record. Returns ``None`` if
+    no cpeMatch targets any of the requested products (shouldn't happen
+    given the virtualMatchString filter, but defensive)."""
+    products: set[str] = set()
+    primary_vendor: str | None = None
+    primary_product: str | None = None
+    for cpe in cpes:
+        parts = cpe.split(":")
+        if len(parts) >= 5:
+            products.add(parts[4])
+            if primary_product is None:
+                primary_vendor = parts[3]
+                primary_product = parts[4]
+    if not products or primary_product is None:
+        return None
+
+    cpe_matches = _collect_cpe_matches(cve, products)
+    if not cpe_matches:
+        return None
+
+    pinned_versions, ranges = _affected_from_cpe_matches(cpe_matches)
+    if not pinned_versions and not ranges:
+        return None
+
+    desc = _english_description(cve)
+    affected_entry: dict = {
+        "package": {
+            # OSV schema's ecosystem field requires a value from a fixed
+            # allowlist. CPE-sourced records have no real OSV ecosystem;
+            # ``GIT`` is the closest neutral choice (it's the bucket OSV
+            # uses for source-coordinate records). The actual CPE
+            # coordinates live in ``database_specific.nvd.cpes``.
+            "ecosystem": "GIT",
+            "name": primary_product,
+            "purl": f"pkg:generic/{primary_vendor}/{primary_product}",
+        },
+    }
+    # OSV semantics: when ``versions`` is present, it's an exhaustive list
+    # and ``ranges`` is ignored. Only emit ``versions`` when we have no
+    # range qualifiers; otherwise emit ``ranges`` (the more expressive form).
+    if ranges:
+        affected_entry["ranges"] = ranges
+    else:
+        affected_entry["versions"] = pinned_versions
+
+    record = {
+        "schema_version": "1.6.0",
+        "id": cve["id"],
+        "published": _normalize_timestamp(cve.get("published")),
+        "modified": _normalize_timestamp(cve.get("lastModified")),
+        "aliases": [],
+        "summary": _summary(desc) if desc else cve["id"],
+        "details": desc,
+        "affected": [affected_entry],
+        "references": _references(cve),
+        "severity": _severity(cve),
+    }
+    return record
+
+
+# ---------- conda-version intersection ----------
+
+
+def _matched_versions(record: dict, versions: list) -> list[str]:
+    """Which conda-forge versions fall inside the synthesized record's
+    affected[] ranges. Reuses ``version_in_affected_entry`` from cve_match."""
+    affected = record["affected"][0]
+    hits: list[str] = []
+    for v in versions:
+        try:
+            if version_in_affected_entry(v.parsed, affected):
+                hits.append(v.version)
+        except Exception:
+            continue
+    return hits
+
+
+def _attach_conda_block(
+    record: dict,
+    *,
+    conda_name: str,
+    matched_versions: list[str],
+    conda_versions_total: int,
+    latest_version: Version | None,
+    cpes: list[str],
+    matched_via: list[str],
+    generated_at: str,
+) -> None:
+    """Attach the conda-forge + nvd database_specific blocks.
+
+    ``cpes`` is the full list of CPE prefixes the package is mapped to.
+    ``matched_via`` is the subset whose NVD query actually returned this
+    advisory — useful for diagnosing which alias provided the coverage."""
+    # Reusing cve_match's _affects_future_version requires an Advisory
+    # dataclass instance — synthesize a minimal one.
+    adv = Advisory(
+        id=record["id"],
+        ecosystem="CPE",
+        name=record["affected"][0]["package"]["name"],
+        aliases=[],
+        summary=record.get("summary"),
+        details=record.get("details"),
+        published=record.get("published"),
+        modified=record.get("modified"),
+        severity=record.get("severity") or [],
+        references=record.get("references") or [],
+        raw_affected=record["affected"][0],
+        raw=record,
+    )
+    record["database_specific"] = {
+        "conda-forge": {
+            "package": conda_name,
+            "purl": conda_purl(conda_name),
+            "source_purls": [record["affected"][0]["package"]["purl"]],
+            "affected_versions": matched_versions,
+            "conda_versions_total": conda_versions_total,
+            "affects_future": _affects_future_version(adv, latest_version),
+            "derived_by": "purl-associator/scripts.nvd_prototype",
+            "generated_at": generated_at,
+        },
+        "nvd": {
+            "cpes": cpes,
+            "matched_via": matched_via,
+            "source": "nvd-rest-api",
+        },
+    }
+
+
+# ---------- main ----------
+
+
+@app.command()
+def main(
+    mappings: Path = typer.Option(
+        DEFAULT_MAPPINGS, help="Merged mappings.json produced by scripts.merge_mappings"
+    ),
+    out_dir: Path = typer.Option(DEFAULT_OUT_DIR, help="Per-package CVE output dir"),
+    only: str | None = typer.Option(
+        None,
+        help="Comma-separated conda names to process (default: every package with a cpes list)",
+    ),
+    nvd_cache: Path = typer.Option(
+        Path("./nvd_cache"), help="Where the NVD feed cache lives"
+    ),
+    force_nvd: bool = typer.Option(False, help="Force re-download of NVD feeds"),
+    nvd_max_age_hours: float = typer.Option(
+        2.0, help="Re-download the NVD modified feed if older than this"
+    ),
+) -> None:
+    """Fetch NVD CVEs for each CPE-mapped conda package and emit JSON files."""
+    cpe_mappings = _load_cpe_mappings(mappings)
+    if only:
+        wanted = {n.strip() for n in only.split(",") if n.strip()}
+        cpe_mappings = {k: v for k, v in cpe_mappings.items() if k in wanted}
+    if not cpe_mappings:
+        console.log("[yellow]No packages with a cpes list — nothing to do.[/]")
+        return
+    asyncio.run(
+        _async_main(
+            out_dir=out_dir,
+            cpe_mappings=cpe_mappings,
+            nvd_cache=nvd_cache,
+            force_nvd=force_nvd,
+            nvd_max_age_hours=nvd_max_age_hours,
+        )
+    )
+
+
+async def _async_main(
+    *,
+    out_dir: Path,
+    cpe_mappings: dict[str, list[str]],
+    nvd_cache: Path,
+    force_nvd: bool,
+    nvd_max_age_hours: float,
+) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    generated_at = datetime.now(UTC).isoformat(timespec="seconds")
+
+    # Build the NVD index once, then look up by CPE prefix per package.
+    # This collapses what used to be ``sum(len(cpes) for cpes in cpe_mappings.values())``
+    # HTTP calls into a single bulk feed sync.
+    console.log("Refreshing NVD feed cache…")
+    index = await fetch_index(
+        cache_dir=nvd_cache,
+        force=force_nvd,
+        max_modified_age_hours=nvd_max_age_hours,
+    )
+    console.log(
+        f"NVD index: [bold]{index.total_cves():,}[/] CVEs across "
+        f"{len(index.feeds)} feed file(s)."
+    )
+
+    names = list(cpe_mappings.keys())
+    records_by_name = await _gather_records(
+        channel="conda-forge", platforms=["linux-64", "noarch"], names=names
+    )
+
+    for conda_name, cpes in cpe_mappings.items():
+        # Look up each CPE prefix and union the results. The same CVE can be
+        # returned by multiple prefixes (e.g. CVE-2023-29491 surfaces under
+        # both gnu:ncurses and invisible-island:ncurses if NVD has both
+        # vendor tags) — dedupe by CVE id.
+        cve_by_id: dict[str, dict] = {}
+        matched_via_by_id: dict[str, list[str]] = {}
+        for cpe in cpes:
+            cves = index.for_cpe(cpe)
+            console.log(f"{conda_name}: NVD index returned {len(cves)} CVEs for {cpe}")
+            for cve in cves:
+                cid = cve.get("id")
+                if not isinstance(cid, str):
+                    continue
+                cve_by_id.setdefault(cid, cve)
+                matched_via_by_id.setdefault(cid, []).append(cpe)
+
+        if not cve_by_id:
+            console.log(f"[yellow]{conda_name}: no CVEs returned, skipping[/]")
+            continue
+
+        repo_records = records_by_name.get(conda_name) or []
+        versions = _aggregate_conda_versions(repo_records)
+        if not versions:
+            console.log(f"[yellow]{conda_name}: no conda-forge versions found, skipping[/]")
+            continue
+        latest_parsed = versions[-1].parsed
+
+        advisories: list[dict] = []
+        for cid, cve in cve_by_id.items():
+            record = _synthesize_osv_record(cve, cpes=cpes, conda_name=conda_name)
+            if record is None:
+                continue
+            matched = _matched_versions(record, versions)
+            _attach_conda_block(
+                record,
+                conda_name=conda_name,
+                matched_versions=matched,
+                conda_versions_total=len(versions),
+                latest_version=latest_parsed,
+                cpes=cpes,
+                matched_via=matched_via_by_id[cid],
+                generated_at=generated_at,
+            )
+            advisories.append(record)
+
+        # Same sort order cve_match uses: hits first.
+        advisories.sort(
+            key=lambda r: not r["database_specific"]["conda-forge"]["affected_versions"]
+        )
+
+        payload = {
+            "schema_version": 1,
+            "package": conda_name,
+            "purls": cpes,  # the source CPE coordinates; not real PURLs
+            "generated_at": generated_at,
+            "conda_versions_total": len(versions),
+            "latest_version": versions[-1].version,
+            "advisories": advisories,
+        }
+        target = out_dir / f"{conda_name}.json"
+        target.write_text(json.dumps(payload, indent=2, sort_keys=False) + "\n")
+        hit_count = sum(
+            1 for a in advisories if a["database_specific"]["conda-forge"]["affected_versions"]
+        )
+        console.log(
+            f"[green]{conda_name}[/]: wrote {target.relative_to(ROOT)} "
+            f"({len(advisories)} advisories, {hit_count} with conda-version hits)"
+        )
+
+
+if __name__ == "__main__":
+    try:
+        app()
+    except KeyboardInterrupt:
+        sys.exit(130)


### PR DESCRIPTION
NVD has these CVEs, just keyed by CPE instead of PURL. This PR adds a parallel matcher that resolves them.

## Approach

Extends `manual.json` entries to accept a `cpes` list alongside `purl`. A new script reads those, queries NVD's nightly feed cache, and emits per-package CVE files in the existing OSV shape — so `merge_cves`, `validate`, and the web UI consume them indistinguishably.

```
manual.json.cpes  →  mappings.json  →  scripts/nvd_prototype.py
                                              ↓ NVD nightly feeds (nvd_cache/)
                                              ↓
                                       mappings/cves/<pkg>.json
```

Demonstrated on `ncurses` (732k downloads, top 10): **0 → 29 advisories, 14 affecting current conda-forge versions**.

## Files

- `scripts/nvd_fetch.py` — sibling to `osv_fetch.py`. Downloads NVD's `nvdcve-2.0-<year>.json.gz` and the rolling `modified` feed, validates with `.meta` sha256, builds an in-memory index keyed by `(part, vendor, product)`. Modified-feed entries override yearly entries.
- `scripts/nvd_prototype.py` — NVD-CVE → OSV-record converter. Handles both NVD version encodings (pinned-in-CPE → OSV `versions[]`; range qualifier siblings → OSV `ranges.events[]`). Reuses `cve_match.py` helpers so version intersection is identical to the OSV path.
- `mappings/manual.json` — added ncurses with `purl: pkg:github/ThomasDickey/ncurses-snapshots` + three CPE aliases (`gnu:ncurses`, `invisible-island:ncurses`, and the NVD-typo'd `invisible-island:ncurse`).
- `.github/workflows/cve_refresh.yml` — runs `nvd_prototype` after `cve_match` (order matters: `cve_match --clean-stale` would prune CPE-only files otherwise).
- `pixi.toml` — `nvd-fetch` + `nvd-cve-match` task aliases.

## Worth knowing while reviewing

- **`ecosystem: "GIT"`** on synthesized records — OSV's schema rejects `"CPE"`, so we use the closest neutral allowlisted value. The real CPE coordinates live under `database_specific.nvd`, which is OSV's sanctioned extension slot.
- **Multi-CPE per package.** NVD splits the same product across vendor aliases (older ncurses CVEs use `gnu`, newer ones use `invisible-island`, one has a typo). The `cpes` field is a list; results are unioned, deduped by CVE id, and each advisory records which alias surfaced it under `database_specific.nvd.matched_via`.
- **Schema-validated.** `pixi run validate` passes on all 1023 per-package files including the new ncurses output.

## Limitations (intentional)

- Only `ncurses` is mapped today. Adding python/ruby/perl/etc. is a one-line `manual.json` edit per package.
- Index is rebuilt from JSON-gz each run (~30s). Cheap to persist later when it matters.
- No stale-file pruning for CPE-only files.
- Distro cross-reference audit (Debian/Ubuntu/Alpine ncurses CVE id sets vs our NVD output) — discussed but not in this PR. Would catch new NVD vendor aliases and CVEs awaiting CPE assignment.



This is how we will display them

<img width="1200" height="616" alt="image" src="https://github.com/user-attachments/assets/596e4f18-2336-41c9-b999-fa51316e4828" />



