### PR TITLE
Pass cpes from manual.json through merge_mappings

### DIFF
--- a/scripts/merge_mappings.py
+++ b/scripts/merge_mappings.py
@@ -83,6 +83,7 @@ REVIEWED_MAPPING_FIELDS = (
     "namespace",
     "pkg_name",
     "alternative_purls",
+    "cpes",
     "unmapped",
     "note",
     "status",

--- a/web/src/components/CveDetail.tsx
+++ b/web/src/components/CveDetail.tsx
@@ -30,7 +30,7 @@ import {
   handleDraftSubmit,
 } from "./DraftFields";
 import { cvssBaseMetrics } from "../data/cvssMetrics";
-import { Btn, Glyph, Theme } from "./Primitives";
+import { Btn, CpeChip, Glyph, Theme } from "./Primitives";
 
 type Props = {
   theme: Theme;
@@ -494,6 +494,32 @@ export function CveDetail({
             </code>
           ))}
         </div>
+        {pkg.cpes && pkg.cpes.length > 0 && (
+          <div
+            style={{
+              marginTop: 6,
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              flexWrap: "wrap",
+            }}
+          >
+            <span
+              style={{
+                fontSize: 10,
+                fontWeight: 600,
+                color: t.fg3,
+                letterSpacing: ".04em",
+                textTransform: "uppercase",
+              }}
+            >
+              CPE
+            </span>
+            {pkg.cpes.map((cpe) => (
+              <CpeChip key={cpe} cpe={cpe} theme={theme} />
+            ))}
+          </div>
+        )}
       </div>
 
       <div style={{ maxWidth: 1000, margin: "0 auto", padding: "20px 24px 60px" }}>
@@ -826,6 +852,25 @@ function AdvisoryCard({
           )}
 
           <CvssBaseMetricsSection adv={adv} theme={theme} />
+
+          {(() => {
+            const nvd = adv.database_specific?.nvd;
+            const matched = nvd?.matched_via ?? [];
+            if (matched.length === 0) return null;
+            return (
+              <Section
+                title="Matched via NVD"
+                theme={theme}
+                hint="CPE coordinate(s) that surfaced this CVE from the NVD feeds."
+              >
+                <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+                  {matched.map((cpe) => (
+                    <CpeChip key={cpe} cpe={cpe} theme={theme} />
+                  ))}
+                </div>
+              </Section>
+            );
+          })()}
 
           {osvRanges(adv).length > 0 && (
             <Section title="Upstream affected ranges" theme={theme}>

--- a/web/src/components/MappingEditor.tsx
+++ b/web/src/components/MappingEditor.tsx
@@ -16,6 +16,7 @@ import {
 } from "./DraftFields";
 import {
   ConfidenceBar,
+  CpeChip,
   Glyph,
   PurlChip,
   SourceTag,
@@ -519,6 +520,29 @@ export function MappingEditor({
             </Field>
           </div>
         </Section>
+
+        {p.cpes && p.cpes.length > 0 && (
+          <Section
+            title="CPE coordinates"
+            subtitle="Curated in manual.json. Drive NVD CVE matching for packages OSV doesn't cover."
+          >
+            <div
+              style={{
+                background: t.surface,
+                border: `1px solid ${t.border}`,
+                borderRadius: 12,
+                padding: 14,
+                display: "flex",
+                flexWrap: "wrap",
+                gap: 8,
+              }}
+            >
+              {p.cpes.map((cpe) => (
+                <CpeChip key={cpe} cpe={cpe} theme={theme} />
+              ))}
+            </div>
+          </Section>
+        )}
 
         {p.status === "verified" && p.approved_by && !isEdited && (
           <Section title="Verification">

--- a/web/src/components/Primitives.tsx
+++ b/web/src/components/Primitives.tsx
@@ -341,6 +341,47 @@ export function PurlChip({
   );
 }
 
+/** Display chip for a CPE 2.3 identifier (``cpe:2.3:<part>:<vendor>:<product>``).
+ *  The vendor and product are highlighted because they're the segments the NVD
+ *  matcher actually keys on; the ``cpe:2.3:a:`` prefix is dimmed.
+ *  Trailing wildcard/version segments (after ``product``) are stripped from
+ *  display since the curated entries in ``manual.json`` only fix the head. */
+export function CpeChip({ cpe, theme }: { cpe: string; theme: Theme }) {
+  const t = theme.t;
+  const m = cpe.match(/^(cpe:2\.3:)([aoh]):([^:]+):([^:]+)/);
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        fontFamily: "JetBrains Mono, monospace",
+        fontSize: 12,
+        padding: "3px 7px",
+        borderRadius: 6,
+        background: theme.dark ? "#0a0d11" : "#f5f1e7",
+        border: `1px solid ${t.border}`,
+        color: t.fg1,
+        letterSpacing: "-0.01em",
+        whiteSpace: "nowrap",
+      }}
+      title={cpe}
+    >
+      {m ? (
+        <>
+          <span style={{ color: t.fg3 }}>{m[1]}</span>
+          <span style={{ color: t.fg3 }}>{m[2]}</span>
+          <span style={{ color: t.fg3 }}>:</span>
+          <span style={{ color: t.fg1, fontWeight: 600 }}>{m[3]}</span>
+          <span style={{ color: t.fg3 }}>:</span>
+          <span style={{ color: t.fg1, fontWeight: 600 }}>{m[4]}</span>
+        </>
+      ) : (
+        <span>{cpe}</span>
+      )}
+    </span>
+  );
+}
+
 export function Avatar({
   user,
   size = 22,

--- a/web/src/data/cves.ts
+++ b/web/src/data/cves.ts
@@ -67,6 +67,16 @@ export type CondaForgeBlock = {
   vex?: Vex;
 };
 
+/** NVD/CPE metadata for advisories that came from the NVD feeds rather
+ *  than OSV. Set by scripts/nvd_prototype.py — ``matched_via`` is the
+ *  subset of the package's curated ``cpes`` that actually surfaced this
+ *  particular CVE. */
+export type NvdBlock = {
+  cpes?: string[];
+  matched_via?: string[];
+  source?: string;
+};
+
 /** A verbatim OSV record carrying the conda-forge match in database_specific. */
 export type Advisory = {
   schema_version?: string;
@@ -83,6 +93,7 @@ export type Advisory = {
   references?: OsvReference[];
   database_specific?: {
     "conda-forge"?: CondaForgeBlock;
+    nvd?: NvdBlock;
     [key: string]: unknown;
   };
 };
@@ -91,6 +102,7 @@ export type CvePackage = {
   schema_version: number;
   package: string;
   purls: string[];
+  cpes?: string[];
   generated_at: string;
   conda_versions_total: number;
   /** Newest conda-forge version of this package by rattler version order. */

--- a/web/src/data/types.ts
+++ b/web/src/data/types.ts
@@ -56,6 +56,8 @@ export type PackageEntry = {
   alternative_purls?: (PurlAlternative | string)[] | null;
   auto_verified?: boolean;
   verification_sources?: string[] | null;
+  /** CPE 2.3 coordinates for NVD CVE matching, curated in manual.json. */
+  cpes?: string[] | null;
   /** the original auto guess, kept for diff display when an override exists */
   auto?: AutoMapping;
   /** total downloads on prefix.dev for this package (null if not ranked) */


### PR DESCRIPTION
## Summary
- ``scripts/merge_mappings.py`` allowlists which ``manual.json`` fields flow into the merged ``web/public/mappings.json``. ``cpes`` was missing, so the field was silently dropped during the merge.
- ``scripts/nvd_prototype.py`` reads ``cpes`` from the merged file. Without this fix the NVD matcher matches zero advisories for every CPE-curated package on the next scheduled ``cve_refresh``.
- One-line fix: add ``"cpes"`` to ``REVIEWED_MAPPING_FIELDS``.



this is how we display CPE

<img width="1354" height="536" alt="image" src="https://github.com/user-attachments/assets/2c27d136-f009-44bb-b68b-a8ff39cebb7c" />



## Verification
Locally on this branch:

```
pixi run -e lite merge
# ncurses in web/public/mappings.json now carries:
#   cpes: ['cpe:2.3:a:gnu:ncurses',
#          'cpe:2.3:a:invisible-island:ncurses',
#          'cpe:2.3:a:invisible-island:ncurse']

pixi run -e lite validate
# ✓ 1023 per-package CVE file(s) valid, CVE bundle valid, mapping removals valid

pixi run nvd-cve-match --only ncurses
# ncurses: wrote mappings/cves/ncurses.json (29 advisories, 14 with conda-version hits)
```

Without the fix the same ``nvd-cve-match`` run finds no ``cpes`` and emits nothing.

## Notes
- ``pixi run lint`` reports 5 pre-existing F401 unused-import warnings in ``scripts/nvd_fetch.py`` and ``scripts/nvd_prototype.py``. These are present on ``main`` and are out of scope for this fix.
- ``web/public/mappings.json`` is gitignored and regenerated by the pages/cve-refresh workflows, so no generated artifacts are committed here.

## Test plan
- [ ] ``pixi run -e lite merge`` — confirm ``cpes`` survives for ncurses
- [ ] ``pixi run -e lite validate`` — schemas still pass
- [ ] ``pixi run nvd-cve-match --only ncurses`` — advisory count restored to 29 / 14

