### PR TITLE
cves: collapse dashboard rows that share a PURL

### DIFF
--- a/web/src/CveApp.tsx
+++ b/web/src/CveApp.tsx
@@ -24,8 +24,15 @@ import { useCveEditStore } from "./stores/userState";
 
 export function CveApp() {
   const theme = useTheme();
-  const { payload, loadError, focusedPkg, setFocusedPkg, packages, focusedPackage } =
-    useCveData();
+  const {
+    payload,
+    loadError,
+    focusedPkg,
+    setFocusedPkg,
+    representatives,
+    membersByRep,
+    focusedPackage,
+  } = useCveData();
   const edits = useCveEditStore((state) => state.edits);
   const setEdits = useCveEditStore((state) => state.setEdits);
   const [focusedAdvisoryId, setFocusedAdvisoryId] = useState<string | null>(null);
@@ -54,7 +61,7 @@ export function CveApp() {
       worst: number;
       hasNow: boolean;
     }> = [];
-    for (const pkg of packages) {
+    for (const pkg of representatives) {
       const rows: Array<{
         adv: (typeof pkg.advisories)[number];
         kind: "now" | "future";
@@ -94,7 +101,7 @@ export function CveApp() {
       return a.pkg.package.localeCompare(b.pkg.package);
     });
     return out;
-  }, [packages, edits]);
+  }, [representatives, edits]);
 
   const goToNextTriagePackage = useMemo<(() => void) | null>(() => {
     if (triageQueue.length === 0) return null;
@@ -447,7 +454,8 @@ export function CveApp() {
               view === "browse" ? (
                 <CvePackageList
                   theme={theme}
-                  packages={packages}
+                  packages={representatives}
+                  membersByRep={membersByRep}
                   edits={edits}
                   focusedId={focusedPkg}
                   setFocusedId={(id) => {
@@ -462,7 +470,8 @@ export function CveApp() {
               ) : (
                 <CveActiveList
                   theme={theme}
-                  packages={packages}
+                  packages={representatives}
+                  membersByRep={membersByRep}
                   edits={edits}
                   focusedPkg={focusedPkg}
                   focusedAdvisoryId={focusedAdvisoryId}
@@ -493,6 +502,7 @@ export function CveApp() {
           <CveDetail
             theme={theme}
             pkg={focusedPackage}
+            variants={(focusedPkg && membersByRep.get(focusedPkg)) || []}
             edits={edits}
             mode={view === "active" ? "triage" : "browse"}
             focusedAdvisoryId={focusedAdvisoryId}
@@ -519,6 +529,7 @@ export function CveApp() {
           theme={theme}
           edits={edits}
           packages={payload.packages}
+          membersByRep={membersByRep}
           onClose={() => setDrawerOpen(false)}
           onCommit={() => {
             setEdits({});

--- a/web/src/components/CveActiveList.tsx
+++ b/web/src/components/CveActiveList.tsx
@@ -14,6 +14,10 @@ import { Glyph, Theme } from "./Primitives";
 type Props = {
   theme: Theme;
   packages: CvePackage[];
+  /** Representative package name → every conda package collapsed into it
+   *  (including the representative). Lets the header show "shared by N
+   *  packages" and the search match hidden variant names. */
+  membersByRep: Map<string, string[]>;
   edits: Record<string, ReviewEdit>;
   focusedPkg: string | null;
   focusedAdvisoryId: string | null;
@@ -63,6 +67,7 @@ type KindFilter = "all" | "now" | "future";
 export function CveActiveList({
   theme,
   packages,
+  membersByRep,
   edits,
   focusedPkg,
   focusedAdvisoryId,
@@ -125,7 +130,11 @@ export function CveActiveList({
     if (kindFilter !== "all" && r.kind !== kindFilter) return false;
     if (onlyUnreviewed && r.reviewed) return false;
     if (ql) {
-      const inName = r.pkg.package.toLowerCase().includes(ql);
+      const inName =
+        r.pkg.package.toLowerCase().includes(ql) ||
+        (membersByRep.get(r.pkg.package) ?? []).some((m) =>
+          m.toLowerCase().includes(ql),
+        );
       const inCve =
         cveIds(r.adv).some((id) => id.toLowerCase().includes(ql)) ||
         r.adv.id.toLowerCase().includes(ql);
@@ -443,6 +452,7 @@ export function CveActiveList({
                     key={`hdr::${it.group.pkg.package}`}
                     theme={theme}
                     group={it.group}
+                    variants={membersByRep.get(it.group.pkg.package) ?? []}
                     focused={focused}
                     style={{
                       position: "absolute",
@@ -597,18 +607,21 @@ export function CveActiveList({
 function GroupHeader({
   theme,
   group,
+  variants,
   focused,
   onClick,
   style,
 }: {
   theme: Theme;
   group: Group;
+  variants: string[];
   focused: boolean;
   onClick: () => void;
   style: React.CSSProperties;
 }) {
   const t = theme.t;
   const band = SEVERITY_BAND(group.worst);
+  const variantCount = variants.length;
   return (
     <div
       onClick={onClick}
@@ -651,6 +664,23 @@ function GroupHeader({
       >
         {group.pkg.latest_version}
       </span>
+      {variantCount > 1 && (
+        <span
+          style={{
+            fontSize: 10,
+            fontWeight: 600,
+            padding: "1px 6px",
+            borderRadius: 3,
+            background: t.inset,
+            color: t.fg2,
+            border: `1px solid ${t.border}`,
+            whiteSpace: "nowrap",
+          }}
+          title={`Same PURL & version as ${variantCount} conda packages — a review here applies to all of them:\n${variants.join("\n")}`}
+        >
+          ×{variantCount}
+        </span>
+      )}
       <span style={{ flex: 1 }} />
       {group.hasNow && (
         <span

--- a/web/src/components/CveDetail.tsx
+++ b/web/src/components/CveDetail.tsx
@@ -35,6 +35,9 @@ import { Btn, CpeChip, Glyph, Theme } from "./Primitives";
 type Props = {
   theme: Theme;
   pkg: CvePackage | null;
+  /** Conda packages collapsed into this representative (incl. itself).
+   *  When >1, a review here fans out to all of them on PR submit. */
+  variants: string[];
   edits: Record<string, ReviewEdit>;
   mode: "triage" | "browse";
   focusedAdvisoryId: string | null;
@@ -303,6 +306,7 @@ function VersionChip({
 export function CveDetail({
   theme,
   pkg,
+  variants,
   edits,
   mode,
   focusedAdvisoryId,
@@ -494,6 +498,49 @@ export function CveDetail({
             </code>
           ))}
         </div>
+        {variants.length > 1 && (
+          <details style={{ marginTop: 8 }}>
+            <summary
+              style={{
+                cursor: "pointer",
+                fontSize: 11.5,
+                color: t.fg2,
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 6,
+              }}
+            >
+              <Glyph name="branch" size={11} />
+              Shared by <strong>{variants.length}</strong> conda packages with the
+              same PURL &amp; version — a review here applies to all of them.
+            </summary>
+            <div
+              style={{
+                display: "flex",
+                flexWrap: "wrap",
+                gap: 6,
+                marginTop: 8,
+              }}
+            >
+              {variants.map((name) => (
+                <code
+                  key={name}
+                  style={{
+                    fontFamily: "JetBrains Mono, monospace",
+                    fontSize: 11,
+                    color: name === pkg.package ? t.fg1 : t.fg2,
+                    background: t.inset,
+                    border: `1px solid ${t.border}`,
+                    borderRadius: 4,
+                    padding: "1px 6px",
+                  }}
+                >
+                  {name}
+                </code>
+              ))}
+            </div>
+          </details>
+        )}
         {pkg.cpes && pkg.cpes.length > 0 && (
           <div
             style={{

--- a/web/src/components/CvePRDrawer.tsx
+++ b/web/src/components/CvePRDrawer.tsx
@@ -16,6 +16,9 @@ type Props = {
   theme: Theme;
   edits: Record<string, ReviewEdit>;
   packages: Record<string, CvePackage>;
+  /** Representative package name → every conda package collapsed into it
+   *  (including the representative). Reviews fan out across the members. */
+  membersByRep: Map<string, string[]>;
   onClose: () => void;
   onCommit: () => void;
   onSelect: (pkg: string, advisoryId: string) => void;
@@ -43,6 +46,7 @@ export function CvePRDrawer({
   theme,
   edits,
   packages,
+  membersByRep,
   onClose,
   onCommit,
   onSelect,
@@ -103,9 +107,19 @@ export function CvePRDrawer({
       statBits.push(`${stats.underInvestigation} under-investigation`);
 
     const total = editEntries.length;
+    // Packages the reviews actually land on once fanned out across every
+    // member that shares a representative's PURL & version.
+    const fanned = new Set<string>();
+    for (const pkg of byPkg.keys()) {
+      for (const m of membersByRep.get(pkg) ?? [pkg]) fanned.add(m);
+    }
+    const fanNote =
+      fanned.size > byPkg.size
+        ? `, fanned out to **${fanned.size}** conda packages sharing those PURLs`
+        : "";
     lines.push(
       `This PR reviews **${total}** CVE assignment${total === 1 ? "" : "s"} ` +
-        `across ${byPkg.size} package${byPkg.size === 1 ? "" : "s"}` +
+        `across ${byPkg.size} package${byPkg.size === 1 ? "" : "s"}${fanNote}` +
         (statBits.length ? ` — ${statBits.join(", ")}.` : "."),
     );
     if (versionOverrideCount > 0) {
@@ -140,6 +154,14 @@ export function CvePRDrawer({
       const purl = pkg?.purls?.[0] || "";
       lines.push(`### ${pkgName}${purl ? ` · \`${purl}\`` : ""}`);
       lines.push("");
+      const members = membersByRep.get(pkgName) ?? [pkgName];
+      if (members.length > 1) {
+        lines.push(
+          `_Applies to ${members.length} conda packages sharing this PURL: ` +
+            `${members.map((m) => `\`${m}\``).join(", ")}._`,
+        );
+        lines.push("");
+      }
 
       for (const [advisoryId, edit] of items) {
         const adv = pkg?.advisories.find((a) => a.id === advisoryId);
@@ -209,6 +231,7 @@ export function CvePRDrawer({
       const result = await submitCveReviewsAsPR({
         token,
         edits,
+        membersByRep,
         title,
         body: body.trim() === "" ? generateBody() : body,
       });
@@ -334,6 +357,7 @@ export function CvePRDrawer({
                     const adv = packages[pkg]?.advisories.find(
                       (a) => a.id === advisoryId,
                     );
+                    const memberCount = (membersByRep.get(pkg) ?? [pkg]).length;
                     return (
                       <div
                         key={key}
@@ -392,6 +416,21 @@ export function CvePRDrawer({
                             {STATUS_LABELS[e.status] || e.status}
                           </span>
                         </div>
+                        {memberCount > 1 && (
+                          <div
+                            style={{
+                              fontSize: 11,
+                              color: t.fg2,
+                              marginBottom: 4,
+                            }}
+                          >
+                            applies to{" "}
+                            <strong style={{ color: t.fg1 }}>
+                              {memberCount}
+                            </strong>{" "}
+                            packages sharing this PURL
+                          </div>
+                        )}
                         {adv?.summary && (
                           <div
                             style={{

--- a/web/src/components/CvePackageList.tsx
+++ b/web/src/components/CvePackageList.tsx
@@ -7,6 +7,10 @@ import { Glyph, Theme } from "./Primitives";
 type Props = {
   theme: Theme;
   packages: CvePackage[];
+  /** Representative package name → every conda package collapsed into it
+   *  (including the representative). Used for the "×N" badge and to let the
+   *  search match collapsed variant names. */
+  membersByRep: Map<string, string[]>;
   edits: Record<string, ReviewEdit>;
   focusedId: string | null;
   setFocusedId: (id: string) => void;
@@ -39,6 +43,7 @@ function packageStats(p: CvePackage, edits: Record<string, ReviewEdit>) {
 export function CvePackageList({
   theme,
   packages,
+  membersByRep,
   edits,
   focusedId,
   setFocusedId,
@@ -53,7 +58,11 @@ export function CvePackageList({
     const ql = q.trim().toLowerCase();
     return packages.filter((p) => {
       if (ql) {
-        const inName = p.package.toLowerCase().includes(ql);
+        const inName =
+          p.package.toLowerCase().includes(ql) ||
+          (membersByRep.get(p.package) ?? []).some((m) =>
+            m.toLowerCase().includes(ql),
+          );
         const inCve = p.advisories.some(
           (a) =>
             cveIds(a).some((id) => id.toLowerCase().includes(ql)) ||
@@ -244,6 +253,7 @@ export function CvePackageList({
               const p = filtered[vi.index];
               const focused = focusedId === p.package;
               const s = packageStats(p, edits);
+              const variants = membersByRep.get(p.package) ?? [];
               return (
                 <div
                   key={p.package}
@@ -289,6 +299,23 @@ export function CvePackageList({
                     >
                       {p.package}
                     </code>
+                    {variants.length > 1 && (
+                      <span
+                        style={{
+                          fontSize: 10,
+                          fontWeight: 600,
+                          padding: "1px 6px",
+                          borderRadius: 3,
+                          background: t.inset,
+                          color: t.fg2,
+                          border: `1px solid ${t.border}`,
+                          whiteSpace: "nowrap",
+                        }}
+                        title={`Same PURL & version as ${variants.length} conda packages — a review here applies to all of them:\n${variants.join("\n")}`}
+                      >
+                        ×{variants.length}
+                      </span>
+                    )}
                     {s.editsHere > 0 && (
                       <span
                         style={{

--- a/web/src/data/cves.ts
+++ b/web/src/data/cves.ts
@@ -148,6 +148,23 @@ export function osvUrl(adv: Advisory): string {
   return `https://osv.dev/vulnerability/${adv.id}`;
 }
 
+/** Key that collapses interchangeable conda packages into one row.
+ *
+ * Many feedstocks ship a base package plus a swarm of `*-with-extras`
+ * variants (e.g. 100+ `airflow-with-*`) that all carry the *same* upstream
+ * PURL set and therefore the same advisories — so the dashboard would
+ * otherwise render the same CVEs dozens of times. We also fold in
+ * ``latest_version``: members of a group must share the shipped conda-forge
+ * version too, since `isActiveOnLatest`/`isFutureAffected` are computed
+ * against it — grouping packages on different versions would hide one
+ * branch's active CVEs behind the representative's. Same PURLs + same latest
+ * version ⇒ identical advisory set *and* identical now/future split, so one
+ * member faithfully represents the rest. */
+export function purlGroupKey(pkg: CvePackage): string {
+  const purls = [...pkg.purls].sort().join(" ");
+  return `${purls} @@ ${pkg.latest_version ?? ""}`;
+}
+
 const SEVERITY_RANK: Record<string, number> = {
   CVSS_V4: 4,
   CVSS_V3: 3,

--- a/web/src/data/useCveData.ts
+++ b/web/src/data/useCveData.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { config } from "../config";
-import { loadCves, type CvePayload } from "./cves";
+import { loadCves, purlGroupKey, type CvePackage, type CvePayload } from "./cves";
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -13,11 +13,7 @@ export function useCveData() {
 
   useEffect(() => {
     loadCves(config.cvesUrl)
-      .then((data) => {
-        setPayload(data);
-        const first = Object.keys(data.packages).sort()[0];
-        if (first) setFocusedPkg(first);
-      })
+      .then(setPayload)
       .catch((err) => setLoadError(errorMessage(err)));
   }, []);
 
@@ -28,11 +24,61 @@ export function useCveData() {
     );
   }, [payload]);
 
+  // Collapse interchangeable packages (same PURLs + same shipped version) so
+  // e.g. the 100+ `airflow-with-*` variants surface once instead of flooding
+  // the list with identical advisories. We keep one *representative* package
+  // per group for display; reviews staged against it fan out to every member
+  // at PR-build time (see CvePRDrawer / buildStatements).
+  const { representatives, membersByRep } = useMemo(() => {
+    const byKey = new Map<string, CvePackage[]>();
+    for (const p of packages) {
+      const k = purlGroupKey(p);
+      const bucket = byKey.get(k);
+      if (bucket) bucket.push(p);
+      else byKey.set(k, [p]);
+    }
+    const reps: CvePackage[] = [];
+    const members = new Map<string, string[]>();
+    for (const bucket of byKey.values()) {
+      // Representative = shortest name (the bare base package, when present),
+      // ties broken alphabetically for stability.
+      bucket.sort(
+        (a, b) =>
+          a.package.length - b.package.length ||
+          a.package.localeCompare(b.package),
+      );
+      const rep = bucket[0];
+      reps.push(rep);
+      members.set(
+        rep.package,
+        bucket.map((m) => m.package),
+      );
+    }
+    reps.sort((a, b) => a.package.localeCompare(b.package));
+    return { representatives: reps, membersByRep: members };
+  }, [packages]);
+
+  // Open on the first representative once the grouping is ready.
+  useEffect(() => {
+    if (focusedPkg == null && representatives.length > 0) {
+      setFocusedPkg(representatives[0].package);
+    }
+  }, [focusedPkg, representatives]);
+
   const focusedPackage = useMemo(
     () =>
       focusedPkg && payload ? payload.packages[focusedPkg] ?? null : null,
     [focusedPkg, payload],
   );
 
-  return { payload, loadError, focusedPkg, setFocusedPkg, packages, focusedPackage };
+  return {
+    payload,
+    loadError,
+    focusedPkg,
+    setFocusedPkg,
+    packages,
+    representatives,
+    membersByRep,
+    focusedPackage,
+  };
 }

--- a/web/src/github/cve_api.ts
+++ b/web/src/github/cve_api.ts
@@ -23,6 +23,13 @@ export type CveSubmitOptions = {
   token: string;
   /** Map of `${packageName}::${advisoryId}` → review edit. */
   edits: Record<string, ReviewEdit>;
+  /** Representative package name → every conda package collapsed into it
+   *  (including the representative). A single review staged against a
+   *  representative is fanned out to a statement per member so the OpenVEX
+   *  document covers every interchangeable package (e.g. all `airflow-with-*`
+   *  variants), not just the one the reviewer happened to see. Omit for no
+   *  fan-out. */
+  membersByRep?: Map<string, string[]>;
   title: string;
   body: string;
 };
@@ -41,32 +48,39 @@ export type CveSubmitResult = {
  * statement per status bucket. */
 export function buildStatements(
   edits: Record<string, ReviewEdit>,
+  membersByRep?: Map<string, string[]>,
 ): OpenVexStatement[] {
   const statements: OpenVexStatement[] = [];
   for (const [key, edit] of Object.entries(edits)) {
     const sep = key.indexOf("::");
     if (sep < 0) continue;
-    const pkg = key.slice(0, sep);
+    const rep = key.slice(0, sep);
     const advisoryId = key.slice(sep + 2);
-    statements.push(buildPackageStatement(pkg, advisoryId, edit));
+    // Fan the review out across every package collapsed under this
+    // representative (same PURLs + version ⇒ same advisory). Falls back to
+    // just the representative when no grouping is supplied.
+    const targets = membersByRep?.get(rep) ?? [rep];
+    for (const pkg of targets) {
+      statements.push(buildPackageStatement(pkg, advisoryId, edit));
 
-    // Version-pinned statements: flip individual conda versions.
-    const { not_affected, affected } = edit.version_overrides;
-    if (not_affected.length > 0) {
-      statements.push(
-        buildVersionOverrideStatement(
-          pkg,
-          advisoryId,
-          not_affected,
-          "not_affected",
-          edit,
-        ),
-      );
-    }
-    if (affected.length > 0) {
-      statements.push(
-        buildVersionOverrideStatement(pkg, advisoryId, affected, "affected", edit),
-      );
+      // Version-pinned statements: flip individual conda versions.
+      const { not_affected, affected } = edit.version_overrides;
+      if (not_affected.length > 0) {
+        statements.push(
+          buildVersionOverrideStatement(
+            pkg,
+            advisoryId,
+            not_affected,
+            "not_affected",
+            edit,
+          ),
+        );
+      }
+      if (affected.length > 0) {
+        statements.push(
+          buildVersionOverrideStatement(pkg, advisoryId, affected, "affected", edit),
+        );
+      }
     }
   }
   return statements;
@@ -78,7 +92,7 @@ export async function submitCveReviewsAsPR(
   if (!config.oauthWorkerUrl) {
     throw new Error("Worker URL not configured — cannot submit PR.");
   }
-  const statements = buildStatements(opts.edits);
+  const statements = buildStatements(opts.edits, opts.membersByRep);
   const endpoint = `${config.oauthWorkerUrl.replace(/\/$/, "")}/api/submit-cves`;
   const res = await fetch(endpoint, {
     method: "POST",


### PR DESCRIPTION
Many feedstocks ship a base package plus a swarm of *-with-extras variants that all carry the same upstream PURL and therefore the same advisories — so the dashboard rendered the same CVEs dozens of times (e.g. 100+ airflow-with-* packages each repeating ~210 identical CVEs).

Group packages by PURL-set + latest_version and show one representative per group. latest_version is part of the key because the now/future triage split is computed against it — grouping on PURL alone would hide one branch's active CVEs. Members of a group are then interchangeable: identical advisory set and identical now/future split. Rows drop from 1048 to 748; the airflow swarm collapses to airflow-with-uv ×100 (v3.0.1) + airflow-with-saml ×7 (v2.10.5).

A review staged against a representative fans out at PR-build time to a VEX statement per member, so triaging airflow once covers every conda package sharing the PURL. The in-memory edits map stays 1:1 with what the reviewer clicked; the PR body notes the fan-out.

Applied to both the Triage and All-packages views, with a ×N badge, variant-name search, and a detail-pane disclosure listing every package a review applies to.