### PR TITLE
sboms: avoid shard rate-limits and stale-branch push failures

### DIFF
--- a/.github/workflows/sbom_refresh.yml
+++ b/.github/workflows/sbom_refresh.yml
@@ -79,6 +79,16 @@ jobs:
       - name: Validate generated data
         run: pixi run validate
 
+      - name: Drop stale refresh branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # create-pull-request hardcodes `git push --force-with-lease`, which
+          # rejects with "stale info" when a previous sboms/refresh branch is
+          # left over from a merged/closed PR. Delete it first so the action
+          # always recreates it cleanly (effectively a plain force push).
+          git push origin --delete sboms/refresh || true
+
       - name: Open / update PR if SBOM data changed
         uses: peter-evans/create-pull-request@v8
         with:

--- a/scripts/automap.py
+++ b/scripts/automap.py
@@ -468,9 +468,15 @@ async def _process_record(
 async def _gather_records(
     *, channel: str, platforms: Iterable[str], names: Iterable[str] | None = None
 ) -> list[RepoDataRecord]:
+    # Sharded repodata fetches one `.msgpack.zst` per package name. That is a
+    # win for a small subset, but querying every conda-forge name means tens of
+    # thousands of shard requests, which anaconda.org rate-limits with a 403.
+    # For the full-channel scan, pull the monolithic `repodata.json` instead:
+    # one download per platform.
+    use_sharded = bool(names)
     gateway = Gateway(
         default_config=SourceConfig(
-            sharded_enabled=True, cache_action="cache-or-fetch"
+            sharded_enabled=use_sharded, cache_action="cache-or-fetch"
         ),
         show_progress=False,
     )


### PR DESCRIPTION
Two fixes for the SBOM refresh workflow on `main`, both surfaced by failed `workflow_dispatch` runs.

## 1. `automap`: 403 from sharded repodata on full scans
The full-channel scan queried one sharded `.msgpack.zst` per conda-forge name (tens of thousands of requests), which anaconda.org rate-limits with `403 Forbidden`:

```
GatewayError: HTTP status client error (403 Forbidden) for url
(https://conda.anaconda.org/conda-forge/noarch/...msgpack.zst)
```

Now the full scan pulls the monolithic `repodata.json` (one download per platform); `--only` subset runs keep sharded repodata, where it's the efficient choice. `cve_match.py` is unchanged — it always queries a specific subset.

## 2. Workflow: `--force-with-lease` "stale info" rejection
`peter-evans/create-pull-request@v8` hardcodes `git push --force-with-lease` (no plain-`--force` toggle). It rejects with "stale info" when a previous `sboms/refresh` branch lingers after a merged PR:

```
! [rejected]  sboms/refresh -> sboms/refresh (stale info)
```

Added a step before the PR step that deletes the remote branch first (`git push origin --delete sboms/refresh || true`), so the action always recreates it cleanly — equivalent to a plain force push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)