### PR TITLE
feat(cpe): remove the top-N cap from CPE discovery

### DIFF
--- a/.github/workflows/cpe_discover.yml
+++ b/.github/workflows/cpe_discover.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       top:
-        description: "Top-N most-downloaded packages to consider"
+        description: "Top-N most-downloaded packages to consider (blank = all packages, no cap)"
         required: false
-        default: "100"
+        default: ""
       only:
         description: "Comma-separated package names (blank = all)"
         required: false
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   cpe-discover:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v6
 
@@ -44,7 +44,11 @@ jobs:
       - name: Run heuristic discovery
         run: |
           set -euo pipefail
-          ARGS=(--top "${{ inputs.top || '100' }}")
+          # No --top on the scheduled run → cpe_discover's default (0 = no
+          # cap) considers every package. A manual dispatch can still pass a
+          # numeric ``top`` input to bound a one-off run.
+          ARGS=()
+          if [ -n "${{ inputs.top }}" ]; then ARGS+=(--top "${{ inputs.top }}"); fi
           if [ -n "${{ inputs.only }}" ]; then ARGS+=(--only "${{ inputs.only }}"); fi
           pixi run cpe-discover "${ARGS[@]}"
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -189,7 +189,7 @@ cmd = "gh workflow run cpe_discover.yml --ref {{ ref }} -f top='{{ top }}' -f on
 description = "Trigger the CPE discovery workflow"
 args = [
   { arg = "ref", default = "main" },
-  { arg = "top", default = "100" },
+  { arg = "top", default = "" },
   { arg = "only", default = "" },
   { arg = "skip_vet", default = "false" },
 ]

--- a/scripts/cpe_discover.py
+++ b/scripts/cpe_discover.py
@@ -727,7 +727,11 @@ def _process_candidate(
 
 @app.command()
 def main(
-    top: int = typer.Option(100, help="How many top-downloaded packages to consider"),
+    top: int = typer.Option(
+        0,
+        help="How many top-downloaded packages to consider. 0 (the default) "
+        "or any value <= 0 means no cap — consider every package.",
+    ),
     only: str | None = typer.Option(
         None,
         help="Comma-separated conda names to process. When set, only these "
@@ -768,7 +772,10 @@ def main(
             if name not in only_set:
                 continue
         else:
-            if considered >= top:
+            # ``top <= 0`` is the sentinel for "no cap" — consider every
+            # ranked package. A positive ``top`` keeps the historical
+            # top-N behaviour.
+            if top > 0 and considered >= top:
                 break
         considered += 1
         if name in already_have_cpes:
@@ -777,7 +784,12 @@ def main(
             continue
         candidates.append((name, entry.download_count, entry))
 
-    scope_desc = f"--only set ({len(only_set)} names)" if only_set else f"top {top}"
+    if only_set:
+        scope_desc = f"--only set ({len(only_set)} names)"
+    elif top > 0:
+        scope_desc = f"top {top}"
+    else:
+        scope_desc = "all packages (no cap)"
     console.log(
         f"{scope_desc}: {len(candidates)} CPE candidates after filtering "
         f"({considered - len(candidates)} skipped — OSV-mapped, "


### PR DESCRIPTION
## Summary

Follow-up to #100. That PR shipped the CPE discovery pipeline with a `--top N` cap (default 100), ranking `auto.json` by `download_count` and only sweeping the most-downloaded slice. This removes the cap so the scheduled `cpe_discover.yml` run considers **every** conda-forge package.

The heuristics, AI vet, safety gates, and downstream merge/CVE-matching are all unchanged — this only flips the default scope from "top 100" to "all".

## Changes

| File | Change |
|---|---|
| `scripts/cpe_discover.py` | `--top` now defaults to `0`, the sentinel for **no cap**. A positive value keeps the historical top-N behaviour for bounded local runs. Cutoff guarded with `top > 0`; `scope_desc` logs `all packages (no cap)`. |
| `.github/workflows/cpe_discover.yml` | Scheduled run passes no `--top` → uncapped. A manual dispatch can still supply a numeric `top` to bound a one-off run (blank = all). `timeout-minutes` 60 → 120 for the larger sweep. |
| `pixi.toml` | `gh-cpe-discover` `top` arg defaults to blank (uncapped). |

## Dry-run measurement (heuristic-only, no AI cost)

`pixi run cpe-discover --top 0 --skip-vet` over the full **32,636**-package set:

| Bucket | Count |
|---|---:|
| Candidates after filtering | 7,233 |
| Skipped (OSV-mapped / already-CPE'd / conda-infra) | 25,403 |
| **auto-accept** (heuristic-confident, ship without AI) | **311 packages / 336 CPEs** |
| **ambiguous** (→ AI vet, ~47 Haiku batches) | **702 packages / 1,335 CPEs** |
| no-match | 6,183 |

Scan completed in **~60s** against a warm NVD cache.

## What this PR does and doesn't do

- **This PR** is config-only — it changes the default scope. It does **not** itself ship any CPEs.
- The first **scheduled** (or manually dispatched) `cpe_discover.yml` run after merge produces the actual data PR on `cpe-pipeline/refresh`: audit files (`cpe_candidates/**`, `cpe_vet/**`) + one `*--cpe-pipeline--*.json` contribution. CVE-file materialization still happens downstream via `cve_refresh.yml`.

## Worth flagging for the reviewer of the *generated* PR

An uncapped sweep auto-accepts **311 packages without AI review** (vs 0 net-new at top-100). The auto-accept heuristics + trusted-vendor allowlist were tuned on the most-downloaded packages; the long tail (rank 10k ≈ 117 downloads, rank 32k = 1 download) has higher name-collision risk. The safety gate (fallback-guess never auto-accepts) still applies, but **tightening auto-accept criteria at tail scale is a reasonable follow-up** if the first uncapped run is noisy.

## Test plan

- [x] `pixi run cpe-discover --top 0 --skip-vet` runs clean over all 32,636 packages and reports the bucket counts above
- [x] `--top 0` logs `all packages (no cap)`; a positive `--top N` still caps at N (historical behaviour preserved)
- [ ] Reviewer: trigger `pixi run gh-cpe-discover` (uncapped) once and sanity-check the generated `cpe-pipeline/refresh` PR before relying on the weekly schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)