### PR TITLE
AI CVE: per-item force redraft + cap PR-body length

### DIFF
--- a/schemas/cve-review-queue.schema.json
+++ b/schemas/cve-review-queue.schema.json
@@ -25,7 +25,11 @@
             "pattern": "^(GHSA-|CVE-|OSV-|PYSEC-|RUSTSEC-|GO-|MAL-|NPM-|PLDB-|HSEC-|ASB-|ALAS-|RHSA-)"
           },
           "reason": { "type": "string" },
-          "note": { "type": "string" }
+          "note": { "type": "string" },
+          "force": {
+            "type": "boolean",
+            "description": "Force a re-draft even when the pair is already drafted and nothing has drifted (per-item equivalent of the runner's --redraft flag)."
+          }
         }
       }
     }

--- a/scripts/cve_ai_enqueue.py
+++ b/scripts/cve_ai_enqueue.py
@@ -59,6 +59,11 @@ def main(
         "manual", "--reason", help="Why this pair is being queued"
     ),
     note: str = typer.Option("", "--note", help="Optional free-form note"),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Force a re-draft even if already drafted with no drift",
+    ),
     queue_dir: Path = typer.Option(DEFAULT_QUEUE_DIR, "--queue-dir"),
     cves_dir: Path = typer.Option(DEFAULT_CVES_DIR, "--cves-dir"),
     skip_existence_check: bool = typer.Option(
@@ -78,13 +83,15 @@ def main(
         )
         sys.exit(2)
 
-    item: dict[str, str] = {
+    item: dict[str, object] = {
         "package": package,
         "advisory_id": advisory,
         "reason": reason,
     }
     if note:
         item["note"] = note
+    if force:
+        item["force"] = True
 
     ts = datetime.now(UTC).strftime("%Y-%m-%dT%H-%M-%S-%fZ")
     run_id = secrets.token_hex(3)

--- a/scripts/cve_ai_requeue_drafts.py
+++ b/scripts/cve_ai_requeue_drafts.py
@@ -2,9 +2,9 @@
 
 Use this after changing ``scripts.cve_ai_review`` prompt semantics. It reads the
 newest draft per ``(package, advisory_id)`` from ``mappings/cve_ai_drafts/`` and
-writes one queue file under ``mappings/cve_review_queue/``. The next
-``cve-ai-review`` run will pick the pairs up; if the prompt version changed, the
-runner redrafts them even without ``--redraft``.
+writes one queue file under ``mappings/cve_review_queue/``. By default each item
+is marked ``force: true``, so the next ``cve-ai-review`` run redrafts the pairs
+even when nothing has drifted (pass ``--no-force`` to redraft only on drift).
 
 Examples::
 
@@ -59,6 +59,13 @@ def main() -> None:
     )
     parser.add_argument("--note", default="", help="Optional note on each queue item")
     parser.add_argument(
+        "--no-force",
+        dest="force",
+        action="store_false",
+        help="Don't force a re-draft; only redraft on prompt/severity/input drift",
+    )
+    parser.set_defaults(force=True)
+    parser.add_argument(
         "--include-human-reviewed",
         action="store_true",
         help="Also requeue pairs already covered by human OpenVEX contributions",
@@ -77,7 +84,7 @@ def main() -> None:
         else load_human_covered_pairs(args.contributions_dir)
     )
 
-    items: list[dict[str, str]] = []
+    items: list[dict[str, object]] = []
     for (pkg, adv), draft in sorted(load_latest_drafts(args.drafts_dir).items()):
         if packages and pkg not in packages:
             continue
@@ -87,9 +94,15 @@ def main() -> None:
             continue
         if (pkg, adv) in covered:
             continue
-        item = {"package": pkg, "advisory_id": adv, "reason": args.reason}
+        item: dict[str, object] = {
+            "package": pkg,
+            "advisory_id": adv,
+            "reason": args.reason,
+        }
         if args.note:
             item["note"] = args.note
+        if args.force:
+            item["force"] = True
         items.append(item)
 
     now = datetime.now(UTC)

--- a/scripts/cve_ai_review.py
+++ b/scripts/cve_ai_review.py
@@ -264,6 +264,7 @@ class QueueItem:
     advisory_id: str
     reason: str = ""
     note: str = ""
+    force: bool = False  # per-item redraft: bypass the already-drafted/no-drift skip
 
 
 @dataclass
@@ -305,7 +306,7 @@ def _load_queue(queue_dir: Path) -> list[QueueItem]:
     """Union of all items across every queue file. Deduped by (pkg, advisory_id)."""
     if not queue_dir.exists():
         return []
-    seen: set[tuple[str, str]] = set()
+    seen: dict[tuple[str, str], QueueItem] = {}
     out: list[QueueItem] = []
     for path in sorted(queue_dir.glob("*.json")):
         try:
@@ -321,17 +322,21 @@ def _load_queue(queue_dir: Path) -> list[QueueItem]:
             if not pkg or not adv:
                 continue
             key = (pkg, adv)
+            force = bool(raw.get("force"))
             if key in seen:
+                # A later forced requeue of an already-queued pair still forces.
+                if force:
+                    seen[key].force = True
                 continue
-            seen.add(key)
-            out.append(
-                QueueItem(
-                    package=pkg,
-                    advisory_id=adv,
-                    reason=raw.get("reason") or "",
-                    note=raw.get("note") or "",
-                )
+            item = QueueItem(
+                package=pkg,
+                advisory_id=adv,
+                reason=raw.get("reason") or "",
+                note=raw.get("note") or "",
+                force=force,
             )
+            seen[key] = item
+            out.append(item)
     return out
 
 
@@ -951,7 +956,7 @@ def _filter_items(
                 SkippedItem(it.package, it.advisory_id, "human_openvex_exists")
             )
             continue
-        if not redraft:
+        if not redraft and not it.force:
             existing = latest_drafts.get(key)
             if existing is not None:
                 if existing.get("prompt_version") != PROMPT_VERSION:

--- a/scripts/cve_ai_summary.py
+++ b/scripts/cve_ai_summary.py
@@ -169,12 +169,18 @@ def _emit_table(rows: list[dict]) -> list[str]:
     return lines
 
 
-def _emit_details(rows: list[dict]) -> list[str]:
-    lines = ["## Per-draft reasoning", ""]
+def _detail_blocks(rows: list[dict]) -> list[list[str]]:
+    """One self-contained ``<details>`` block per package (incl. trailing blank).
+
+    Returned as separate blocks so the body assembler can drop whole-package
+    sections when the rendered body would exceed GitHub's PR-body size limit.
+    """
     by_pkg: dict[str, list[dict]] = {}
     for r in rows:
         by_pkg.setdefault(r["package"], []).append(r)
+    blocks: list[list[str]] = []
     for pkg, items in sorted(by_pkg.items()):
+        lines: list[str] = []
         lines.append(
             f"<details><summary><code>{pkg}</code> — {len(items)} draft(s)</summary>"
         )
@@ -236,7 +242,55 @@ def _emit_details(rows: list[dict]) -> list[str]:
             lines.append("")
         lines.append("</details>")
         lines.append("")
-    return lines
+        blocks.append(lines)
+    return blocks
+
+
+# GitHub rejects PR bodies longer than 65,536 characters, measured (like the
+# GraphQL/JS notion of string length) in UTF-16 code units — so emoji and other
+# astral chars count as 2. Cap a little under that for headroom.
+GITHUB_PR_BODY_LIMIT = 65536
+DEFAULT_MAX_CHARS = 65000
+
+
+def _u16len(s: str) -> int:
+    """Length in UTF-16 code units — how GitHub counts a PR body's characters."""
+    return len(s.encode("utf-16-le")) // 2
+
+
+def _assemble_body(head_lines: list[str], blocks: list[list[str]], max_chars: int) -> str:
+    """Join header/table + as many per-package detail blocks as fit under the cap.
+
+    Whole-package blocks are dropped (never split mid-section) once adding the
+    next one would exceed ``max_chars``; a note records how many were omitted.
+    Length is measured in UTF-16 code units to match GitHub's limit.
+    """
+    note_tmpl = (
+        "> ⚠️ Per-draft reasoning truncated to fit GitHub's "
+        f"{GITHUB_PR_BODY_LIMIT:,}-character PR-body limit — **{{omitted}}** "
+        "package section(s) omitted. See `mappings/cve_ai_drafts/` or the SPA "
+        "for the full reasoning."
+    )
+    reserve = _u16len(note_tmpl.format(omitted=len(blocks))) + 2
+
+    lines = list(head_lines) + ["## Per-draft reasoning", ""]
+    length = sum(_u16len(s) + 1 for s in lines)  # +1 for the joining newline
+    omitted = 0
+    for i, block in enumerate(blocks):
+        block_len = sum(_u16len(s) + 1 for s in block)
+        if length + block_len + reserve > max_chars:
+            omitted = len(blocks) - i
+            break
+        lines.extend(block)
+        length += block_len
+    if omitted:
+        lines.append(note_tmpl.format(omitted=omitted))
+        lines.append("")
+
+    body = "\n".join(lines)
+    while _u16len(body) > max_chars:  # backstop (e.g. an enormous table)
+        body = body[:-256].rstrip() + "\n"
+    return body
 
 
 def main() -> int:
@@ -249,6 +303,13 @@ def main() -> int:
     )
     parser.add_argument(
         "--out", type=Path, default=None, help="Write to this path (default: stdout)"
+    )
+    parser.add_argument(
+        "--max-chars",
+        type=int,
+        default=DEFAULT_MAX_CHARS,
+        help=f"Cap body length (default {DEFAULT_MAX_CHARS}; GitHub limit is "
+        f"{GITHUB_PR_BODY_LIMIT}).",
     )
     args = parser.parse_args()
 
@@ -265,9 +326,8 @@ def main() -> int:
             "(no new drafts in this run — nothing to summarise)\n"
         )
     else:
-        body = "\n".join(
-            _emit_header(rows, drafts) + _emit_table(rows) + _emit_details(rows)
-        )
+        head_lines = _emit_header(rows, drafts) + _emit_table(rows)
+        body = _assemble_body(head_lines, _detail_blocks(rows), args.max_chars)
 
     if args.out:
         args.out.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/merge_ai_drafts.py
+++ b/scripts/merge_ai_drafts.py
@@ -112,7 +112,7 @@ def _collect_drafts(drafts_dir: Path) -> dict[str, dict[str, dict]]:
 
 
 def _collect_queue(queue_dir: Path) -> dict[str, dict[str, dict]]:
-    """{package: {advisory_id: {enqueued_at, enqueued_by}}} — newest per pair."""
+    """{package: {advisory_id: {enqueued_at, enqueued_by, force}}} — newest per pair."""
     out: dict[str, dict[str, dict]] = {}
     if not queue_dir.exists():
         return out
@@ -133,7 +133,11 @@ def _collect_queue(queue_dir: Path) -> dict[str, dict[str, dict]]:
             existing = out.setdefault(pkg, {}).get(adv)
             if existing and existing.get("enqueued_at", "") >= ts:
                 continue
-            out[pkg][adv] = {"enqueued_at": ts, "enqueued_by": by}
+            out[pkg][adv] = {
+                "enqueued_at": ts,
+                "enqueued_by": by,
+                "force": bool(item.get("force")),
+            }
     return out
 
 
@@ -149,6 +153,59 @@ def _filter_covered(
     return dict(sorted(out.items()))
 
 
+def _parse_iso(s: str) -> datetime | None:
+    """Parse an ISO-8601 timestamp, tolerating a trailing ``Z``.
+
+    ``enqueued_at`` (``…Z`` from the worker, ``…+00:00`` from scripts) and a
+    draft's ``generated_at`` use different spellings, so they can't be compared
+    as strings — parse both before comparing.
+    """
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _pending_queue(
+    queue_tree: dict[str, dict[str, dict]],
+    covered: set[tuple[str, str]],
+    draft_ts: dict[tuple[str, str], str],
+) -> dict[str, dict[str, dict]]:
+    """Queue pairs still awaiting an AI draft (the queue tab's contents).
+
+    A pair is shown when it is not human-covered and either has no draft yet,
+    or was force-enqueued (a redraft request) with no draft newer than the
+    enqueue — i.e. the forced redraft hasn't been produced yet. Once a draft at
+    or after the enqueue lands, the pair drops out again. Without the force
+    carve-out a re-queued pair would be hidden the moment an old draft existed,
+    so requested re-reviews would never surface (queue files are append-only).
+    """
+    out: dict[str, dict[str, dict]] = {}
+    for pkg, advs in queue_tree.items():
+        keep: dict[str, dict] = {}
+        for adv, meta in advs.items():
+            if (pkg, adv) in covered:
+                continue
+            dts = draft_ts.get((pkg, adv))
+            if dts is None:
+                keep[adv] = meta  # never drafted → waiting for the AI
+                continue
+            if meta.get("force"):
+                enq = _parse_iso(meta.get("enqueued_at", ""))
+                drf = _parse_iso(dts)
+                # Show while the redraft is still pending; if either timestamp
+                # is unparseable, err toward visibility.
+                if enq is None or drf is None or enq > drf:
+                    keep[adv] = meta
+                    continue
+            # Drafted and not a pending forced redraft → handled, hide it.
+        if keep:
+            out[pkg] = dict(sorted(keep.items()))
+    return dict(sorted(out.items()))
+
+
 def main(
     drafts_dir: Path = DEFAULT_DRAFTS_DIR,
     queue_dir: Path = DEFAULT_QUEUE_DIR,
@@ -158,11 +215,14 @@ def main(
 ) -> None:
     covered = _load_human_covered_pairs(contributions_dir)
     drafts = _filter_covered(_collect_drafts(drafts_dir), covered)
-    # The queue sidecar additionally hides items that already have a draft.
-    drafted_pairs: set[tuple[str, str]] = {
-        (pkg, adv) for pkg, advs in drafts.items() for adv in advs
+    # The queue sidecar hides items that already have a draft — except a forced
+    # re-queue whose redraft hasn't landed yet, which stays "waiting for AI".
+    draft_ts: dict[tuple[str, str], str] = {
+        (pkg, adv): info.get("generated_at") or ""
+        for pkg, advs in drafts.items()
+        for adv, info in advs.items()
     }
-    queue = _filter_covered(_collect_queue(queue_dir), covered | drafted_pairs)
+    queue = _pending_queue(_collect_queue(queue_dir), covered, draft_ts)
 
     drafts_out.parent.mkdir(parents=True, exist_ok=True)
     drafts_out.write_text(

--- a/web/src/CveApp.tsx
+++ b/web/src/CveApp.tsx
@@ -210,15 +210,20 @@ export function CveApp() {
     if (items.length === 0) return;
     if (!isLoggedIn) setLoginOpen(true);
     setEnqueueItems((prev) => {
-      const seen = new Set(prev.map((it) => `${it.package}::${it.advisory_id}`));
-      const out = [...prev];
+      const byKey = new Map<string, EnqueueItem>(
+        prev.map((it) => [`${it.package}::${it.advisory_id}`, it]),
+      );
       for (const it of items) {
         const key = `${it.package}::${it.advisory_id}`;
-        if (seen.has(key)) continue;
-        seen.add(key);
-        out.push(it);
+        const existing = byKey.get(key);
+        if (existing) {
+          // Re-staging an already-queued pair with force upgrades it.
+          if (it.force && !existing.force) byKey.set(key, { ...existing, force: true });
+          continue;
+        }
+        byKey.set(key, it);
       }
-      return out;
+      return [...byKey.values()];
     });
     setEnqueueOpen(true);
   }

--- a/web/src/components/CveAiWorkList.tsx
+++ b/web/src/components/CveAiWorkList.tsx
@@ -307,7 +307,13 @@ export function CveAiWorkList({
                 size="sm"
                 disabled={selectedRows.length === 0}
                 onClick={() => {
-                  onBulkEnqueue(selectedRows.map((r) => ({ package: r.pkg.package, advisory_id: r.adv.id })));
+                  onBulkEnqueue(
+                    selectedRows.map((r) => ({
+                      package: r.pkg.package,
+                      advisory_id: r.adv.id,
+                      force: true,
+                    })),
+                  );
                   clearSelection();
                 }}
               >

--- a/web/src/github/cve_enqueue_api.ts
+++ b/web/src/github/cve_enqueue_api.ts
@@ -12,6 +12,8 @@ export type EnqueueItem = {
   package: string;
   advisory_id: string;
   note?: string;
+  /** Force a re-draft even when the pair is already drafted and nothing drifted. */
+  force?: boolean;
 };
 
 export type EnqueueOptions = {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -718,6 +718,8 @@ type EnqueueItem = {
   advisory_id: string;
   reason?: string;
   note?: string;
+  /** Force a re-draft even when the pair is already drafted and nothing drifted. */
+  force?: boolean;
 };
 
 type EnqueueBody = {
@@ -761,6 +763,7 @@ function validateEnqueueItems(items: unknown): { ok: EnqueueItem[]; error: strin
     const item: EnqueueItem = { package: pkg, advisory_id: adv };
     if (typeof r.reason === "string") item.reason = r.reason;
     if (typeof r.note === "string") item.note = r.note;
+    if (r.force === true) item.force = true;
     out.push(item);
   }
   return { ok: out, error: null };


### PR DESCRIPTION
## Why

Three issues with the AI CVE review flow:

1. **"Requeue selected" silently no-op'd for unchanged drafts.** When you re-queue an already-drafted `(package, advisory)` pair, `_filter_items()` skips it as `already_drafted_no_drift` unless `--redraft` was passed at the workflow level, or the prompt version / severity / inputs drifted. The "Requeue selected" button and the enqueue worker had no way to signal a forced redraft, so re-reviewing an unchanged draft produced nothing and the UI kept showing the old draft.

2. **The AI queue tab couldn't represent a pending redraft.** `merge_ai_drafts` hid any queued pair that already had a draft (`drafted ⇒ not pending`). That was correct only while a re-queue was a no-op; with the `force` flag a re-queued pair *will* be redrafted, so it must stay visible until the new draft lands.

3. **`cve_ai_review.yml` failed opening the draft PR** with `GraphQL: Body is too long (maximum is 65536 characters)` once enough drafts accumulated ([failing run](https://github.com/prefix-dev/purl-associator/actions/runs/26825572644/job/79091958682)).

## What

### Per-item `force` flag (end to end)
- **schema** (`cve-review-queue.schema.json`): allow optional `items[].force` (boolean)
- **runner** (`cve_ai_review.py`): `QueueItem.force`, read in `_load_queue` (OR'd when the same pair is deduped across files), and honored in `_filter_items` — `force` bypasses the `already_drafted_no_drift` skip
- **worker** (`worker/src/index.ts`): validate and pass `force` through into the queue file
- **web**: "Requeue selected" (`CveAiWorkList.tsx`) sends `force: true`; staging dedup in `CveApp.tsx` upgrades an existing staged pair to forced
- **CLI**: `cve_ai_enqueue --force`; `cve_ai_requeue_drafts` now forces by default (`--no-force` opts out)

### Force-aware AI queue sidecar (`merge_ai_drafts.py`)
- `_collect_queue` now records `force` per pair.
- The queue view keeps a pair when it has **no draft**, **or** when a **forced** enqueue post-dates the latest draft (the redraft is still pending) — so a requested re-review reappears in the queue tab and drops out again once its new draft lands. Non-forced behavior is unchanged.
- `enqueued_at` (`…Z`) and `generated_at` (`…+00:00`) use different ISO spellings, so that comparison parses to `datetime` rather than comparing strings.

### Cap PR-body length (`cve_ai_summary.py`)
- Header + compact summary table always survive; per-package `<details>` reasoning sections are dropped (with a visible note recording how many) once they'd push the body over the cap (`--max-chars`, default 65000).
- Length measured in **UTF-16 code units** to match how GitHub counts the 65536 limit (the body is full of emoji / surrogate pairs).

## Testing
- web `tsc --noEmit`: clean; worker `tsc --noEmit`: clean
- `cve_ai_summary` against current drafts: body now **64,385 UTF-16 units** (was over 65536), header/table intact, note appended for omitted sections; tiny-cap edge case truncates correctly.
- `merge_ai_drafts` force-aware queue: unit-tested all cases — non-forced+drafted hidden; forced newer-than-draft shown; forced older-than-draft hidden; forced never-drafted shown; unparseable timestamp errs toward visibility. Cross-format `Z` vs `+00:00` compares correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)