### PR TITLE
Improve AI CVE draft review and sidecar freshness

### DIFF
--- a/.github/workflows/cve_ai_review.yml
+++ b/.github/workflows/cve_ai_review.yml
@@ -101,9 +101,6 @@ jobs:
 
           pixi run cve-ai-review "${ARGS[@]}"
 
-      - name: Refresh SPA sidecars
-        run: pixi run merge-ai-drafts
-
       - name: Generate PR body
         run: |
           mkdir -p .tmp
@@ -111,15 +108,15 @@ jobs:
           echo "---"
           head -40 .tmp/ai-pr-body.md || true
 
-      - name: Commit sidecar refresh
+      - name: Commit draft files
         run: |
           set -euo pipefail
-          git add web/public/cve_ai_drafts.json web/public/cve_ai_queue.json mappings/cve_ai_drafts/ || true
+          git add mappings/cve_ai_drafts/ || true
           if ! git diff --cached --quiet; then
-            git commit -m "cve-ai-review: refresh SPA sidecars"
+            git commit -m "cve-ai-review: refresh drafts"
             git push
           else
-            echo "No sidecar changes to commit."
+            echo "No draft changes to commit."
           fi
 
       - name: Open PR if not already open

--- a/.github/workflows/cve_refresh.yml
+++ b/.github/workflows/cve_refresh.yml
@@ -104,11 +104,6 @@ jobs:
         # the refresh PR.
         run: pixi run validate
 
-      - name: Refresh AI draft / queue SPA sidecars
-        # Keeps web/public/cve_ai_drafts.json + cve_ai_queue.json fresh so the
-        # SPA never lags behind a cves.json refresh.
-        run: pixi run merge-ai-drafts
-
       - name: Generate PR body
         run: |
           pixi run python -m scripts.cve_summary \
@@ -124,11 +119,6 @@ jobs:
           add-paths: |
             mappings/cves/**
             mappings/cve_review_queue/**
-            web/public/cves.json
-            web/public/cves-index.json
-            web/public/cve_packages/**
-            web/public/cve_ai_drafts.json
-            web/public/cve_ai_queue.json
           branch: cves/refresh
           base: main
           title: "cves: refresh advisories"

--- a/.github/workflows/cve_sidecars.yml
+++ b/.github/workflows/cve_sidecars.yml
@@ -1,0 +1,61 @@
+name: Regenerate CVE dashboard sidecars
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "mappings/cves/**"
+      - "mappings/cve_contributions/**"
+      - "mappings/cve_ai_drafts/**"
+      - "mappings/cve_review_queue/**"
+      - "scripts/merge_cves.py"
+      - "scripts/merge_ai_drafts.py"
+      - "scripts/cve_common.py"
+      - "scripts/validate.py"
+      - "schemas/**"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: cve-sidecars
+  cancel-in-progress: true
+
+jobs:
+  regenerate:
+    # Avoid a loop when this workflow pushes the generated web/public files.
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: prefix-dev/setup-pixi@v0.9.5
+        with:
+          pixi-version: latest
+          cache: true
+          environments: lite
+
+      - name: Regenerate CVE dashboard payloads
+        run: |
+          pixi run -e lite merge-cves
+          pixi run -e lite merge-ai-drafts
+          pixi run -e lite validate
+
+      - name: Commit regenerated sidecars
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add \
+            web/public/cves.json \
+            web/public/cves-index.json \
+            web/public/cve_packages/ \
+            web/public/cve_ai_drafts.json \
+            web/public/cve_ai_queue.json
+          if git diff --cached --quiet; then
+            echo "CVE dashboard sidecars are already current."
+          else
+            git commit -m "cves: regenerate dashboard sidecars"
+            git push
+          fi

--- a/pixi.toml
+++ b/pixi.toml
@@ -215,11 +215,20 @@ cmd = "npm install"
 cwd = "web"
 description = "Install frontend npm dependencies"
 
+[tasks.web-data]
+depends-on = [
+  { task = "merge", environment = "lite" },
+  { task = "merge-cves", environment = "lite" },
+  { task = "merge-ai-drafts", environment = "lite" },
+  { task = "merge-sboms", environment = "lite" },
+]
+description = "Regenerate frontend data payloads from mappings/ source files"
+
 [tasks.web-dev]
 cmd = "npm run dev -- --host {{ host }} --port {{ port }}"
 cwd = "web"
-depends-on = ["web-install"]
-description = "Run the frontend Vite dev server"
+depends-on = ["web-install", "web-data"]
+description = "Regenerate frontend data and run the Vite dev server"
 args = [
   { arg = "host", default = "127.0.0.1" },
   { arg = "port", default = "5173" },
@@ -228,8 +237,8 @@ args = [
 [tasks.web-build]
 cmd = "npm run build"
 cwd = "web"
-depends-on = ["web-install"]
-description = "Build the frontend"
+depends-on = ["web-install", "web-data"]
+description = "Regenerate frontend data and build the frontend"
 
 [tasks.web-preview]
 cmd = "npm run preview -- --host {{ host }} --port {{ port }}"

--- a/scripts/cve_ai_review.py
+++ b/scripts/cve_ai_review.py
@@ -71,7 +71,7 @@ DEFAULT_LIMIT = 50
 REALTIME_CONCURRENCY = 4  # API mode; claude-cli forces 1.
 # Bump this whenever SYSTEM_PROMPT semantics change in a way that should
 # invalidate existing drafts once their queue items are seen again.
-PROMPT_VERSION = "2026-06-02.openvex-status-history-v1"
+PROMPT_VERSION = "2026-06-03.verify-conda-shipped-versions-v1"
 
 
 SYSTEM_PROMPT = """You review CVE coverage suggestions for conda-forge packages.
@@ -88,8 +88,15 @@ auto-derived match is a sensible CVE coverage assertion and produce:
    Avoid hedging when the evidence is clear; say "unknown" when it isn't.
 
 2. **affected_versions** — does the conda `affected_versions` set look right
-   given the OSV ranges and the conda release history? Suggest adds/removes
-   when you can; provide reasoning that quotes the specific OSV range events.
+   given the OSV ranges and the conda release history? Suggest removes when a
+   listed conda-forge version is outside the vulnerable range. Suggest adds
+   only for versions you can verify are present in the provided conda-forge
+   package data (for example, already listed in `affected_versions` or clearly
+   identified as the package's `latest_conda_version`). Do not invent upstream
+   fixed or affected versions as conda-forge releases; if a version is not
+   shown in the prompt as shipped on conda-forge, mention it in notes/action
+   text but do not put it in `suggested_adds`. Provide reasoning that quotes
+   the specific OSV range events.
 
 3. **runtime_applicability** — does the vulnerable code actually execute in
    the conda artifact? Consider:
@@ -123,6 +130,14 @@ oriented, not latest-version-only:
   is a different artifact, or the OSV range is over-broad and all matched conda
   versions should be removed.
 - Use `under_investigation` when unsure.
+
+Before claiming the automated conda `affected_versions` are wrong because an
+upstream version should be added/removed, verify that the version exists in the
+conda-forge data shown in the prompt. Upstream project releases, PyPI versions,
+Git tags, or changelog versions are not automatically conda-forge versions.
+If the needed conda-forge version is not present in the prompt, do not suggest
+it as a version override; instead explain that conda-forge shipping status needs
+human verification.
 
 If you cannot tell, use `under_investigation` and explain in the rationale.
 

--- a/web/src/CveApp.tsx
+++ b/web/src/CveApp.tsx
@@ -23,7 +23,8 @@ import {
   type ReviewEdit,
 } from "./data/cves";
 import { useCveData } from "./data/useCveData";
-import { useCveEditStore } from "./stores/userState";
+import { buildCveAiWorkRows, cveReviewKey } from "./data/cveAiWorkItems";
+import { useCveAiReviewQueueStore, useCveEditStore } from "./stores/userState";
 import type { EnqueueItem } from "./github/cve_enqueue_api";
 
 export function CveApp() {
@@ -56,7 +57,8 @@ export function CveApp() {
   // AI CVE review state.
   const [aiDrafts, setAiDrafts] = useState<AiDraftsPayload | null>(null);
   const [aiQueue, setAiQueue] = useState<AiQueuePayload | null>(null);
-  const [enqueueItems, setEnqueueItems] = useState<EnqueueItem[]>([]);
+  const enqueueItems = useCveAiReviewQueueStore((state) => state.items);
+  const setEnqueueItems = useCveAiReviewQueueStore((state) => state.setItems);
   const [enqueueOpen, setEnqueueOpen] = useState(false);
 
   const t = theme.t;
@@ -69,6 +71,7 @@ export function CveApp() {
     loadAiDrafts(config.aiDraftsUrl).then(setAiDrafts);
     loadAiQueue(config.aiQueueUrl).then(setAiQueue);
   }, []);
+
 
   // Packages that still have at least one unreviewed advisory shipping now
   // (or affecting a future version). Ordered the same way the triage list
@@ -146,7 +149,7 @@ export function CveApp() {
   const editsCount = Object.keys(edits).length;
 
   function editKey(pkg: string, advisoryId: string): string {
-    return `${pkg}::${advisoryId}`;
+    return cveReviewKey(pkg, advisoryId);
   }
 
   function handleEdit(
@@ -189,6 +192,30 @@ export function CveApp() {
     () => new Set(enqueueItems.map((it) => `${it.package}::${it.advisory_id}`)),
     [enqueueItems],
   );
+
+  function handleAiDraftApplied(pkgName: string, advisoryId: string): void {
+    const currentKey = editKey(pkgName, advisoryId);
+    const openDrafts = buildCveAiWorkRows({
+      mode: "drafts",
+      packages: representatives,
+      membersByRep,
+      edits,
+      aiDrafts,
+      aiQueue,
+      enqueuedAdvisories: enqueuedSet,
+      includeCurrentKey: currentKey,
+    });
+    const idx = openDrafts.findIndex(
+      (row) => row.pkg.package === pkgName && row.adv.id === advisoryId,
+    );
+    const next =
+      openDrafts[idx >= 0 ? idx + 1 : 0] ??
+      openDrafts.find((row) => editKey(row.pkg.package, row.adv.id) !== currentKey);
+    if (!next) return;
+    setView("aiDrafts");
+    setFocusedPkg(next.pkg.package);
+    setFocusedAdvisoryId(next.adv.id);
+  }
 
   function handleEnqueueAi(pkg: string, advisoryId: string): void {
     if (!isLoggedIn) {
@@ -658,6 +685,9 @@ export function CveApp() {
             aiQueue={aiQueue}
             enqueuedAdvisories={enqueuedSet}
             onEnqueueAi={handleEnqueueAi}
+            onAiDraftApplied={(advisoryId) => {
+              if (focusedPackage) handleAiDraftApplied(focusedPackage.package, advisoryId);
+            }}
           />
           )}
         </div>
@@ -698,6 +728,7 @@ export function CveApp() {
           items={enqueueItems}
           onClose={() => setEnqueueOpen(false)}
           onRemove={handleRemoveEnqueue}
+          onClear={() => setEnqueueItems([])}
           onSubmitted={() => {
             setEnqueueItems([]);
           }}

--- a/web/src/components/CveAiWorkList.tsx
+++ b/web/src/components/CveAiWorkList.tsx
@@ -1,16 +1,24 @@
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import type {
-  AiDraft,
   AiDraftsPayload,
   AiQueuePayload,
-  CveAdvisoryIndex,
   CvePackageIndex,
   ReviewEdit,
 } from "../data/cves";
-import { Glyph, Theme, Btn } from "./Primitives";
+import {
+  aiStatusChangeLabel,
+  buildCveAiWorkRows,
+  draftNeedsCloserRead,
+  type CveAiWorkRow,
+} from "../data/cveAiWorkItems";
+import { Glyph, Theme, Btn, FilterChip } from "./Primitives";
+import { useCveAiWorkListPrefsStore } from "../stores/userState";
+import type { EnqueueItem } from "../github/cve_enqueue_api";
+import { useSetSelection } from "../hooks/useSetSelection";
 
 type Mode = "queue" | "drafts";
 type SeverityFilter = "all" | "critical" | "high+";
+type StatusChangeFilter = "all" | string;
 
 type Props = {
   theme: Theme;
@@ -24,70 +32,10 @@ type Props = {
   aiQueue: AiQueuePayload | null;
   enqueuedAdvisories: Set<string>;
   onSelect: (pkgName: string, advisoryId: string) => void;
-  onBulkEnqueue: (items: { package: string; advisory_id: string }[]) => void;
+  onBulkEnqueue: (items: EnqueueItem[]) => void;
 };
 
-type Row = {
-  pkg: CvePackageIndex;
-  adv: CveAdvisoryIndex;
-  score: number;
-  reviewed: boolean;
-  queued: boolean;
-  drafted: boolean;
-  draft?: AiDraft;
-  locallyQueued: boolean;
-};
-
-function reviewedStatus(edit: ReviewEdit | undefined, adv: CveAdvisoryIndex): boolean {
-  const status = edit?.status ?? adv.vex_status;
-  return !!status && status !== "under_investigation";
-}
-
-function packageDraft(
-  aiDrafts: AiDraftsPayload | null,
-  packages: string[],
-  advisoryId: string,
-): AiDraft | undefined {
-  for (const pkg of packages) {
-    const draft = aiDrafts?.drafts[pkg]?.[advisoryId];
-    if (draft) return draft;
-  }
-  return undefined;
-}
-
-function draftNeedsCloserRead(draft: AiDraft): boolean {
-  return (
-    !draft.affected_versions.agrees_with_match ||
-    draft.runtime_applicability.applies === "unknown" ||
-    draft.runtime_applicability.applies === "partial" ||
-    draft.severity_in_conda_context.assessment === "unknown"
-  );
-}
-
-function statusChangeLabel(adv: CveAdvisoryIndex, draft: AiDraft): string {
-  const current = adv.vex_status ?? "unreviewed";
-  return current === draft.openvex_status
-    ? `keeps ${draft.openvex_status}`
-    : `${current} → ${draft.openvex_status}`;
-}
-
-function packageQueued(
-  aiQueue: AiQueuePayload | null,
-  packages: string[],
-  advisoryId: string,
-): boolean {
-  return packages.some((pkg) => Boolean(aiQueue?.queue[pkg]?.[advisoryId]));
-}
-
-function locallyQueued(
-  enqueued: Set<string>,
-  packages: string[],
-  advisoryId: string,
-): boolean {
-  return packages.some((pkg) => enqueued.has(`${pkg}::${advisoryId}`));
-}
-
-function rowKey(row: Pick<Row, "pkg" | "adv">): string {
+function rowKey(row: Pick<CveAiWorkRow, "pkg" | "adv">): string {
   return `${row.pkg.package}::${row.adv.id}`;
 }
 
@@ -160,79 +108,58 @@ export function CveAiWorkList({
   onBulkEnqueue,
 }: Props) {
   const t = theme.t;
-  const [q, setQ] = useState("");
-  const [sev, setSev] = useState<SeverityFilter>("all");
-  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const searchByMode = useCveAiWorkListPrefsStore((state) => state.search);
+  const severityByMode = useCveAiWorkListPrefsStore((state) => state.severity);
+  const statusChangeByMode = useCveAiWorkListPrefsStore((state) => state.statusChange);
+  const setModePref = useCveAiWorkListPrefsStore((state) => state.setModePref);
+  const q = searchByMode[mode] ?? "";
+  const sev = (severityByMode[mode] ?? "all") as SeverityFilter;
+  const statusChange = (statusChangeByMode[mode] ?? "all") as StatusChangeFilter;
+  const setQ = (value: string) => setModePref("search", mode, value);
+  const setSev = (value: SeverityFilter) => setModePref("severity", mode, value);
+  const setStatusChange = (value: StatusChangeFilter) => setModePref("statusChange", mode, value);
+  const { selected, toggleSelected, selectItems, clearSelection } = useSetSelection(rowKey);
 
-  const allRows = useMemo<Row[]>(() => {
-    const out: Row[] = [];
-    for (const pkg of packages) {
-      const lookupPackages = membersByRep.get(pkg.package) ?? [pkg.package];
-      for (const adv of pkg.advisories) {
-        const key = `${pkg.package}::${adv.id}`;
-        const draft = packageDraft(aiDrafts, lookupPackages, adv.id);
-        const drafted = Boolean(draft);
-        const queued = packageQueued(aiQueue, lookupPackages, adv.id);
-        const locallyQueued_ = locallyQueued(enqueuedAdvisories, lookupPackages, adv.id);
-        const reviewed = reviewedStatus(edits[key], adv);
-        if (mode === "drafts") {
-          if (!drafted || reviewed) continue;
-        } else {
-          if (!queued || drafted || reviewed) continue;
-        }
-        out.push({
-          pkg,
-          adv,
-          score: adv.severity?.score_num ?? 0,
-          reviewed,
-          queued,
-          drafted,
-          draft,
-          locallyQueued: locallyQueued_,
-        });
-      }
-    }
-    out.sort((a, b) => {
-      if (a.score !== b.score) return b.score - a.score;
-      return a.adv.primary_id.localeCompare(b.adv.primary_id) || a.pkg.package.localeCompare(b.pkg.package);
-    });
-    return out;
-  }, [packages, membersByRep, aiDrafts, aiQueue, enqueuedAdvisories, edits, mode]);
+  const allRows = useMemo(
+    () =>
+      buildCveAiWorkRows({
+        mode,
+        packages,
+        membersByRep,
+        edits,
+        aiDrafts,
+        aiQueue,
+        enqueuedAdvisories,
+      }),
+    [packages, membersByRep, aiDrafts, aiQueue, enqueuedAdvisories, edits, mode],
+  );
 
   const ql = q.trim().toLowerCase();
   const rows = useMemo(() => {
     return allRows.filter((r) => {
       if (sev === "critical" && r.score < 9) return false;
       if (sev === "high+" && r.score < 7) return false;
+      if (mode === "drafts" && statusChange !== "all" && r.draft && aiStatusChangeLabel(r.adv, r.draft) !== statusChange) return false;
       if (!ql) return true;
       const names = [r.pkg.package, ...(membersByRep.get(r.pkg.package) ?? [])].join(" ").toLowerCase();
       const ids = [r.adv.id, r.adv.primary_id, ...(r.adv.cve_ids ?? []), ...(r.adv.aliases ?? [])].join(" ").toLowerCase();
       return names.includes(ql) || ids.includes(ql) || (r.adv.summary ?? "").toLowerCase().includes(ql);
     });
-  }, [allRows, ql, sev, membersByRep]);
+  }, [allRows, ql, sev, statusChange, mode, membersByRep]);
+
+  const statusChangeOptions = useMemo(() => {
+    const labels = new Set<string>();
+    for (const row of allRows) {
+      if (row.draft) labels.add(aiStatusChangeLabel(row.adv, row.draft));
+    }
+    return [...labels].sort();
+  }, [allRows]);
 
   const selectableRows = mode === "drafts" ? rows.filter((r) => !r.locallyQueued) : [];
   const selectedRows = selectableRows.filter((r) => selected.has(rowKey(r)));
 
-  function toggleSelected(key: string): void {
-    setSelected((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
-  }
-
   function selectVisible(): void {
-    setSelected((prev) => {
-      const next = new Set(prev);
-      for (const row of selectableRows) next.add(rowKey(row));
-      return next;
-    });
-  }
-
-  function clearSelection(): void {
-    setSelected(new Set());
+    selectItems(selectableRows);
   }
 
   return (
@@ -253,22 +180,36 @@ export function CveAiWorkList({
         />
         <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
           {(["all", "critical", "high+"] as SeverityFilter[]).map((value) => (
-            <button
+            <FilterChip
               key={value}
+              theme={theme}
+              active={sev === value}
               onClick={() => setSev(value)}
+              rounded
+            >
+              {value === "high+" ? "High + critical" : value[0].toUpperCase() + value.slice(1)}
+            </FilterChip>
+          ))}
+          {mode === "drafts" && statusChangeOptions.length > 0 && (
+            <select
+              value={statusChange}
+              onChange={(e) => setStatusChange(e.target.value)}
+              title="Filter by AI status change"
               style={{
-                border: `1px solid ${sev === value ? t.accent : t.border}`,
-                background: sev === value ? t.surface2 : "transparent",
-                color: sev === value ? t.fg1 : t.fg2,
+                background: t.inset,
+                color: t.fg1,
+                border: `1px solid ${t.border}`,
                 borderRadius: 999,
                 padding: "4px 8px",
                 fontSize: 11,
-                cursor: "pointer",
               }}
             >
-              {value === "high+" ? "High + critical" : value[0].toUpperCase() + value.slice(1)}
-            </button>
-          ))}
+              <option value="all">All status changes</option>
+              {statusChangeOptions.map((label) => (
+                <option key={label} value={label}>{label}</option>
+              ))}
+            </select>
+          )}
           {mode === "drafts" && selectableRows.length > 0 && (
             <span style={{ marginLeft: "auto", display: "inline-flex", gap: 6, alignItems: "center" }}>
               <button
@@ -378,11 +319,18 @@ export function CveAiWorkList({
                   <AiBadge
                     theme={theme}
                     tone="info"
-                    label={statusChangeLabel(r.adv, r.draft)}
+                    label={aiStatusChangeLabel(r.adv, r.draft)}
                   />
                 </div>
               )}
-              <div style={{ marginTop: 4, fontFamily: "JetBrains Mono, monospace", color: t.fg2, fontSize: 11 }}>{r.pkg.package}</div>
+              <div style={{ marginTop: 4, fontFamily: "JetBrains Mono, monospace", color: t.fg2, fontSize: 11 }}>
+                {r.pkg.package}
+                {mode === "queue" && r.packageQueueCount > 1 && (
+                  <span style={{ marginLeft: 8, fontFamily: "Inter, sans-serif", color: t.fg3 }}>
+                    {r.packageQueueCount} CVEs queued for this package
+                  </span>
+                )}
+              </div>
               {r.adv.summary && <div style={{ marginTop: 4, color: t.fg2, fontSize: 12, lineHeight: 1.35 }}>{r.adv.summary}</div>}
             </button>
           );

--- a/web/src/components/CveDetail.tsx
+++ b/web/src/components/CveDetail.tsx
@@ -19,8 +19,6 @@ import {
   cveIds,
   editFromAiDraft,
   editFromVex,
-  getAiDraftFor,
-  isAdvisoryQueued,
   isActiveOnLatest,
   isEditNonEmpty,
   isFutureAffected,
@@ -36,6 +34,7 @@ import {
   handleDraftSubmit,
 } from "./DraftFields";
 import { cvssBaseMetrics } from "../data/cvssMetrics";
+import { packageDraft, packageQueued, locallyQueued } from "../data/cveAiWorkItems";
 import { Btn, CpeChip, Glyph, Theme } from "./Primitives";
 
 type Props = {
@@ -55,6 +54,7 @@ type Props = {
   aiQueue: AiQueuePayload | null;
   enqueuedAdvisories: Set<string>;
   onEnqueueAi: (pkg: string, advisoryId: string) => void;
+  onAiDraftApplied?: (advisoryId: string) => void;
 };
 
 function severityLevel(v: number): {
@@ -330,6 +330,7 @@ export function CveDetail({
   aiQueue,
   enqueuedAdvisories,
   onEnqueueAi,
+  onAiDraftApplied,
 }: Props) {
   const t = theme.t;
 
@@ -626,12 +627,13 @@ export function CveDetail({
               onReset={() => onResetEdit(adv.id)}
               isLoggedIn={isLoggedIn}
               onRequestLogin={onRequestLogin}
-              aiDraft={aiDraftForAnyPackage(aiDrafts, aiLookupPackages, adv.id)}
+              aiDraft={packageDraft(aiDrafts, aiLookupPackages, adv.id)}
               aiQueued={
-                aiQueuedForAnyPackage(aiQueue, aiLookupPackages, adv.id) ||
-                locallyQueuedForAnyPackage(enqueuedAdvisories, aiLookupPackages, adv.id)
+                packageQueued(aiQueue, aiLookupPackages, adv.id) ||
+                locallyQueued(enqueuedAdvisories, aiLookupPackages, adv.id)
               }
               onEnqueueAi={() => onEnqueueAi(pkg.package, adv.id)}
+              onAiDraftApplied={() => onAiDraftApplied?.(adv.id)}
             />
             );
           })}
@@ -685,12 +687,13 @@ export function CveDetail({
                     onReset={() => onResetEdit(adv.id)}
                     isLoggedIn={isLoggedIn}
                     onRequestLogin={onRequestLogin}
-                    aiDraft={aiDraftForAnyPackage(aiDrafts, aiLookupPackages, adv.id)}
+                    aiDraft={packageDraft(aiDrafts, aiLookupPackages, adv.id)}
                     aiQueued={
-                      aiQueuedForAnyPackage(aiQueue, aiLookupPackages, adv.id) ||
-                      locallyQueuedForAnyPackage(enqueuedAdvisories, aiLookupPackages, adv.id)
+                      packageQueued(aiQueue, aiLookupPackages, adv.id) ||
+                      locallyQueued(enqueuedAdvisories, aiLookupPackages, adv.id)
                     }
                     onEnqueueAi={() => onEnqueueAi(pkg.package, adv.id)}
+                    onAiDraftApplied={() => onAiDraftApplied?.(adv.id)}
                   />
                 ))}
             </>
@@ -715,6 +718,7 @@ function AdvisoryCard({
   aiDraft,
   aiQueued,
   onEnqueueAi,
+  onAiDraftApplied,
 }: {
   theme: Theme;
   pkgName: string;
@@ -729,6 +733,7 @@ function AdvisoryCard({
   aiDraft: AiDraft | undefined;
   aiQueued: boolean;
   onEnqueueAi: () => void;
+  onAiDraftApplied?: () => void;
 }) {
   const t = theme.t;
   const [expanded, setExpanded] = useState(defaultExpanded);
@@ -939,9 +944,14 @@ function AdvisoryCard({
               theme={theme}
               draft={aiDraft}
               adv={adv}
-              onUseAsStartingPoint={() => {
+              onFillForm={() => {
                 if (!isLoggedIn) onRequestLogin();
                 onEdit(editFromAiDraft(aiDraft));
+              }}
+              onApplyAndNext={() => {
+                if (!isLoggedIn) onRequestLogin();
+                onEdit(editFromAiDraft(aiDraft));
+                onAiDraftApplied?.();
               }}
             />
           )}
@@ -1395,33 +1405,6 @@ function AddVersionInline({
 
 /* ------------ AI CVE review (drafts + queue) ------------ */
 
-function aiDraftForAnyPackage(
-  payload: AiDraftsPayload | null,
-  packages: string[],
-  advisoryId: string,
-): AiDraft | undefined {
-  for (const pkg of packages) {
-    const draft = getAiDraftFor(payload, pkg, advisoryId);
-    if (draft) return draft;
-  }
-  return undefined;
-}
-
-function aiQueuedForAnyPackage(
-  payload: AiQueuePayload | null,
-  packages: string[],
-  advisoryId: string,
-): boolean {
-  return packages.some((pkg) => Boolean(isAdvisoryQueued(payload, pkg, advisoryId)));
-}
-
-function locallyQueuedForAnyPackage(
-  enqueued: Set<string>,
-  packages: string[],
-  advisoryId: string,
-): boolean {
-  return packages.some((pkg) => enqueued.has(`${pkg}::${advisoryId}`));
-}
 
 function AiChip({
   theme,
@@ -1561,16 +1544,39 @@ function aiTakeaways(draft: AiDraft): string[] {
   return out;
 }
 
+function AiDraftActions({
+  theme,
+  onFillForm,
+  onApplyAndNext,
+}: {
+  theme: Theme;
+  onFillForm: () => void;
+  onApplyAndNext: () => void;
+}) {
+  return (
+    <div style={{ display: "inline-flex", gap: 8 }}>
+      <Btn theme={theme} variant="secondary" onClick={onFillForm}>
+        Fill OpenVEX form
+      </Btn>
+      <Btn theme={theme} variant="primary" onClick={onApplyAndNext}>
+        Apply & next
+      </Btn>
+    </div>
+  );
+}
+
 function AiDraftPanel({
   theme,
   draft,
   adv,
-  onUseAsStartingPoint,
+  onFillForm,
+  onApplyAndNext,
 }: {
   theme: Theme;
   draft: AiDraft;
   adv: Advisory;
-  onUseAsStartingPoint: () => void;
+  onFillForm: () => void;
+  onApplyAndNext: () => void;
 }) {
   const t = theme.t;
   const af = draft.affected_versions;
@@ -1600,9 +1606,11 @@ function AiDraftPanel({
           {draft.model} · {(draft.generated_at || "").slice(0, 10)}
         </span>
         <span style={{ flex: 1 }} />
-        <Btn theme={theme} variant="primary" onClick={onUseAsStartingPoint}>
-          Apply AI suggestion
-        </Btn>
+        <AiDraftActions
+          theme={theme}
+          onFillForm={onFillForm}
+          onApplyAndNext={onApplyAndNext}
+        />
       </div>
 
       <div
@@ -1711,12 +1719,14 @@ function AiDraftPanel({
         }}
       >
         <div style={{ fontSize: 10.5, color: t.fg3, lineHeight: 1.4 }}>
-          This is a draft, not authoritative. Apply it to seed the OpenVEX form,
-          review/edit it, then submit via the Review changes drawer.
+          This is a draft, not authoritative. Fill the OpenVEX form to review/edit
+          it here, or Apply & next to stage it and advance through the AI drafts queue.
         </div>
-        <Btn theme={theme} variant="primary" onClick={onUseAsStartingPoint}>
-          Apply AI suggestion
-        </Btn>
+        <AiDraftActions
+          theme={theme}
+          onFillForm={onFillForm}
+          onApplyAndNext={onApplyAndNext}
+        />
       </div>
     </div>
   );
@@ -1783,7 +1793,7 @@ function OpenVexSuggestionPreview({
   const removes = draft.affected_versions.suggested_removes ?? [];
   if (adds.length || removes.length) {
     rows.push({
-      label: "version_overrides",
+      label: "per-version statements",
       value: (
         <div style={{ display: "grid", gap: 3 }}>
           {adds.length > 0 && <div>affected: {adds.join(", ")}</div>}
@@ -1793,7 +1803,7 @@ function OpenVexSuggestionPreview({
     });
   } else {
     rows.push({
-      label: "version_overrides",
+      label: "per-version statements",
       value:
         draft.openvex_status === "fixed"
           ? "none — package-level fixed statement; keep the historical affected-version list for old vulnerable builds"
@@ -1859,8 +1869,8 @@ function OpenVexSuggestionPreview({
         ))}
       </div>
       <div style={{ marginTop: 8, color: t.fg3, fontSize: 11.5 }}>
-        Applying the suggestion copies these fields into the review form below;
-        the final PR will wrap them in the OpenVEX document envelope with the selected package and advisory.
+        OpenVEX has product-specific statements, not a literal version_overrides field.
+        Suggested adds/removes are represented as separate version-pinned OpenVEX statements in the final PR.
       </div>
     </AiDraftSection>
   );

--- a/web/src/components/CveEnqueueDrawer.tsx
+++ b/web/src/components/CveEnqueueDrawer.tsx
@@ -10,6 +10,7 @@ type Props = {
   items: EnqueueItem[];
   onClose: () => void;
   onRemove: (pkg: string, advisoryId: string) => void;
+  onClear: () => void;
   onSubmitted: () => void;
   isLoggedIn: boolean;
   onRequestLogin: () => void;
@@ -28,6 +29,7 @@ export function CveEnqueueDrawer({
   items,
   onClose,
   onRemove,
+  onClear,
   onSubmitted,
   isLoggedIn,
   onRequestLogin,
@@ -211,21 +213,26 @@ export function CveEnqueueDrawer({
               borderTop: `1px solid ${t.border}`,
               display: "flex",
               gap: 8,
-              justifyContent: "flex-end",
+              justifyContent: "space-between",
             }}
           >
-            <Btn theme={theme} variant="ghost" onClick={onClose}>
-              Cancel
+            <Btn theme={theme} variant="ghost" onClick={onClear} disabled={submitting}>
+              Clear all
             </Btn>
-            <Btn
-              theme={theme}
-              variant="primary"
-              icon="pr"
-              onClick={submit}
-              disabled={submitting}
-            >
-              {submitting ? "Opening PR…" : "Submit batch"}
-            </Btn>
+            <div style={{ display: "flex", gap: 8 }}>
+              <Btn theme={theme} variant="ghost" onClick={onClose}>
+                Cancel
+              </Btn>
+              <Btn
+                theme={theme}
+                variant="primary"
+                icon="pr"
+                onClick={submit}
+                disabled={submitting}
+              >
+                {submitting ? "Opening PR…" : "Submit batch"}
+              </Btn>
+            </div>
           </div>
         )}
       </div>

--- a/web/src/components/PackageTable.tsx
+++ b/web/src/components/PackageTable.tsx
@@ -2,7 +2,7 @@ import { useMemo, useRef, useState } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import type { Edit, MappingPackageIndex, PackageEntry } from "../data/types";
 import { ECOSYSTEMS } from "../data/loader";
-import { EcosystemChip, Glyph, StatusPill, Theme } from "./Primitives";
+import { EcosystemChip, FilterChip, Glyph, StatusPill, Theme } from "./Primitives";
 
 export type SortKey =
   | "name"
@@ -746,41 +746,6 @@ function SortHeader({
           ▲
         </span>
       )}
-    </button>
-  );
-}
-
-function FilterChip({
-  theme,
-  active,
-  onClick,
-  children,
-}: {
-  theme: Theme;
-  active: boolean;
-  onClick: () => void;
-  children: React.ReactNode;
-}) {
-  const t = theme.t;
-  return (
-    <button
-      onClick={onClick}
-      style={{
-        display: "inline-flex",
-        alignItems: "center",
-        gap: 6,
-        background: active ? t.accent : t.surface2,
-        color: active ? t.accentFg : t.fg1,
-        border: `1px solid ${active ? t.accent : t.border}`,
-        borderRadius: 6,
-        padding: "3px 8px",
-        fontSize: 11.5,
-        fontWeight: 600,
-        cursor: "pointer",
-        fontFamily: "Inter, sans-serif",
-      }}
-    >
-      {children}
     </button>
   );
 }

--- a/web/src/components/Primitives.tsx
+++ b/web/src/components/Primitives.tsx
@@ -471,6 +471,45 @@ export function SourceTag({ source, theme }: { source: string; theme: Theme }) {
   );
 }
 
+type FilterChipProps = {
+  theme: Theme;
+  active: boolean;
+  onClick: () => void;
+  children: ReactNode;
+  rounded?: boolean;
+};
+
+export function FilterChip({
+  theme,
+  active,
+  onClick,
+  children,
+  rounded = false,
+}: FilterChipProps) {
+  const t = theme.t;
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        background: active ? t.accent : t.surface2,
+        color: active ? t.accentFg : t.fg1,
+        border: `1px solid ${active ? t.accent : t.border}`,
+        borderRadius: rounded ? 999 : 6,
+        padding: rounded ? "4px 8px" : "3px 8px",
+        fontSize: rounded ? 11 : 11.5,
+        fontWeight: 600,
+        cursor: "pointer",
+        fontFamily: "Inter, sans-serif",
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
 type BtnProps = {
   children: ReactNode;
   onClick?: () => void;

--- a/web/src/data/cveAiWorkItems.ts
+++ b/web/src/data/cveAiWorkItems.ts
@@ -1,0 +1,132 @@
+import type {
+  AiDraft,
+  AiDraftsPayload,
+  AiQueuePayload,
+  CveAdvisoryIndex,
+  CvePackageIndex,
+  ReviewEdit,
+} from "./cves";
+
+export type CveAiWorkMode = "queue" | "drafts";
+
+export type CveAiWorkRow = {
+  pkg: CvePackageIndex;
+  adv: CveAdvisoryIndex;
+  score: number;
+  reviewed: boolean;
+  queued: boolean;
+  drafted: boolean;
+  draft?: AiDraft;
+  locallyQueued: boolean;
+  packageQueueCount: number;
+};
+
+export function reviewStatusIsResolved(status: string | undefined): boolean {
+  return !!status && status !== "under_investigation";
+}
+
+export function cveReviewKey(pkg: string, advisoryId: string): string {
+  return `${pkg}::${advisoryId}`;
+}
+
+export function packageDraft(
+  aiDrafts: AiDraftsPayload | null,
+  packages: string[],
+  advisoryId: string,
+): AiDraft | undefined {
+  for (const pkg of packages) {
+    const draft = aiDrafts?.drafts[pkg]?.[advisoryId];
+    if (draft) return draft;
+  }
+  return undefined;
+}
+
+export function packageQueued(
+  aiQueue: AiQueuePayload | null,
+  packages: string[],
+  advisoryId: string,
+): boolean {
+  return packages.some((pkg) => Boolean(aiQueue?.queue[pkg]?.[advisoryId]));
+}
+
+export function locallyQueued(
+  enqueued: Set<string>,
+  packages: string[],
+  advisoryId: string,
+): boolean {
+  return packages.some((pkg) => enqueued.has(cveReviewKey(pkg, advisoryId)));
+}
+
+export function aiStatusChangeLabel(adv: CveAdvisoryIndex, draft: AiDraft): string {
+  const current = adv.vex_status ?? "unreviewed";
+  return current === draft.openvex_status
+    ? `keeps ${draft.openvex_status}`
+    : `${current} → ${draft.openvex_status}`;
+}
+
+export function draftNeedsCloserRead(draft: AiDraft): boolean {
+  return (
+    !draft.affected_versions.agrees_with_match ||
+    draft.runtime_applicability.applies === "unknown" ||
+    draft.runtime_applicability.applies === "partial" ||
+    draft.severity_in_conda_context.assessment === "unknown"
+  );
+}
+
+export function buildCveAiWorkRows({
+  mode,
+  packages,
+  membersByRep,
+  edits,
+  aiDrafts,
+  aiQueue,
+  enqueuedAdvisories,
+  includeCurrentKey,
+}: {
+  mode: CveAiWorkMode;
+  packages: CvePackageIndex[];
+  membersByRep: Map<string, string[]>;
+  edits: Record<string, ReviewEdit>;
+  aiDrafts: AiDraftsPayload | null;
+  aiQueue: AiQueuePayload | null;
+  enqueuedAdvisories: Set<string>;
+  /** Used by Apply & next: keep the just-applied row while choosing the next one. */
+  includeCurrentKey?: string;
+}): CveAiWorkRow[] {
+  const out: CveAiWorkRow[] = [];
+  for (const pkg of packages) {
+    const lookupPackages = membersByRep.get(pkg.package) ?? [pkg.package];
+    for (const adv of pkg.advisories) {
+      const key = cveReviewKey(pkg.package, adv.id);
+      const draft = packageDraft(aiDrafts, lookupPackages, adv.id);
+      const drafted = Boolean(draft);
+      const queued = packageQueued(aiQueue, lookupPackages, adv.id);
+      const locallyQueued_ = locallyQueued(enqueuedAdvisories, lookupPackages, adv.id);
+      const reviewed = reviewStatusIsResolved(edits[key]?.status ?? adv.vex_status);
+      if (mode === "drafts") {
+        if (!drafted || (reviewed && key !== includeCurrentKey)) continue;
+      } else {
+        if (!queued || drafted || reviewed) continue;
+      }
+      out.push({
+        pkg,
+        adv,
+        score: adv.severity?.score_num ?? 0,
+        reviewed,
+        queued,
+        drafted,
+        draft,
+        locallyQueued: locallyQueued_,
+        packageQueueCount: 0,
+      });
+    }
+  }
+  const counts = new Map<string, number>();
+  for (const row of out) counts.set(row.pkg.package, (counts.get(row.pkg.package) ?? 0) + 1);
+  for (const row of out) row.packageQueueCount = counts.get(row.pkg.package) ?? 1;
+  out.sort((a, b) => {
+    if (a.score !== b.score) return b.score - a.score;
+    return a.adv.primary_id.localeCompare(b.adv.primary_id) || a.pkg.package.localeCompare(b.pkg.package);
+  });
+  return out;
+}

--- a/web/src/hooks/useSetSelection.ts
+++ b/web/src/hooks/useSetSelection.ts
@@ -1,0 +1,28 @@
+import { useState } from "react";
+
+export function useSetSelection<T>(keyFor: (item: T) => string) {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  function toggleSelected(key: string): void {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  function selectItems(items: T[]): void {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      for (const item of items) next.add(keyFor(item));
+      return next;
+    });
+  }
+
+  function clearSelection(): void {
+    setSelected(new Set());
+  }
+
+  return { selected, toggleSelected, selectItems, clearSelection };
+}

--- a/web/src/stores/userState.ts
+++ b/web/src/stores/userState.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { persist, type PersistStorage, type StorageValue } from "zustand/middleware";
 import type { ReviewEdit } from "../data/cves";
+import type { EnqueueItem } from "../github/cve_enqueue_api";
 import type { Edit } from "../data/types";
 import { storageKey } from "../storage/namespace";
 
@@ -14,25 +15,23 @@ import { storageKey } from "../storage/namespace";
 const STORAGE_KEYS = {
   stagedPurlEdits: storageKey("staged_edits"),
   stagedCveEdits: storageKey("staged_cve_edits"),
+  stagedCveAiReviews: storageKey("staged_cve_ai_reviews"),
+  cveAiWorkListPrefs: storageKey("cve_ai_work_list_prefs"),
 } as const;
 
-type PersistedEdits<T> = { edits: Record<string, T> };
-
-function persistedEditStorage<T>(): PersistStorage<PersistedEdits<T>> {
+function safeJsonStorage<T>(
+  migrate?: (parsed: unknown) => StorageValue<T>,
+): PersistStorage<T> {
   return {
     getItem: (name) => {
       try {
         const raw = localStorage.getItem(name);
         if (!raw) return null;
-        const parsed = JSON.parse(raw) as
-          | StorageValue<PersistedEdits<T>>
-          | Record<string, T>;
+        const parsed = JSON.parse(raw) as StorageValue<T> | unknown;
         if (parsed && typeof parsed === "object" && "state" in parsed) {
-          return parsed as StorageValue<PersistedEdits<T>>;
+          return parsed as StorageValue<T>;
         }
-        // Migration path for the pre-Zustand format, where the storage value was
-        // the raw edits object under the same key.
-        return { state: { edits: parsed as Record<string, T> }, version: 0 };
+        return migrate ? migrate(parsed) : null;
       } catch {
         return null;
       }
@@ -52,6 +51,20 @@ function persistedEditStorage<T>(): PersistStorage<PersistedEdits<T>> {
       }
     },
   };
+}
+
+type PersistedEdits<T> = { edits: Record<string, T> };
+
+function persistedEditStorage<T>(): PersistStorage<PersistedEdits<T>> {
+  return safeJsonStorage<PersistedEdits<T>>((parsed) => {
+    // Migration path for the pre-Zustand format, where the storage value was
+    // the raw edits object under the same key.
+    return { state: { edits: parsed as Record<string, T> }, version: 0 };
+  });
+}
+
+function persistedJsonStorage<T>(): PersistStorage<T> {
+  return safeJsonStorage<T>();
 }
 
 type PurlEditState = {
@@ -106,6 +119,83 @@ export const useCveEditStore = create<CveEditState>()(
       name: STORAGE_KEYS.stagedCveEdits,
       storage: persistedEditStorage<ReviewEdit>(),
       partialize: (state) => ({ edits: state.edits }),
+    },
+  ),
+);
+
+type CveAiReviewQueueState = {
+  items: EnqueueItem[];
+  setItems: (
+    next: EnqueueItem[] | ((previous: EnqueueItem[]) => EnqueueItem[]),
+  ) => void;
+  clearItems: () => void;
+};
+
+export const useCveAiReviewQueueStore = create<CveAiReviewQueueState>()(
+  persist(
+    (set) => ({
+      items: [],
+      setItems: (next) =>
+        set((state) => ({
+          items: typeof next === "function" ? next(state.items) : next,
+        })),
+      clearItems: () => set({ items: [] }),
+    }),
+    {
+      name: STORAGE_KEYS.stagedCveAiReviews,
+      storage: persistedJsonStorage<CveAiReviewQueueState>(),
+      partialize: (state) => ({ items: state.items }) as CveAiReviewQueueState,
+    },
+  ),
+);
+
+type ModePrefs = {
+  search: Record<string, string>;
+  severity: Record<string, string>;
+  statusChange: Record<string, string>;
+};
+
+type ModePrefField = keyof ModePrefs;
+
+type CveAiWorkListPrefsState = ModePrefs & {
+  setModePref: (field: ModePrefField, mode: string, value: string) => void;
+  setSearch: (mode: string, value: string) => void;
+  setSeverity: (mode: string, value: string) => void;
+  setStatusChange: (mode: string, value: string) => void;
+};
+
+function modePrefPatch(
+  state: ModePrefs,
+  field: ModePrefField,
+  mode: string,
+  value: string,
+): Pick<ModePrefs, ModePrefField> {
+  return { [field]: { ...state[field], [mode]: value } } as Pick<ModePrefs, ModePrefField>;
+}
+
+export const useCveAiWorkListPrefsStore = create<CveAiWorkListPrefsState>()(
+  persist(
+    (set) => ({
+      search: {},
+      severity: {},
+      statusChange: {},
+      setModePref: (field, mode, value) =>
+        set((state) => modePrefPatch(state, field, mode, value)),
+      setSearch: (mode, value) =>
+        set((state) => modePrefPatch(state, "search", mode, value)),
+      setSeverity: (mode, value) =>
+        set((state) => modePrefPatch(state, "severity", mode, value)),
+      setStatusChange: (mode, value) =>
+        set((state) => modePrefPatch(state, "statusChange", mode, value)),
+    }),
+    {
+      name: STORAGE_KEYS.cveAiWorkListPrefs,
+      storage: persistedJsonStorage<CveAiWorkListPrefsState>(),
+      partialize: (state) => ({
+        search: state.search,
+        severity: state.severity,
+        statusChange: state.statusChange,
+      }) as CveAiWorkListPrefsState,
     },
   ),
 );


### PR DESCRIPTION
## What changed

This PR has two related pieces of work for the CVE dashboard and AI review flow.

### AI draft review UX

The AI drafts panel is now a bit safer and easier to work through:

- split the old “Apply AI suggestion” action into two explicit choices:
  - **Fill OpenVEX form**: copies the AI recommendation into the form so it can be reviewed/edited in place
  - **Apply & next**: stages the recommendation and advances to the next AI draft
- added filtering for AI drafts by status transition, e.g. `unreviewed → fixed`, so a batch of suspicious recommendations can be reviewed or requeued together
- persist staged AI review queue items and AI work-list filters with the existing Zustand/localStorage pattern
- show when an AI queue package has multiple CVEs waiting for review
- added a **Clear all** button to the “Ask AI to review” drawer
- clarified that OpenVEX does not have a literal `version_overrides` field; version changes are represented by version-pinned OpenVEX statements
- tightened the AI reviewer prompt so it does not suggest conda-forge version overrides unless those versions are actually present in the prompt’s conda-forge data

I also pulled the repeated AI draft/queue lookup and row-building logic into shared helpers so the list view and “Apply & next” navigation use the same source of truth.

### Generated CVE sidecar freshness

We saw a case where a human CVE review had been merged, but the AI drafts panel could still show the same item because the committed `web/public` sidecars were stale. Pages regenerated fresh data during deploy, but the repository copy of the generated JSON could lag until a later CVE/AI workflow happened to refresh it.

To make that deterministic, this PR adds a dedicated `main` push workflow that regenerates and commits the CVE dashboard sidecars whenever the source CVE inputs change:

- `mappings/cves/**`
- `mappings/cve_contributions/**`
- `mappings/cve_ai_drafts/**`
- `mappings/cve_review_queue/**`
- relevant merge/validation scripts and schemas

That workflow now owns the committed generated dashboard payloads:

- `web/public/cves.json`
- `web/public/cves-index.json`
- `web/public/cve_packages/**`
- `web/public/cve_ai_drafts.json`
- `web/public/cve_ai_queue.json`

Because of that, the CVE refresh and AI review workflows no longer carry generated sidecars in their PRs. They only commit their source data, and the new post-merge workflow keeps the generated frontend data in sync on `main`.

Finally, the local frontend tasks now regenerate data before starting/building the app, so local development behaves like Pages deploy and does not accidentally use stale sidecars.

## Why

The main goal is to avoid reviewing stale AI drafts after a human review has already landed, and to make the AI review UI less error-prone when working through a queue. Generated files should be derived from source data in one predictable place instead of being refreshed opportunistically by several unrelated workflows.

## Validation

- `python -m py_compile scripts/cve_ai_review.py`
- `pixi run python` YAML parse check for `.github/workflows/*.yml`
- `pixi task list` includes the new `web-data` task
- `pixi run web-build`


## Screenshots

<img width="1440" height="1000" alt="ai-draft-detail" src="https://github.com/user-attachments/assets/0204e9bf-ba0b-4c73-8115-b6a338b63767" />
<img width="1440" height="1000" alt="ai-drafts-list" src="https://github.com/user-attachments/assets/45e1b4ed-2920-462d-a162-69ce94e042d3" />
<img width="1440" height="1000" alt="image" src="https://github.com/user-attachments/assets/299634ab-44fe-4aa5-8e0c-b4ae53c61bec" />
<img width="1440" height="1000" alt="ask-ai-drawer-clear" src="https://github.com/user-attachments/assets/863b2b75-2c19-4fdb-a585-f70c1ce8575c" />
