### PR TITLE
ci: auto-merge pipeline PRs behind a validate check

### DIFF
--- a/.github/workflows/automap.yml
+++ b/.github/workflows/automap.yml
@@ -69,8 +69,16 @@ jobs:
           cat /tmp/automap_pr_body.md
 
       - name: Open / update PR if mappings changed
+        id: pr
         uses: peter-evans/create-pull-request@v8
         with:
+          # PRs created with the default GITHUB_TOKEN can't trigger the
+          # validate workflow (GitHub's recursion guard), so the required
+          # check would never report and auto-merge would never fire. Use the
+          # PIPELINE_PAT secret when present; the fallback keeps the pipeline
+          # working before the secret exists — the PR just waits for a
+          # manual merge.
+          token: ${{ secrets.PIPELINE_PAT || github.token }}
           add-paths: |
             mappings/auto.json
             web/public/mappings.json
@@ -82,3 +90,19 @@ jobs:
           body-path: /tmp/automap_pr_body.md
           commit-message: "automap: refresh PURL mappings"
           delete-branch: true
+
+      - name: Enable auto-merge
+        if: steps.pr.outputs.pull-request-number
+        env:
+          # Same PAT as above: a merge performed by auto-merge enabled with
+          # GITHUB_TOKEN would not trigger the pages deploy on main.
+          GH_TOKEN: ${{ secrets.PIPELINE_PAT || github.token }}
+          PR: ${{ steps.pr.outputs.pull-request-number }}
+        run: |
+          set -euo pipefail
+          # Idempotent: when create-pull-request updates an existing PR the
+          # earlier auto-merge request is still active, and enabling it twice
+          # errors.
+          if [ -z "$(gh pr view "$PR" --json autoMergeRequest --jq '.autoMergeRequest // empty')" ]; then
+            gh pr merge --auto --squash "$PR"
+          fi

--- a/.github/workflows/cpe_discover.yml
+++ b/.github/workflows/cpe_discover.yml
@@ -117,8 +117,12 @@ jobs:
           cat /tmp/cpe_pr_body.md
 
       - name: Open / update PR
+        id: pr
         uses: peter-evans/create-pull-request@v8
         with:
+          # PRs created with the default GITHUB_TOKEN can't trigger the
+          # validate workflow (GitHub's recursion guard) — see automap.yml.
+          token: ${{ secrets.PIPELINE_PAT || github.token }}
           # Audit artifacts (candidates + vet) and the shipping contribution.
           # web/public/mappings.json is gitignored so won't be added even if
           # it appears in the workspace.
@@ -132,3 +136,19 @@ jobs:
           commit-message: "cpe: refresh CPE mappings"
           delete-branch: true
           body-path: /tmp/cpe_pr_body.md
+
+      - name: Enable auto-merge
+        if: steps.pr.outputs.pull-request-number
+        env:
+          # Same PAT as above: a merge performed by auto-merge enabled with
+          # GITHUB_TOKEN would not trigger the pages deploy on main.
+          GH_TOKEN: ${{ secrets.PIPELINE_PAT || github.token }}
+          PR: ${{ steps.pr.outputs.pull-request-number }}
+        run: |
+          set -euo pipefail
+          # Idempotent: when create-pull-request updates an existing PR the
+          # earlier auto-merge request is still active, and enabling it twice
+          # errors.
+          if [ -z "$(gh pr view "$PR" --json autoMergeRequest --jq '.autoMergeRequest // empty')" ]; then
+            gh pr merge --auto --squash "$PR"
+          fi

--- a/.github/workflows/download_counts.yml
+++ b/.github/workflows/download_counts.yml
@@ -116,8 +116,12 @@ jobs:
           cat /tmp/download_counts_pr_body.md
 
       - name: Open / update PR if counts changed
+        id: pr
         uses: peter-evans/create-pull-request@v8
         with:
+          # PRs created with the default GITHUB_TOKEN can't trigger the
+          # validate workflow (GitHub's recursion guard) — see automap.yml.
+          token: ${{ secrets.PIPELINE_PAT || github.token }}
           add-paths: |
             mappings/auto.json
             web/public/mappings.json
@@ -129,3 +133,19 @@ jobs:
           body-path: /tmp/download_counts_pr_body.md
           commit-message: "download-counts: refresh prefix.dev totals"
           delete-branch: true
+
+      - name: Enable auto-merge
+        if: steps.pr.outputs.pull-request-number
+        env:
+          # Same PAT as above: a merge performed by auto-merge enabled with
+          # GITHUB_TOKEN would not trigger the pages deploy on main.
+          GH_TOKEN: ${{ secrets.PIPELINE_PAT || github.token }}
+          PR: ${{ steps.pr.outputs.pull-request-number }}
+        run: |
+          set -euo pipefail
+          # Idempotent: when create-pull-request updates an existing PR the
+          # earlier auto-merge request is still active, and enabling it twice
+          # errors.
+          if [ -z "$(gh pr view "$PR" --json autoMergeRequest --jq '.autoMergeRequest // empty')" ]; then
+            gh pr merge --auto --squash "$PR"
+          fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,75 @@
+name: Validate mappings
+
+# PR-time gate for the scheduled data pipelines (automap, download-counts,
+# cpe-discover) and user contributions alike: rebuilds the served payload and
+# validates it before anything lands on main. The `validate` job is a
+# required status check on main (repo ruleset), which is what lets the
+# pipeline PRs auto-merge without a human rubber stamp.
+#
+# No `paths:` filter on purpose — a required check that a path filter skips
+# never reports a status, which would leave unrelated PRs stuck on
+# "Expected — waiting for status" forever.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: validate-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: prefix-dev/setup-pixi@v0.9.5
+        with:
+          pixi-version: latest
+          cache: true
+          environments: lite
+
+      - name: Rebuild served identity mapping payload
+        run: pixi run -e lite mappings:merge
+
+      - name: Validate identity mapping payload
+        run: pixi run -e lite mappings:validate
+
+      - name: Guard against mass removals in auto.json
+        # A pipeline bug or an upstream source returning empty shows up as a
+        # huge wave of deletions, and schema validation can't catch that — an
+        # empty-but-valid file passes. Compare package counts against the base
+        # branch and fail on a >20% drop. Intentional mass removals can still
+        # land: admins bypass the required check.
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF"
+          python3 - <<'PY'
+          import json
+          import subprocess
+          import sys
+
+          def package_count(rev):
+              show = subprocess.run(
+                  ["git", "show", f"{rev}:mappings/auto.json"],
+                  capture_output=True,
+                  text=True,
+              )
+              if show.returncode != 0:
+                  return 0
+              return len(json.loads(show.stdout).get("packages", {}))
+
+          before = package_count("FETCH_HEAD")
+          after = package_count("HEAD")
+          print(f"packages on base: {before:,}; on PR head: {after:,}")
+          if before >= 100 and after < 0.8 * before:
+              sys.exit(
+                  f"auto.json shrank from {before:,} to {after:,} packages "
+                  "(>20% drop) — refusing to validate."
+              )
+          PY


### PR DESCRIPTION
Makes the scheduled data pipelines self-merging so they no longer need a human rubber stamp, while user contributions keep requiring review.

## What changes

- **New `validate` workflow** runs on every PR to `main`: rebuilds the served payload (`mappings:merge`), validates it (`mappings:validate`), and guards against mass removals in `mappings/auto.json` (>20% package drop fails). This check becomes a required status check via a repo ruleset, so it is the gate that replaces manual approval.
- **automap / download-counts / cpe-discover** enable GitHub auto-merge (squash) on the PRs they open. Once `validate` is green, the PR merges itself and the pages deploy picks it up.
- **`create-pull-request` switches to a `PIPELINE_PAT` secret** (fine-grained PAT, falls back to `GITHUB_TOKEN`). Two reasons: PRs created by `GITHUB_TOKEN` cannot trigger the validate workflow, and merges from auto-merge enabled by `GITHUB_TOKEN` would not trigger the pages deploy on `main`.

## Transitional behavior (before the PAT secret exists)

Pipelines keep working exactly as today: the PR is created with `GITHUB_TOKEN`, the validate check never reports, and the PR waits for a manual merge. Nothing breaks — auto-merge just stays pending.

## Repo settings (done alongside this PR)

- Auto-merge enabled on the repo
- Ruleset on `main` requiring the `validate` check, with admin bypass for direct pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)