### PR TITLE
ci: mint pipeline tokens from a GitHub App

### DIFF
--- a/.github/workflows/automap.yml
+++ b/.github/workflows/automap.yml
@@ -68,17 +68,26 @@ jobs:
           echo "----- PR body preview -----"
           cat /tmp/automap_pr_body.md
 
+      - name: Mint pipeline bot token
+        # PRs created with the default GITHUB_TOKEN can't trigger the
+        # validate workflow (GitHub's recursion guard), so the required check
+        # would never report and auto-merge would never fire. Mint a
+        # short-lived token from the org-owned pipeline GitHub App instead.
+        # The step is skipped when the app isn't configured yet; the token
+        # fallback chain below then degrades to a PIPELINE_PAT secret and
+        # finally to GITHUB_TOKEN, where the PR just waits for a manual merge.
+        id: app-token
+        if: vars.PIPELINE_APP_ID
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.PIPELINE_APP_ID }}
+          private-key: ${{ secrets.PIPELINE_APP_PRIVATE_KEY }}
+
       - name: Open / update PR if mappings changed
         id: pr
         uses: peter-evans/create-pull-request@v8
         with:
-          # PRs created with the default GITHUB_TOKEN can't trigger the
-          # validate workflow (GitHub's recursion guard), so the required
-          # check would never report and auto-merge would never fire. Use the
-          # PIPELINE_PAT secret when present; the fallback keeps the pipeline
-          # working before the secret exists — the PR just waits for a
-          # manual merge.
-          token: ${{ secrets.PIPELINE_PAT || github.token }}
+          token: ${{ steps.app-token.outputs.token || secrets.PIPELINE_PAT || github.token }}
           add-paths: |
             mappings/auto.json
             web/public/mappings.json
@@ -94,9 +103,9 @@ jobs:
       - name: Enable auto-merge
         if: steps.pr.outputs.pull-request-number
         env:
-          # Same PAT as above: a merge performed by auto-merge enabled with
+          # Same token as above: a merge performed by auto-merge enabled with
           # GITHUB_TOKEN would not trigger the pages deploy on main.
-          GH_TOKEN: ${{ secrets.PIPELINE_PAT || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.PIPELINE_PAT || github.token }}
           PR: ${{ steps.pr.outputs.pull-request-number }}
         run: |
           set -euo pipefail

--- a/.github/workflows/cpe_discover.yml
+++ b/.github/workflows/cpe_discover.yml
@@ -116,13 +116,21 @@ jobs:
           echo "----- PR body preview -----"
           cat /tmp/cpe_pr_body.md
 
+      - name: Mint pipeline bot token
+        # PRs created with the default GITHUB_TOKEN can't trigger the
+        # validate workflow (GitHub's recursion guard) — see automap.yml.
+        id: app-token
+        if: vars.PIPELINE_APP_ID
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.PIPELINE_APP_ID }}
+          private-key: ${{ secrets.PIPELINE_APP_PRIVATE_KEY }}
+
       - name: Open / update PR
         id: pr
         uses: peter-evans/create-pull-request@v8
         with:
-          # PRs created with the default GITHUB_TOKEN can't trigger the
-          # validate workflow (GitHub's recursion guard) — see automap.yml.
-          token: ${{ secrets.PIPELINE_PAT || github.token }}
+          token: ${{ steps.app-token.outputs.token || secrets.PIPELINE_PAT || github.token }}
           # Audit artifacts (candidates + vet) and the shipping contribution.
           # web/public/mappings.json is gitignored so won't be added even if
           # it appears in the workspace.
@@ -140,9 +148,9 @@ jobs:
       - name: Enable auto-merge
         if: steps.pr.outputs.pull-request-number
         env:
-          # Same PAT as above: a merge performed by auto-merge enabled with
+          # Same token as above: a merge performed by auto-merge enabled with
           # GITHUB_TOKEN would not trigger the pages deploy on main.
-          GH_TOKEN: ${{ secrets.PIPELINE_PAT || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.PIPELINE_PAT || github.token }}
           PR: ${{ steps.pr.outputs.pull-request-number }}
         run: |
           set -euo pipefail

--- a/.github/workflows/download_counts.yml
+++ b/.github/workflows/download_counts.yml
@@ -115,13 +115,21 @@ jobs:
           echo "----- PR body preview -----"
           cat /tmp/download_counts_pr_body.md
 
+      - name: Mint pipeline bot token
+        # PRs created with the default GITHUB_TOKEN can't trigger the
+        # validate workflow (GitHub's recursion guard) — see automap.yml.
+        id: app-token
+        if: vars.PIPELINE_APP_ID
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.PIPELINE_APP_ID }}
+          private-key: ${{ secrets.PIPELINE_APP_PRIVATE_KEY }}
+
       - name: Open / update PR if counts changed
         id: pr
         uses: peter-evans/create-pull-request@v8
         with:
-          # PRs created with the default GITHUB_TOKEN can't trigger the
-          # validate workflow (GitHub's recursion guard) — see automap.yml.
-          token: ${{ secrets.PIPELINE_PAT || github.token }}
+          token: ${{ steps.app-token.outputs.token || secrets.PIPELINE_PAT || github.token }}
           add-paths: |
             mappings/auto.json
             web/public/mappings.json
@@ -137,9 +145,9 @@ jobs:
       - name: Enable auto-merge
         if: steps.pr.outputs.pull-request-number
         env:
-          # Same PAT as above: a merge performed by auto-merge enabled with
+          # Same token as above: a merge performed by auto-merge enabled with
           # GITHUB_TOKEN would not trigger the pages deploy on main.
-          GH_TOKEN: ${{ secrets.PIPELINE_PAT || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.PIPELINE_PAT || github.token }}
           PR: ${{ steps.pr.outputs.pull-request-number }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
Follow-up to #153: prefer an org-owned GitHub App over a personal PAT for the pipeline PRs.

- Each pipeline run mints a short-lived (1h) installation token via `actions/create-github-app-token@v2` — no long-lived credential in secrets, no expiry rotation, not tied to a personal account, and PRs are attributed to the app bot.
- The mint step is skipped when the `PIPELINE_APP_ID` variable isn't set; the token chain degrades to `PIPELINE_PAT`, then `GITHUB_TOKEN` (today's behavior: PR waits for manual merge).

Setup once merged: create the app under the prefix-dev org (Contents RW + Pull requests RW, webhook off, install on this repo only), then set the `PIPELINE_APP_ID` variable and `PIPELINE_APP_PRIVATE_KEY` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)