### PR TITLE
ci: bump create-github-app-token to v3

### DIFF
--- a/.github/workflows/automap.yml
+++ b/.github/workflows/automap.yml
@@ -78,7 +78,7 @@ jobs:
         # finally to GITHUB_TOKEN, where the PR just waits for a manual merge.
         id: app-token
         if: vars.PIPELINE_APP_ID
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.PIPELINE_APP_ID }}
           private-key: ${{ secrets.PIPELINE_APP_PRIVATE_KEY }}

--- a/.github/workflows/cpe_discover.yml
+++ b/.github/workflows/cpe_discover.yml
@@ -121,7 +121,7 @@ jobs:
         # validate workflow (GitHub's recursion guard) — see automap.yml.
         id: app-token
         if: vars.PIPELINE_APP_ID
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.PIPELINE_APP_ID }}
           private-key: ${{ secrets.PIPELINE_APP_PRIVATE_KEY }}

--- a/.github/workflows/download_counts.yml
+++ b/.github/workflows/download_counts.yml
@@ -120,7 +120,7 @@ jobs:
         # validate workflow (GitHub's recursion guard) — see automap.yml.
         id: app-token
         if: vars.PIPELINE_APP_ID
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.PIPELINE_APP_ID }}
           private-key: ${{ secrets.PIPELINE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
v2 runs on Node 20, which GitHub Actions force-switches to Node 24 on 2026-06-16 (per the deprecation annotation on today's automap run). v3 supports Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)