### PR TITLE
Make CPE identities editable in the mapping editor

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -76,6 +76,16 @@ export function App() {
     const altsMatch =
       currentAltSet.size === editAltSet.size &&
       [...currentAltSet].every((p) => editAltSet.has(p));
+    // CPEs are a set; an edit that ends up matching the package's current
+    // list is untouched, so the contribution keeps omitting the field.
+    const currentCpeSet = new Set(focusedPkg.cpes ?? []);
+    const cpesMatch =
+      newEdit.cpes === undefined ||
+      (newEdit.cpes.length === currentCpeSet.size &&
+        newEdit.cpes.every((c) => currentCpeSet.has(c)));
+    if (newEdit.cpes !== undefined && cpesMatch) {
+      newEdit = { ...newEdit, cpes: undefined };
+    }
     const isSame =
       !newEdit.unmapped &&
       newEdit.purl === (focusedPkg.purl ?? "") &&
@@ -83,6 +93,7 @@ export function App() {
       (newEdit.namespace || "") === (focusedPkg.namespace || "") &&
       newEdit.pkgName === (focusedPkg.pkg_name ?? focusedPkg.name) &&
       altsMatch &&
+      cpesMatch &&
       !newEdit.note;
     setEdits((prev) => {
       const next = { ...prev };

--- a/web/src/components/MappingEditor.tsx
+++ b/web/src/components/MappingEditor.tsx
@@ -106,9 +106,11 @@ export function MappingEditor({
     pkgName: edit?.pkgName ?? p.pkg_name ?? auto.pkg_name ?? p.name,
     purl: edit?.purl ?? p.purl ?? auto.purl ?? "",
     alternative_purls: edit?.alternative_purls ?? currentAlternativePurls,
+    cpes: edit?.cpes,
     unmapped: edit?.unmapped ?? p.unmapped ?? p.purl === null,
     note: edit?.note ?? "",
   };
+  const effCpes = eff.cpes ?? p.cpes ?? [];
 
   const isEdited = !!edit;
   const isVerified =
@@ -158,6 +160,15 @@ export function MappingEditor({
       alternative_purls: [...eff.alternative_purls, purl],
       unmapped: false,
     });
+  }
+
+  function removeCpe(cpe: string): void {
+    onEdit({ ...eff, cpes: effCpes.filter((c) => c !== cpe) });
+  }
+
+  function addCpe(cpe: string): void {
+    if (!isValidCpe(cpe) || effCpes.includes(cpe)) return;
+    onEdit({ ...eff, cpes: [...effCpes, cpe] });
   }
 
   function updatePurlString(str: string): void {
@@ -521,28 +532,18 @@ export function MappingEditor({
           </div>
         </Section>
 
-        {p.cpes && p.cpes.length > 0 && (
-          <Section
-            title="CPE identities"
-            subtitle="Read-only package identity metadata used by downstream NVD/CVE tooling. PURL edits do not change these CPEs."
-          >
-            <div
-              style={{
-                background: t.surface,
-                border: `1px solid ${t.border}`,
-                borderRadius: 12,
-                padding: 14,
-                display: "flex",
-                flexWrap: "wrap",
-                gap: 8,
-              }}
-            >
-              {p.cpes.map((cpe) => (
-                <CpeChip key={cpe} cpe={cpe} theme={theme} />
-              ))}
-            </div>
-          </Section>
-        )}
+        <Section
+          title="CPE identities"
+          subtitle="Package identity metadata used by downstream NVD/CVE tooling. Edits are recorded in the mapping alongside the PURL."
+        >
+          <CpeList
+            theme={theme}
+            cpes={effCpes}
+            isEdited={eff.cpes !== undefined}
+            onRemove={removeCpe}
+            onAdd={addCpe}
+          />
+        </Section>
 
         {p.status === "verified" && p.approved_by && !isEdited && (
           <Section title="Verification">
@@ -926,6 +927,176 @@ function ResultingPurls({
             }}
           >
             Add another
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+/** Mirrors CPE23_RE in scripts/validate.py — CPE 2.3 vendor/product prefix. */
+const CPE23_RE = /^cpe:2\.3:[aho*-]:[^:]+:[^:]+(?::[^:]*){0,10}$/;
+
+function isValidCpe(cpe: string): boolean {
+  return CPE23_RE.test(cpe);
+}
+
+function CpeList({
+  theme,
+  cpes,
+  isEdited,
+  onRemove,
+  onAdd,
+}: {
+  theme: Theme;
+  cpes: string[];
+  isEdited: boolean;
+  onRemove: (cpe: string) => void;
+  onAdd: (cpe: string) => void;
+}) {
+  const t = theme.t;
+  const [draft, setDraft] = useState("");
+  const draftValid = isValidCpe(draft.trim());
+
+  return (
+    <div
+      style={{
+        background: t.surface,
+        border: `1px solid ${t.border}`,
+        borderRadius: 12,
+        padding: 14,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          marginBottom: 10,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 11,
+            color: t.fg2,
+            fontWeight: 600,
+            letterSpacing: ".04em",
+            textTransform: "uppercase",
+          }}
+        >
+          CPE identities
+        </span>
+        <span
+          style={{
+            fontSize: 10,
+            fontWeight: 700,
+            background: theme.dark ? "#0a0d11" : "#ece8df",
+            color: t.fg2,
+            padding: "0 6px",
+            borderRadius: 3,
+            fontVariantNumeric: "tabular-nums",
+          }}
+        >
+          {cpes.length}
+        </span>
+        <span style={{ fontSize: 11, color: t.fg3 }}>
+          all are recorded in the mapping
+        </span>
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {cpes.length === 0 && (
+          <div
+            style={{
+              fontSize: 12,
+              color: t.fg3,
+              fontStyle: "italic",
+              padding: "6px 0",
+            }}
+          >
+            No CPEs.
+          </div>
+        )}
+
+        {cpes.map((cpe) => (
+          <div
+            key={cpe}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              padding: "7px 10px",
+              background: t.surface2,
+              border: `1px solid ${t.border}`,
+              borderRadius: 8,
+            }}
+          >
+            <CpeChip cpe={cpe} theme={theme} edited={isEdited} />
+            <div style={{ flex: 1 }} />
+            <button
+              onClick={() => onRemove(cpe)}
+              title="Remove"
+              style={{
+                background: "transparent",
+                border: `1px solid ${t.border}`,
+                borderRadius: 6,
+                color: t.fg2,
+                width: 24,
+                height: 24,
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                cursor: "pointer",
+              }}
+            >
+              <Glyph name="close" size={11} />
+            </button>
+          </div>
+        ))}
+
+        <form
+          onSubmit={(e) =>
+            handleDraftSubmit(e, () => {
+              if (draftValid) {
+                onAdd(draft.trim());
+                setDraft("");
+              }
+            })
+          }
+          style={{ display: "flex", gap: 6, marginTop: 4 }}
+        >
+          <input
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder="cpe:2.3:a:vendor:product"
+            style={{
+              flex: 1,
+              background: t.surface,
+              color: t.fg1,
+              border: `1px solid ${t.border}`,
+              borderRadius: 8,
+              padding: "6px 10px",
+              fontSize: 12,
+              fontFamily: "JetBrains Mono, monospace",
+              outline: "none",
+            }}
+          />
+          <button
+            type="submit"
+            disabled={!draftValid}
+            style={{
+              background: t.surface2,
+              border: `1px solid ${t.border}`,
+              borderRadius: 8,
+              color: t.fg1,
+              fontSize: 12,
+              fontWeight: 600,
+              padding: "0 12px",
+              cursor: draftValid ? "pointer" : "not-allowed",
+              opacity: draftValid ? 1 : 0.5,
+            }}
+          >
+            Add
           </button>
         </form>
       </div>

--- a/web/src/components/PRDrawer.tsx
+++ b/web/src/components/PRDrawer.tsx
@@ -92,7 +92,7 @@ export function PRDrawer({
     const lines: string[] = [];
     // Headline summary: counts by transition so a reviewer can size up the
     // PR at a glance before scrolling.
-    const stats = { approved: 0, overrode: 0, unmapped: 0, updated: 0 };
+    const stats = { approved: 0, overrode: 0, unmapped: 0, updated: 0, cpes: 0 };
     const bullets: string[] = [];
 
     for (const [id, e] of editEntries) {
@@ -123,24 +123,32 @@ export function PRDrawer({
       const matchesAuto =
         !!pkg.auto?.purl && afterPrimary === pkg.auto.purl;
 
+      // CPE diff — only present when the edit touched CPEs (e.cpes defined).
+      const beforeCpes = pkg.cpes ?? [];
+      const afterCpes = e.cpes ?? beforeCpes;
+      const beforeCpeSet = new Set(beforeCpes);
+      const afterCpeSet = new Set(afterCpes);
+      const cpeAdded = afterCpes.filter((c) => !beforeCpeSet.has(c));
+      const cpeRemoved = beforeCpes.filter((c) => !afterCpeSet.has(c));
+      const purlChanged = added.length > 0 || removed.length > 0 || primaryChanged;
+
       // Classify the transition for the headline counter and prefix tag.
       let tag = "approved auto guess";
       if (e.unmapped) {
         stats.unmapped++;
         tag = "marked as no-PURL";
-      } else if (pkg.status === "verified" && (added.length || removed.length || primaryChanged)) {
+      } else if (pkg.status === "verified" && purlChanged) {
         stats.updated++;
         tag = "updated verified mapping";
-      } else if (
-        pkg.auto?.purl &&
-        !matchesAuto &&
-        (added.length || removed.length || primaryChanged)
-      ) {
+      } else if (pkg.auto?.purl && !matchesAuto && purlChanged) {
         stats.overrode++;
         tag = "overrode auto guess";
       } else if (matchesAuto && (added.length || removed.length)) {
         stats.updated++;
         tag = "approved auto guess + added alternates";
+      } else if (!purlChanged && (cpeAdded.length || cpeRemoved.length)) {
+        stats.cpes++;
+        tag = "updated CPEs";
       } else {
         stats.approved++;
         tag = "approved auto guess";
@@ -175,6 +183,12 @@ export function PRDrawer({
       if (e.unmapped) {
         bullets.push(`  - now: _unmapped_`);
       }
+      for (const cpe of cpeRemoved) {
+        bullets.push(`  - \`-\` \`${cpe}\` (cpe)`);
+      }
+      for (const cpe of cpeAdded) {
+        bullets.push(`  - \`+\` \`${cpe}\` (cpe)`);
+      }
       if (e.note) bullets.push(`  - _${e.note}_`);
     }
 
@@ -183,6 +197,7 @@ export function PRDrawer({
     if (stats.approved) parts.push(`${stats.approved} approved`);
     if (stats.overrode) parts.push(`${stats.overrode} overrode auto`);
     if (stats.updated) parts.push(`${stats.updated} updated existing`);
+    if (stats.cpes) parts.push(`${stats.cpes} updated CPEs`);
     if (stats.unmapped) parts.push(`${stats.unmapped} marked no-PURL`);
 
     lines.push(
@@ -368,6 +383,18 @@ export function PRDrawer({
                     const beforeSet = new Set(beforePurls);
                     const afterSet = new Set(afterPurls);
 
+                    // CPE diff lines — only when the edit touched CPEs.
+                    const beforeCpes = pkg.cpes ?? [];
+                    const afterCpes = e.cpes ?? beforeCpes;
+                    const beforeCpeSet = new Set(beforeCpes);
+                    const afterCpeSet = new Set(afterCpes);
+                    const cpeRemoved = beforeCpes.filter(
+                      (c) => !afterCpeSet.has(c),
+                    );
+                    const cpeAdded = afterCpes.filter(
+                      (c) => !beforeCpeSet.has(c),
+                    );
+
                     return (
                       <div
                         key={id}
@@ -497,6 +524,70 @@ export function PRDrawer({
                               </div>
                             );
                           })}
+                          {cpeRemoved.map((cpe, i) => (
+                            <div
+                              key={`cr-${i}`}
+                              style={{
+                                display: "flex",
+                                alignItems: "center",
+                                gap: 6,
+                                color: theme.dark ? "#ff8e6a" : "#a8401b",
+                                background: theme.dark
+                                  ? "rgba(255,142,106,.08)"
+                                  : "#ffece5",
+                                padding: "2px 6px",
+                                borderRadius: 3,
+                                marginTop: 2,
+                              }}
+                            >
+                              <span style={{ opacity: 0.7 }}>−</span>
+                              <span>{cpe}</span>
+                              <span
+                                style={{
+                                  fontSize: 9,
+                                  fontWeight: 700,
+                                  letterSpacing: ".06em",
+                                  textTransform: "uppercase",
+                                  color: t.fg3,
+                                  marginLeft: "auto",
+                                }}
+                              >
+                                cpe
+                              </span>
+                            </div>
+                          ))}
+                          {cpeAdded.map((cpe, i) => (
+                            <div
+                              key={`ca-${i}`}
+                              style={{
+                                display: "flex",
+                                alignItems: "center",
+                                gap: 6,
+                                color: theme.dark ? "#9adf6d" : "#5b9b2c",
+                                background: theme.dark
+                                  ? "rgba(154,223,109,.08)"
+                                  : "#ecf5dc",
+                                padding: "2px 6px",
+                                borderRadius: 3,
+                                marginTop: 2,
+                              }}
+                            >
+                              <span style={{ opacity: 0.7 }}>+</span>
+                              <span>{cpe}</span>
+                              <span
+                                style={{
+                                  fontSize: 9,
+                                  fontWeight: 700,
+                                  letterSpacing: ".06em",
+                                  textTransform: "uppercase",
+                                  color: t.fg3,
+                                  marginLeft: "auto",
+                                }}
+                              >
+                                cpe
+                              </span>
+                            </div>
+                          ))}
                         </div>
                         {e.note && (
                           <div

--- a/web/src/components/Primitives.tsx
+++ b/web/src/components/Primitives.tsx
@@ -346,7 +346,15 @@ export function PurlChip({
  *  matcher actually keys on; the ``cpe:2.3:a:`` prefix is dimmed.
  *  Trailing wildcard/version segments (after ``product``) are stripped from
  *  display since the curated entries in ``manual.json`` only fix the head. */
-export function CpeChip({ cpe, theme }: { cpe: string; theme: Theme }) {
+export function CpeChip({
+  cpe,
+  theme,
+  edited = false,
+}: {
+  cpe: string;
+  theme: Theme;
+  edited?: boolean;
+}) {
   const t = theme.t;
   const m = cpe.match(/^(cpe:2\.3:)([aoh]):([^:]+):([^:]+)/);
   return (
@@ -358,7 +366,13 @@ export function CpeChip({ cpe, theme }: { cpe: string; theme: Theme }) {
         fontSize: 12,
         padding: "3px 7px",
         borderRadius: 6,
-        background: theme.dark ? "#0a0d11" : "#f5f1e7",
+        background: edited
+          ? theme.dark
+            ? "#1a2233"
+            : "#e9efff"
+          : theme.dark
+            ? "#0a0d11"
+            : "#f5f1e7",
         border: `1px solid ${t.border}`,
         color: t.fg1,
         letterSpacing: "-0.01em",

--- a/web/src/data/types.ts
+++ b/web/src/data/types.ts
@@ -102,6 +102,9 @@ export type Edit = {
   pkgName: string;
   purl: string;
   alternative_purls: string[];
+  /** Full replacement CPE list. undefined = untouched — the contribution
+   *  omits the field so the cpe-pipeline layer keeps owning CPEs. */
+  cpes?: string[];
   unmapped: boolean;
   note: string;
   approved?: boolean;

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -247,6 +247,9 @@ type EditPayload = {
   pkgName: string;
   purl: string;
   alternative_purls: string[];
+  /** Full replacement CPE list; absent when the edit didn't touch CPEs so
+   *  the cpe-pipeline layer keeps owning them. */
+  cpes?: string[];
   unmapped: boolean;
   note: string;
 };
@@ -277,9 +280,15 @@ function buildContributionFile(
 ): string {
   const packages: Record<string, unknown> = {};
   for (const [name, edit] of Object.entries(edits)) {
+    // CPE identity is independent of PURL existence, so the list rides along
+    // even for unmapped packages. Like alternative_purls, a present list
+    // (including []) replaces all earlier layers; an absent one leaves the
+    // cpe-pipeline layer in charge.
+    const cpes = Array.isArray(edit.cpes) ? edit.cpes : undefined;
     if (edit.unmapped) {
       packages[name] = {
         unmapped: true,
+        cpes,
         note: edit.note || undefined,
       };
     } else {
@@ -292,6 +301,7 @@ function buildContributionFile(
         // lets merge_mappings keep auto-generated alternatives from the base
         // layer, which makes reviewer removals ineffective.
         alternative_purls: edit.alternative_purls,
+        cpes,
         note: edit.note || undefined,
       };
     }


### PR DESCRIPTION
## What

The "CPE identities" section in the mapping editor was read-only. This makes it editable — a simple list with remove buttons and a validated add input — so reviewers can fix wrong or missing CPEs straight from the UI. CPE edits ride the existing edit → contribution-file → PR flow.


## How

- **`Edit.cpes?: string[]`** — `undefined` means untouched: the contribution file omits the key entirely, so the cpe-pipeline layer keeps owning CPEs for packages the reviewer didn't touch. A present list (including `[]`) is a full replacement, the same replace-all invariant `alternative_purls` uses (#66).
- **MappingEditor** — the section now always renders (so CPEs can be added to packages that have none) with per-CPE remove buttons and an add form validated against the same regex as `scripts/validate.py` (`CPE23_RE`).
- **App.tsx** — an edit whose CPE list is set-equal to the package's current list is normalized back to `undefined`, so PURL-only edits never snapshot CPEs; CPE changes also count in the staged/no-op detection.
- **PRDrawer** — staged-change cards show `−`/`+` CPE diff lines, the generated PR body lists them with a `(cpe)` marker, and CPE-only edits are tagged "updated CPEs" in the headline counts.
- **Worker** — `EditPayload` gains `cpes` and `buildContributionFile` passes it through for both mapped and unmapped packages (CPE identity is independent of PURL existence).

No backend changes: `merge_mappings.py` already includes `cpes` in `REVIEWED_MAPPING_FIELDS` and `validate.py` already validates the field in contributions.

## Verification

- `tsc --noEmit` + `vite build` pass in `web/`
- `tsc --noEmit` passes in `worker/`
- No automated UI tests exist in web/worker; the editor flow was not exercised in a browser as part of this PR.

This is how it looks like:

<img width="793" height="364" alt="image" src="https://github.com/user-attachments/assets/a4e807a2-6b90-4c16-8103-53295803c177" />

