### PR TITLE
feat(mappings): publish provenance for each package identity

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - "web/**"
       - "mappings/**"
+      - "scripts/merge_mappings.py"
+      - "scripts/validate.py"
+      - "tests/**"
+      - "pixi.toml"
+      - "pixi.lock"
       - ".github/workflows/pages.yml"
   workflow_dispatch:
 
@@ -38,6 +43,9 @@ jobs:
 
       - name: Refresh served identity mapping payload
         run: pixi run -e lite mappings:merge
+
+      - name: Test identity mapping contract
+        run: pixi run -e lite mappings:test
 
       - name: Validate identity mapping payload
         run: pixi run -e lite mappings:validate

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Rebuild served identity mapping payload
         run: pixi run -e lite mappings:merge
 
+      - name: Test identity mapping contract
+        run: pixi run -e lite mappings:test
+
       - name: Validate identity mapping payload
         run: pixi run -e lite mappings:validate
 

--- a/README.md
+++ b/README.md
@@ -31,13 +31,58 @@ The core object is a conda-forge package identity record:
     "cpe:2.3:a:gnu:ncurses",
     "cpe:2.3:a:invisible-island:ncurses"
   ],
-  "status": "verified"
+  "status": "verified",
+  "identities": [
+    {
+      "kind": "purl",
+      "role": "primary",
+      "value": "pkg:github/ThomasDickey/ncurses-snapshots",
+      "provenance": {
+        "availability": "available",
+        "source": "manual",
+        "review": {
+          "status": "verified",
+          "reviewer": "nichmor",
+          "reviewed_at": "2026-05-25T00:00:00Z"
+        }
+      }
+    },
+    {
+      "kind": "cpe",
+      "role": "associated",
+      "value": "cpe:2.3:a:gnu:ncurses",
+      "provenance": { "availability": "unavailable" }
+    }
+  ]
 }
 ```
 
 PURLs identify source/package ecosystem coordinates. CPEs identify NVD
 vendor/product coordinates. CPE strings stored here are identity-level prefixes;
 this repository does not store CVE affected ranges or per-CVE version decisions.
+
+### Published identity provenance contract
+
+The generated payload's `identities` array is the authoritative per-identity
+view for downstream consumers:
+
+- `kind: "purl", role: "primary"` identifies the primary PURL. Its provenance
+  contains a required review `status`, a nullable `reviewer`, and an optional
+  `reviewed_at`. Automatic primary identities additionally retain their
+  available confidence and source evidence.
+- `kind: "purl", role: "alternative"` identifies an alternative PURL. Detailed
+  alternatives retain their own `source` and `confidence`; bare string
+  alternatives use `availability: "unavailable"`. They never inherit the
+  primary PURL's review object.
+- `kind: "cpe", role: "associated"` identifies a CPE prefix. The current source
+  model does not retain CPE-level attribution, so its provenance is explicitly
+  `unavailable` and never inferred from primary review state.
+
+Identity order is deterministic: primary PURL, alternatives in source order,
+then CPEs in source order. A missing primary PURL produces no primary identity.
+Every published confidence is a finite JSON number; `NaN` and infinities are
+rejected. Contribution precedence compares timezone-aware timestamps as UTC
+instants, with the on-disk filename as the deterministic tie-breaker.
 
 ## Sources and outputs
 
@@ -51,6 +96,27 @@ this repository does not store CVE affected ranges or per-CVE version decisions.
 | `web/public/mappings.json` | generated full mapping bundle |
 | `web/public/mappings-index.json` | generated compact index for the web app |
 | `web/public/mapping_packages/*.json` | generated sharded package detail payloads |
+
+### Payload versions and compatibility
+
+PFX-1826 advances `mappings.json` from schema 1 to **2**,
+`mappings-index.json` from schema 2 to **3**, and mapping detail shards from
+schema 1 to **2**. These versions add `identities` without removing or changing
+legacy `purl`, `alternative_purls`, `cpes`, `status`, or attribution fields.
+This additive compatibility window lets existing clients continue reading the
+legacy fields while provenance-aware clients migrate to `identities`. New
+clients should reject unknown future schema versions rather than guessing.
+The validator accepts the immediately preceding schemas during this window but
+requires and validates the per-identity contract on current schemas.
+
+The payload deployed by the Pages workflow is canonical. The checked-in
+`mappings-index.json` and shard files are build inputs/cache for the app, not a
+supported raw-consumer contract on their own: a source change can leave them
+stale until `mappings:merge` regenerates the bundle, index, and all shards
+atomically. Consumers should use the deployed Pages payload rather than mixing
+checked-in generations. Routine changes should not commit the 257-file shard
+churn unless repository policy explicitly requires an atomic generated-data
+refresh.
 
 ## PURL flow
 
@@ -82,6 +148,12 @@ CPE discovery is part of identity mapping, not CVE assignment. The retained CPE
 pipeline proposes NVD vendor/product prefixes and promotes accepted mappings as
 normal contribution files. Those CPEs then flow through `scripts.merge_mappings`
 into the public mapping payload.
+
+CPE list behavior is intentionally unchanged: a contribution containing `cpes`
+replaces the prior list. Changing that to union semantics could make explicit
+UI/pipeline removals impossible, so PFX-1826 does not silently change it. A
+separate follow-up should decide whether CPE contributions need an explicit
+replace/union operation before any union behavior is introduced.
 
 ```mermaid
 flowchart TD
@@ -138,6 +210,7 @@ Run these checks before opening a PR:
 
 ```sh
 pixi run -e lite mappings:merge
+pixi run -e lite mappings:test
 pixi run -e lite mappings:validate
 pixi run app:check
 ```

--- a/pixi.toml
+++ b/pixi.toml
@@ -27,6 +27,7 @@ python = ">=3.13,<3.14"
 [feature.lite.tasks]
 "mappings:merge" = "python -m scripts.merge_mappings"
 "mappings:validate" = "python -m scripts.validate"
+"mappings:test" = "python -m unittest discover -s tests -v"
 
 [environments]
 default = ["lite"]
@@ -131,13 +132,20 @@ depends-on = ["web:install", "worker:install"]
 description = "Install web and Worker npm dependencies"
 
 [tasks."app:check"]
-depends-on = ["mappings:validate", "web:build", "worker:typecheck"]
-description = "Validate data, build the web app, and typecheck the Worker"
+cmd = "python -m unittest discover -s tests -v && npm --prefix web test && python -m scripts.merge_mappings && python -m scripts.validate && npm --prefix web run build && npm --prefix worker run typecheck"
+depends-on = ["app:install"]
+description = "Run contract tests, validate data, build the web app, and typecheck the Worker"
 
 [tasks."web:install"]
 cmd = "npm install"
 cwd = "web"
 description = "Install frontend npm dependencies"
+
+[tasks."web:test"]
+cmd = "npm test"
+cwd = "web"
+depends-on = ["web:install"]
+description = "Run browser payload decoder contract tests"
 
 [tasks."web:data"]
 depends-on = [

--- a/scripts/merge_mappings.py
+++ b/scripts/merge_mappings.py
@@ -1,18 +1,8 @@
-"""Merge auto.json + manual.json + contributions/*.json into the single
-payload the frontend consumes.
+"""Merge reviewed identity mapping layers into the published payloads.
 
-**Layering, oldest → newest (newer wins):**
-
-1. ``mappings/auto.json`` — automap output.
-2. ``mappings/manual.json`` — legacy human-curated overrides (single file).
-3. ``mappings/contributions/*.json`` — per-PR contribution files, sorted by
-   ``timestamp`` (or filename if absent). Each PR drops one new file with a
-   unique name, so concurrent PRs never conflict on disk; the merge below
-   resolves them in chronological order.
-
-Output: ``web/public/mappings.json`` for backwards compatibility, plus the split
-payload ``web/public/mappings-index.json`` and sharded
-``web/public/mapping_packages/*.json`` detail files.
+Layering is auto.json, manual.json, then contributions/*.json ordered by their
+trusted timestamp and on-disk filename.  Published legacy fields remain
+additive-compatible while ``identities`` carries provenance for each identity.
 """
 
 from __future__ import annotations
@@ -20,8 +10,11 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
+import re
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_AUTO = ROOT / "mappings" / "auto.json"
@@ -32,55 +25,20 @@ DEFAULT_OUT = ROOT / "web" / "public" / "mappings.json"
 DEFAULT_INDEX_OUT = ROOT / "web" / "public" / "mappings-index.json"
 DEFAULT_DETAIL_DIR = ROOT / "web" / "public" / "mapping_packages"
 
-
-def _load_json(path: Path, default: dict) -> dict:
-    if not path.exists():
-        return default
-    try:
-        return json.loads(path.read_text())
-    except json.JSONDecodeError:
-        return default
-
-
-def _load_downloads(path: Path) -> dict[str, int]:
-    """Return ``{name: total_count}`` from ``mappings/top_downloads.json``.
-
-    The file is produced by ``scripts.top_downloads`` and tracks prefix.dev
-    download counts. Missing file → empty mapping, so the merge stays usable
-    on fresh checkouts.
-    """
-    if not path.exists():
-        return {}
-    try:
-        data = json.loads(path.read_text())
-    except json.JSONDecodeError:
-        return {}
-    out: dict[str, int] = {}
-    for row in data.get("packages") or []:
-        name = row.get("name")
-        count = row.get("total_count")
-        if isinstance(name, str) and isinstance(count, int):
-            out[name] = count
-    return out
-
-
-def _load_contributions(directory: Path) -> list[dict]:
-    if not directory.exists():
-        return []
-    entries: list[dict] = []
-    for f in sorted(directory.glob("*.json")):
-        try:
-            data = json.loads(f.read_text())
-        except json.JSONDecodeError:
-            continue
-        data.setdefault("_filename", f.name)
-        # Fall back to filename for sort key if timestamp is missing/invalid.
-        if not isinstance(data.get("timestamp"), str):
-            data["timestamp"] = f.stem
-        entries.append(data)
-    entries.sort(key=lambda d: (d.get("timestamp") or "", d.get("_filename")))
-    return entries
-
+BUNDLE_SCHEMA_VERSION = 2
+INDEX_SCHEMA_VERSION = 3
+DETAIL_SCHEMA_VERSION = 2
+SOURCE_SCHEMA_VERSION = 1
+REVIEW_STATUSES = {"auto-unverified", "auto-verified", "verified", "unmapped", "edited"}
+PRIMARY_SOURCES = {"auto", "manual"}
+ALTERNATIVE_SOURCES = {
+    "recipe-source",
+    "recipe-deps",
+    "recipe-source+recipe-deps",
+    "parselmouth-artifact",
+}
+CPE23_RE = re.compile(r"^cpe:2\.3:[aho*\-]:[^:]+:[^:]+(?::[^:]*){0,10}$")
+PURL_RE = re.compile(r"^pkg:[a-z][a-z0-9.+-]*/[^\s?#]+(?:\?[^\s#]+)?(?:#[^\s]+)?$")
 
 REVIEWED_MAPPING_FIELDS = (
     "purl",
@@ -93,10 +51,255 @@ REVIEWED_MAPPING_FIELDS = (
     "note",
     "status",
 )
+PRIMARY_REVIEW_FIELDS = ("purl", "type", "namespace", "pkg_name", "unmapped", "status")
+_INTERNAL_PRIMARY = "_primary_identity_provenance"
+
+
+def _duplicate_safe_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key {key!r}")
+        result[key] = value
+    return result
+
+
+def _reject_nonstandard_number(value: str) -> None:
+    raise ValueError(f"non-standard numeric value {value}")
+
+
+def _load_json(path: Path, default: dict | None = None) -> dict[str, Any]:
+    if not path.exists():
+        if default is not None:
+            return default
+        raise ValueError(f"{path}: file does not exist")
+    try:
+        value = json.loads(
+            path.read_text(),
+            object_pairs_hook=_duplicate_safe_object,
+            parse_constant=_reject_nonstandard_number,
+        )
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise ValueError(f"{path}: invalid JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: payload must be an object")
+    return value
+
+
+def _parse_timestamp(value: Any, label: str) -> datetime:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be a valid timezone-aware ISO-8601 timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(
+            f"{label} must be a valid timezone-aware ISO-8601 timestamp"
+        ) from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError(f"{label} must include a timezone offset")
+    return parsed.astimezone(UTC)
+
+
+def _valid_timestamp(value: Any) -> bool:
+    try:
+        _parse_timestamp(value, "timestamp")
+    except ValueError:
+        return False
+    return True
+
+
+def _finite_number(value: Any) -> bool:
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, (int, float))
+        and math.isfinite(value)
+    )
+
+
+def _require_string(value: Any, label: str, *, nullable: bool = False) -> None:
+    if nullable and value is None:
+        return
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(
+            f"{label} must be a non-empty string" + (" or null" if nullable else "")
+        )
+
+
+def _validate_purl(value: Any, label: str) -> None:
+    _require_string(value, label)
+    if not PURL_RE.fullmatch(value):
+        raise ValueError(f"{label} is not a valid package URL: {value!r}")
+
+
+def _validate_cpes(value: Any, label: str) -> None:
+    if not isinstance(value, list):
+        raise ValueError(f"{label} must be an array")
+    seen: set[str] = set()
+    for index, cpe in enumerate(value):
+        item_label = f"{label}[{index}]"
+        _require_string(cpe, item_label)
+        if not CPE23_RE.fullmatch(cpe):
+            raise ValueError(
+                f"{item_label} is not a valid CPE 2.3 vendor/product prefix"
+            )
+        if cpe in seen:
+            raise ValueError(f"{item_label} duplicates {cpe!r}")
+        seen.add(cpe)
+
+
+def _validate_alternatives(value: Any, label: str, primary: Any) -> None:
+    if not isinstance(value, list):
+        raise ValueError(f"{label} must be an array")
+    seen: set[str] = set()
+    for index, alternative in enumerate(value):
+        item_label = f"{label}[{index}]"
+        if isinstance(alternative, str):
+            purl = alternative
+            _validate_purl(purl, item_label)
+        elif isinstance(alternative, dict):
+            allowed = {"purl", "type", "namespace", "pkg_name", "confidence", "source"}
+            extras = set(alternative) - allowed
+            missing = allowed - set(alternative)
+            if extras or missing:
+                raise ValueError(
+                    f"{item_label} detailed alternative fields must be exactly {sorted(allowed)}; "
+                    f"missing={sorted(missing)}, forbidden={sorted(extras)}"
+                )
+            purl = alternative["purl"]
+            _validate_purl(purl, f"{item_label}.purl")
+            _require_string(alternative["type"], f"{item_label}.type")
+            _require_string(
+                alternative["namespace"], f"{item_label}.namespace", nullable=True
+            )
+            _require_string(alternative["pkg_name"], f"{item_label}.pkg_name")
+            confidence = alternative["confidence"]
+            if not _finite_number(confidence):
+                raise ValueError(f"{item_label}.confidence must be a finite number")
+            if alternative["source"] not in ALTERNATIVE_SOURCES:
+                raise ValueError(
+                    f"{item_label}.source is unsupported: {alternative['source']!r}"
+                )
+        else:
+            raise ValueError(f"{item_label} must be a PURL string or detailed object")
+        if purl in seen:
+            raise ValueError(f"{item_label} duplicates {purl!r}")
+        if purl == primary:
+            raise ValueError(f"{item_label} duplicates the primary PURL")
+        seen.add(purl)
+
+
+def _validate_package_entry(entry: Any, label: str, *, auto: bool) -> None:
+    if not isinstance(entry, dict):
+        raise ValueError(f"{label} must be an object")
+    if _INTERNAL_PRIMARY in entry or "_filename" in entry:
+        raise ValueError(f"{label} uses a reserved internal field")
+    purl = entry.get("purl")
+    if purl is not None:
+        _validate_purl(purl, f"{label}.purl")
+    for key in ("type", "namespace", "pkg_name"):
+        if key in entry:
+            _require_string(entry[key], f"{label}.{key}", nullable=True)
+    if "alternative_purls" in entry and entry["alternative_purls"] is not None:
+        _validate_alternatives(
+            entry["alternative_purls"], f"{label}.alternative_purls", purl
+        )
+    if "cpes" in entry and entry["cpes"] is not None:
+        _validate_cpes(entry["cpes"], f"{label}.cpes")
+    if "unmapped" in entry and not isinstance(entry["unmapped"], bool):
+        raise ValueError(f"{label}.unmapped must be a boolean")
+    if "status" in entry and entry["status"] not in REVIEW_STATUSES:
+        raise ValueError(f"{label}.status is unsupported: {entry['status']!r}")
+    if entry.get("status") == "unmapped" and entry.get("unmapped") is not True:
+        raise ValueError(f"{label}.status unmapped requires unmapped: true")
+    if "approved_by" in entry:
+        _require_string(entry["approved_by"], f"{label}.approved_by")
+    if "approved_at" in entry and not _valid_timestamp(entry["approved_at"]):
+        raise ValueError(f"{label}.approved_at must be a valid ISO-8601 timestamp")
+    if auto:
+        confidence = entry.get("confidence")
+        if not _finite_number(confidence):
+            raise ValueError(f"{label}.confidence must be a finite number")
+        sources = entry.get("sources")
+        if not isinstance(sources, list) or any(
+            not isinstance(source, str) or not source for source in sources
+        ):
+            raise ValueError(f"{label}.sources must be an array of non-empty strings")
+
+
+def _validate_source_payload(
+    payload: dict[str, Any], label: str, *, kind: str
+) -> dict[str, dict]:
+    if payload.get("schema_version") != SOURCE_SCHEMA_VERSION:
+        raise ValueError(
+            f"{label}: unsupported schema_version {payload.get('schema_version')!r}; "
+            f"supported version is {SOURCE_SCHEMA_VERSION}"
+        )
+    if "_filename" in payload:
+        raise ValueError(
+            f"{label}: _filename is reserved and cannot control merge ordering"
+        )
+    packages = payload.get("packages")
+    if not isinstance(packages, dict):
+        raise ValueError(f"{label}: packages must be an object")
+    for name, entry in packages.items():
+        _require_string(name, f"{label}: package identifier")
+        _validate_package_entry(entry, f"{label}:{name}", auto=kind == "auto")
+    if kind == "manual":
+        attribution = {
+            "approved_by": payload.get("updated_by"),
+            "approved_at": payload.get("updated_at"),
+        }
+        for name, entry in packages.items():
+            if _reviews_primary(entry):
+                _effective_attribution(entry, attribution, f"{label}:{name}")
+    if kind == "contribution":
+        _require_string(payload.get("author"), f"{label}.author")
+        if not _valid_timestamp(payload.get("timestamp")):
+            raise ValueError(f"{label}.timestamp must be a valid ISO-8601 timestamp")
+    return packages
+
+
+def _load_downloads(path: Path) -> dict[str, int]:
+    if not path.exists():
+        return {}
+    data = _load_json(path)
+    rows = data.get("packages")
+    if not isinstance(rows, list):
+        raise ValueError(f"{path}: packages must be an array")
+    out: dict[str, int] = {}
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise ValueError(f"{path}: packages[{index}] must be an object")
+        name, count = row.get("name"), row.get("total_count")
+        _require_string(name, f"{path}: packages[{index}].name")
+        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+            raise ValueError(
+                f"{path}: packages[{index}].total_count must be a non-negative integer"
+            )
+        if name in out:
+            raise ValueError(f"{path}: duplicate package identifier {name!r}")
+        out[name] = count
+    return out
+
+
+def _load_contributions(directory: Path) -> list[tuple[dict[str, Any], str]]:
+    if not directory.exists():
+        return []
+    entries: list[tuple[dict[str, Any], str]] = []
+    for path in sorted(directory.glob("*.json")):
+        data = _load_json(path)
+        _validate_source_payload(data, str(path), kind="contribution")
+        entries.append((data, path.name))
+    entries.sort(
+        key=lambda item: (
+            _parse_timestamp(item[0]["timestamp"], f"{directory / item[1]}.timestamp"),
+            item[1],
+        )
+    )
+    return entries
 
 
 def _auto_snapshot(auto_entry: dict) -> dict:
-    """Return the preserved automatic guess shown as secondary UI context."""
     return {
         "purl": auto_entry.get("purl"),
         "type": auto_entry.get("type"),
@@ -108,20 +311,19 @@ def _auto_snapshot(auto_entry: dict) -> dict:
     }
 
 
-def _reviewed_mapping_patch(override: dict) -> dict:
-    """Return fields that a human review layer owns.
+def _reviews_primary(override: dict) -> bool:
+    return any(
+        key in override and override[key] is not None for key in PRIMARY_REVIEW_FIELDS
+    )
 
-    ``alternative_purls`` is intentionally replace-all when present. This is the
-    core #66 invariant: if a reviewer removes an auto-suggested PURL, the latest
-    reviewed list (even ``[]``) must replace the auto list rather than be merged
-    with it. Omitted fields keep the previous layer for backwards compatibility.
-    """
-    patch: dict = {}
-    for key in REVIEWED_MAPPING_FIELDS:
-        if key in override and override[key] is not None:
-            patch[key] = override[key]
-    patch.setdefault("status", "verified")
-    return patch
+
+def _effective_attribution(override: dict, attribution: dict, label: str) -> dict:
+    reviewer = override.get("approved_by", attribution.get("approved_by"))
+    reviewed_at = override.get("approved_at", attribution.get("approved_at"))
+    _require_string(reviewer, f"{label}.approved_by")
+    if not _valid_timestamp(reviewed_at):
+        raise ValueError(f"{label}.approved_at must be a valid ISO-8601 timestamp")
+    return {"approved_by": reviewer, "approved_at": reviewed_at}
 
 
 def _apply_reviewed_override(
@@ -130,16 +332,113 @@ def _apply_reviewed_override(
     name: str,
     override: dict,
     attribution: dict,
+    *,
+    label: str,
 ) -> None:
     base = merged.get(name, {"name": name})
-    merged[name] = {
-        **base,
-        **_reviewed_mapping_patch(override),
-        "source": "manual",
-        **attribution,
+    reviews_primary = _reviews_primary(override)
+    patch = {
+        key: override[key]
+        for key in REVIEWED_MAPPING_FIELDS
+        if key in override and override[key] is not None
     }
-    if name in auto_packages:
-        merged[name]["auto"] = _auto_snapshot(auto_packages[name])
+
+    # Preserve the legacy package-level merge behavior during the additive
+    # window: every reviewed layer marks the package manual/verified and owns
+    # legacy attribution, including the 848 CPE-only package overrides.
+    legacy_attribution = {
+        key: value for key, value in attribution.items() if value is not None
+    }
+    patch.setdefault("status", "verified")
+    result = {**base, **patch, "source": "manual", **legacy_attribution}
+
+    if reviews_primary:
+        # Per-package manual attribution owns the new typed identity even when
+        # the historical package-level fields omitted it. Contributions carry
+        # the same current attribution at file level. Do not rewrite legacy
+        # attribution merely to make the additive identity view convenient.
+        current_attribution = _effective_attribution(override, attribution, label)
+        if override.get("unmapped") is True:
+            result.update(
+                {
+                    "purl": None,
+                    "type": None,
+                    "namespace": None,
+                    "pkg_name": None,
+                    "alternative_purls": [],
+                    "unmapped": True,
+                    "status": "unmapped",
+                }
+            )
+        else:
+            result["unmapped"] = False
+        result[_INTERNAL_PRIMARY] = {
+            "availability": "available",
+            "source": "manual",
+            "review": {
+                "status": result["status"],
+                "reviewer": current_attribution["approved_by"],
+                "reviewed_at": current_attribution["approved_at"],
+            },
+        }
+
+    if name in auto_packages and "auto" not in result:
+        result["auto"] = _auto_snapshot(auto_packages[name])
+    merged[name] = result
+
+
+def _identity_records(entry: dict) -> list[dict]:
+    identities: list[dict] = []
+    if isinstance(entry.get("purl"), str) and not entry.get("unmapped"):
+        identities.append(
+            {
+                "kind": "purl",
+                "role": "primary",
+                "value": entry["purl"],
+                "provenance": entry[_INTERNAL_PRIMARY],
+            }
+        )
+    for alternative in entry.get("alternative_purls") or []:
+        if isinstance(alternative, str):
+            identity = {
+                "kind": "purl",
+                "role": "alternative",
+                "value": alternative,
+                "provenance": {"availability": "unavailable"},
+            }
+        else:
+            identity = {
+                "kind": "purl",
+                "role": "alternative",
+                "value": alternative["purl"],
+                "coordinates": {
+                    "type": alternative["type"],
+                    "namespace": alternative["namespace"],
+                    "pkg_name": alternative["pkg_name"],
+                },
+                "provenance": {
+                    "availability": "available",
+                    "source": alternative["source"],
+                    "confidence": alternative["confidence"],
+                },
+            }
+        identities.append(identity)
+    for cpe in entry.get("cpes") or []:
+        identities.append(
+            {
+                "kind": "cpe",
+                "role": "associated",
+                "value": cpe,
+                "provenance": {"availability": "unavailable"},
+            }
+        )
+    return identities
+
+
+def _with_identities(entry: dict) -> dict:
+    result = {key: value for key, value in entry.items() if key != _INTERNAL_PRIMARY}
+    result["identities"] = _identity_records(entry)
+    return result
 
 
 def _index_package(name: str, entry: dict, detail_path: str) -> dict:
@@ -153,10 +452,11 @@ def _index_package(name: str, entry: dict, detail_path: str) -> dict:
         "status": entry.get("status"),
         "download_count": entry.get("download_count"),
         "detail_path": detail_path,
+        "identities": entry.get("identities", []),
     }
     for key in ("alternative_purls", "unmapped", "cpes"):
         if key in entry and entry.get(key) is not None:
-            out[key] = entry.get(key)
+            out[key] = entry[key]
     return out
 
 
@@ -164,29 +464,96 @@ def _write_split_payload(payload: dict, index_out: Path, detail_dir: Path) -> No
     detail_dir.mkdir(parents=True, exist_ok=True)
     for stale in detail_dir.glob("*.json"):
         stale.unlink()
-
     index_packages: dict[str, dict] = {}
     shards: dict[str, dict[str, dict]] = {}
-    for name, entry in sorted((payload.get("packages") or {}).items()):
+    for name, entry in sorted(payload["packages"].items()):
         shard = hashlib.sha256(name.encode()).hexdigest()[:2]
         detail_path = f"mapping_packages/{shard}.json"
-        detail = {**entry, "name": name}
-        shards.setdefault(shard, {})[name] = detail
+        shards.setdefault(shard, {})[name] = {**entry, "name": name}
         index_packages[name] = _index_package(name, entry, detail_path)
-
     for shard, packages in sorted(shards.items()):
-        shard_payload = {"schema_version": 1, "packages": packages}
         (detail_dir / f"{shard}.json").write_text(
-            json.dumps(shard_payload, separators=(",", ":")) + "\n"
+            json.dumps(
+                {"schema_version": DETAIL_SCHEMA_VERSION, "packages": packages},
+                separators=(",", ":"),
+                allow_nan=False,
+            )
+            + "\n"
         )
-
     index_payload = {
-        **{k: v for k, v in payload.items() if k != "packages"},
-        "schema_version": 2,
+        **{key: value for key, value in payload.items() if key != "packages"},
+        "schema_version": INDEX_SCHEMA_VERSION,
         "packages": index_packages,
     }
     index_out.parent.mkdir(parents=True, exist_ok=True)
-    index_out.write_text(json.dumps(index_payload, separators=(",", ":")) + "\n")
+    index_out.write_text(
+        json.dumps(index_payload, separators=(",", ":"), allow_nan=False) + "\n"
+    )
+
+
+def _build_published_packages(
+    auto_data: dict[str, Any],
+    manual_data: dict[str, Any],
+    contrib_files: list[tuple[dict[str, Any], str]],
+    downloads_by_name: dict[str, int],
+    *,
+    auto_label: str,
+    manual_label: str,
+    contributions_label: Path,
+) -> dict[str, dict]:
+    """Replay the validated source layers into canonical published records."""
+    auto_packages = _validate_source_payload(auto_data, auto_label, kind="auto")
+    manual_packages = _validate_source_payload(manual_data, manual_label, kind="manual")
+    merged: dict[str, dict] = {}
+    for name, entry in auto_packages.items():
+        status = "auto-verified" if entry.get("auto_verified") else "auto-unverified"
+        primary = {
+            "availability": "available",
+            "source": "auto",
+            "confidence": entry["confidence"],
+            "sources": entry["sources"],
+            "review": {"status": status, "reviewer": None},
+        }
+        merged[name] = {
+            **entry,
+            "status": status,
+            "source": "auto",
+            _INTERNAL_PRIMARY: primary,
+        }
+
+    legacy_attribution = {
+        "approved_by": manual_data.get("updated_by"),
+        "approved_at": manual_data.get("updated_at"),
+    }
+    for name, override in manual_packages.items():
+        _apply_reviewed_override(
+            merged,
+            auto_packages,
+            name,
+            override,
+            legacy_attribution,
+            label=f"{manual_label}:{name}",
+        )
+
+    for contribution, filename in contrib_files:
+        attribution = {
+            "approved_by": contribution["author"],
+            "approved_at": contribution["timestamp"],
+        }
+        for name, override in contribution["packages"].items():
+            _apply_reviewed_override(
+                merged,
+                auto_packages,
+                name,
+                override,
+                attribution,
+                label=f"{contributions_label / filename}:{name}",
+            )
+
+    for name, entry in merged.items():
+        if entry.get("download_count") is None and name in downloads_by_name:
+            entry["download_count"] = downloads_by_name[name]
+    return {name: _with_identities(entry) for name, entry in merged.items()}
 
 
 def main(
@@ -197,54 +564,26 @@ def main(
     out: Path = DEFAULT_OUT,
     index_out: Path = DEFAULT_INDEX_OUT,
     detail_dir: Path = DEFAULT_DETAIL_DIR,
+    generated_at: str | None = None,
 ) -> None:
-    auto_data = _load_json(auto, {"packages": {}})
-    manual_data = _load_json(manual, {"packages": {}})
+    auto_data = _load_json(auto)
+    manual_data = _load_json(manual)
     contrib_files = _load_contributions(contributions)
     downloads_by_name = _load_downloads(downloads)
-
-    merged: dict[str, dict] = {}
-
-    # Layer 1: auto.
-    for name, entry in auto_data.get("packages", {}).items():
-        status = "auto-verified" if entry.get("auto_verified") else "auto-unverified"
-        merged[name] = {**entry, "status": status, "source": "auto"}
-
-    # Layer 2: manual.json (legacy single-file overrides).
-    legacy_attribution = {
-        "approved_by": manual_data.get("updated_by"),
-        "approved_at": manual_data.get("updated_at"),
-    }
-    auto_packages = auto_data.get("packages", {})
-    for name, override in manual_data.get("packages", {}).items():
-        _apply_reviewed_override(
-            merged,
-            auto_packages,
-            name,
-            override,
-            {k: v for k, v in legacy_attribution.items() if v is not None},
-        )
-
-    # Layer 3: contributions, oldest → newest.
-    for contrib in contrib_files:
-        attribution = {
-            "approved_by": contrib.get("author"),
-            "approved_at": contrib.get("timestamp"),
-        }
-        for name, override in (contrib.get("packages") or {}).items():
-            _apply_reviewed_override(merged, auto_packages, name, override, attribution)
-
-    # Fallback for entries that don't carry ``download_count`` from auto.json
-    # (e.g. manual-only or contribution-only names). Hydration of auto.json
-    # is owned by ``scripts.hydrate_downloads``; we don't clobber its values
-    # here, even when the name is absent from top_downloads.json.
-    for name, entry in merged.items():
-        if entry.get("download_count") is None and name in downloads_by_name:
-            entry["download_count"] = downloads_by_name[name]
-
+    published = _build_published_packages(
+        auto_data,
+        manual_data,
+        contrib_files,
+        downloads_by_name,
+        auto_label=str(auto),
+        manual_label=str(manual),
+        contributions_label=contributions,
+    )
+    auto_packages = auto_data["packages"]
+    manual_packages = manual_data["packages"]
     payload = {
-        "schema_version": 1,
-        "generated_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        "schema_version": BUNDLE_SCHEMA_VERSION,
+        "generated_at": generated_at or datetime.now(UTC).isoformat(timespec="seconds"),
         "auto_generated_at": auto_data.get("generated_at"),
         "manual_updated_at": manual_data.get("updated_at"),
         "contribution_count": len(contrib_files),
@@ -252,18 +591,16 @@ def main(
         if downloads_by_name
         else None,
         "channel": auto_data.get("channel", "conda-forge"),
-        "package_count": len(merged),
-        "packages": dict(sorted(merged.items())),
+        "package_count": len(published),
+        "packages": dict(sorted(published.items())),
     }
-
     out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(json.dumps(payload, indent=2) + "\n")
+    out.write_text(json.dumps(payload, indent=2, allow_nan=False) + "\n")
     _write_split_payload(payload, index_out, detail_dir)
     print(
-        f"Merged auto={len(auto_data.get('packages', {}))} + "
-        f"manual={len(manual_data.get('packages', {}))} + "
+        f"Merged auto={len(auto_packages)} + manual={len(manual_packages)} + "
         f"contributions={len(contrib_files)} → {out}, {index_out}, {detail_dir} "
-        f"({len(merged)} packages)"
+        f"({len(published)} packages)"
     )
 
 

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -1,77 +1,71 @@
-"""Validate package identity mapping payloads.
-
-This repository owns conda-forge package identity mappings only: PURLs and CPEs.
-CVE assignment, VEX review, AI CVE drafts, and SBOM-derived findings are owned by
-downstream consumers.
-
-Checks performed:
-
-* ``web/public/mappings.json`` preserves reviewed ``alternative_purls`` lists
-  from ``mappings/manual.json`` and ``mappings/contributions/*.json`` exactly.
-* ``web/public/mappings-index.json`` references existing shard files under
-  ``web/public/mapping_packages/`` and every referenced package appears in its
-  shard.
-* every CPE value in manual/contribution/generated mapping payloads is a CPE
-  2.3 string prefix (``cpe:2.3:<part>:<vendor>:<product>`` or longer).
-
-Run via ``pixi run -e lite mappings:validate``.
-"""
+"""Validate source and published package identity mapping contracts."""
 
 from __future__ import annotations
 
 import argparse
-import json
-import re
+import math
 import sys
 from pathlib import Path
 from typing import Any
 
+from scripts import merge_mappings
+
 ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_AUTO_MAPPINGS = ROOT / "mappings" / "auto.json"
 DEFAULT_MANUAL_MAPPINGS = ROOT / "mappings" / "manual.json"
 DEFAULT_MAPPING_CONTRIB_DIR = ROOT / "mappings" / "contributions"
 DEFAULT_MAPPINGS_BUNDLE = ROOT / "web" / "public" / "mappings.json"
 DEFAULT_MAPPINGS_INDEX = ROOT / "web" / "public" / "mappings-index.json"
 DEFAULT_MAPPINGS_DETAIL_DIR = ROOT / "web" / "public" / "mapping_packages"
 
-CPE23_RE = re.compile(r"^cpe:2\.3:[aho\*\-]:[^:]+:[^:]+(?::[^:]*){0,10}$")
+CPE23_RE = merge_mappings.CPE23_RE
+PURL_RE = merge_mappings.PURL_RE
+SUPPORTED_BUNDLE_SCHEMAS = {1, 2}
+SUPPORTED_INDEX_SCHEMAS = {2, 3}
+SUPPORTED_DETAIL_SCHEMAS = {1, 2}
+CURRENT_BUNDLE_SCHEMA = 2
+CURRENT_INDEX_SCHEMA = 3
+CURRENT_DETAIL_SCHEMA = 2
+REVIEW_STATUSES = merge_mappings.REVIEW_STATUSES
+PRIMARY_SOURCES = merge_mappings.PRIMARY_SOURCES
+ALTERNATIVE_SOURCES = merge_mappings.ALTERNATIVE_SOURCES
 
 
 def _load(path: Path) -> dict[str, Any]:
-    return json.loads(path.read_text())
+    return merge_mappings._load_json(path)
 
 
 def _rel(path: Path) -> Path | str:
     return path.relative_to(ROOT) if path.is_relative_to(ROOT) else path
 
 
+def _valid_timestamp(value: Any) -> bool:
+    return merge_mappings._valid_timestamp(value)
+
+
 def _purl_list(value: Any) -> list[str]:
-    out: list[str] = []
-    for item in value or []:
-        if isinstance(item, str):
-            out.append(item)
-        elif isinstance(item, dict) and isinstance(item.get("purl"), str):
-            out.append(item["purl"])
-    return out
-
-
-def _load_mapping_contributions(
-    directory: Path, errors: list[str]
-) -> list[dict[str, Any]]:
-    if not directory.exists():
+    if not isinstance(value, list):
         return []
-    entries: list[dict[str, Any]] = []
-    for path in sorted(directory.glob("*.json")):
-        try:
-            data = _load(path)
-        except json.JSONDecodeError as exc:
-            errors.append(f"{_rel(path)}: invalid JSON: {exc}")
-            continue
-        data.setdefault("_filename", path.name)
-        if not isinstance(data.get("timestamp"), str):
-            data["timestamp"] = path.stem
-        entries.append(data)
-    entries.sort(key=lambda d: (d.get("timestamp") or "", d.get("_filename")))
-    return entries
+    return [
+        item if isinstance(item, str) else item.get("purl")
+        for item in value
+        if isinstance(item, (str, dict))
+    ]
+
+
+def _validate_schema_version(
+    payload: dict[str, Any], label: str, supported: set[int], errors: list[str]
+) -> int | None:
+    version = payload.get("schema_version")
+    if isinstance(version, bool) or not isinstance(version, int):
+        errors.append(f"{label}: schema_version must be an integer")
+        return None
+    if version not in supported:
+        errors.append(
+            f"{label}: unsupported schema_version {version}; supported versions are {sorted(supported)}"
+        )
+        return None
+    return version
 
 
 def _validate_cpes(value: Any, label: str, errors: list[str]) -> None:
@@ -81,46 +75,459 @@ def _validate_cpes(value: Any, label: str, errors: list[str]) -> None:
         errors.append(f"{label}: cpes must be an array")
         return
     seen: set[str] = set()
-    for i, cpe in enumerate(value):
-        item_label = f"{label}.cpes[{i}]"
-        if not isinstance(cpe, str):
-            errors.append(f"{item_label}: CPE must be a string")
-            continue
-        if cpe in seen:
-            errors.append(f"{item_label}: duplicate CPE {cpe!r}")
-        seen.add(cpe)
-        if not CPE23_RE.match(cpe):
+    for index, cpe in enumerate(value):
+        item_label = f"{label}.cpes[{index}]"
+        if not isinstance(cpe, str) or not cpe:
+            errors.append(f"{item_label}: CPE must be a non-empty string")
+        elif not CPE23_RE.fullmatch(cpe):
             errors.append(
                 f"{item_label}: {cpe!r} is not a valid CPE 2.3 vendor/product prefix"
             )
+        if isinstance(cpe, str) and cpe in seen:
+            errors.append(f"{item_label}: duplicate CPE {cpe!r}")
+        if isinstance(cpe, str):
+            seen.add(cpe)
+
+
+def _validate_published_confidences(
+    entry: dict[str, Any], label: str, errors: list[str]
+) -> None:
+    if "confidence" in entry and not merge_mappings._finite_number(entry["confidence"]):
+        errors.append(f"{label}.confidence: confidence must be a finite number")
+    auto = entry.get("auto")
+    if auto is not None:
+        if not isinstance(auto, dict):
+            errors.append(f"{label}.auto: must be an object")
+        elif not merge_mappings._finite_number(auto.get("confidence")):
+            errors.append(
+                f"{label}.auto.confidence: confidence must be a finite number"
+            )
+    alternatives = entry.get("alternative_purls")
+    if isinstance(alternatives, list):
+        for index, alternative in enumerate(alternatives):
+            if isinstance(alternative, dict) and not merge_mappings._finite_number(
+                alternative.get("confidence")
+            ):
+                errors.append(
+                    f"{label}.alternative_purls[{index}].confidence: "
+                    "confidence must be a finite number"
+                )
+
+
+def _error_extra_fields(
+    value: dict, allowed: set[str], label: str, errors: list[str]
+) -> None:
+    extras = set(value) - allowed
+    if extras:
+        errors.append(f"{label}: forbidden fields {sorted(extras)}")
+
+
+def _validate_identity_contract(
+    entry: dict[str, Any], label: str, errors: list[str]
+) -> None:
+    identities = entry.get("identities")
+    if not isinstance(identities, list):
+        errors.append(f"{label}: identities must be an array")
+        return
+
+    expected: list[dict[str, Any]] = []
+    purl = entry.get("purl")
+    unmapped = entry.get("unmapped") is True
+    if isinstance(purl, str) and not unmapped:
+        # The exact primary provenance is checked structurally below; source
+        # layer regeneration checks attribution equality against source data.
+        expected.append({"kind": "purl", "role": "primary", "value": purl})
+    alternatives = entry.get("alternative_purls") or []
+    if not isinstance(alternatives, list):
+        errors.append(f"{label}: alternative_purls must be an array or null")
+        alternatives = []
+    for alternative in alternatives:
+        value = (
+            alternative
+            if isinstance(alternative, str)
+            else alternative.get("purl")
+            if isinstance(alternative, dict)
+            else None
+        )
+        expected.append(
+            {
+                "kind": "purl",
+                "role": "alternative",
+                "value": value,
+                "source": alternative,
+            }
+        )
+    cpes = entry.get("cpes") or []
+    if not isinstance(cpes, list):
+        errors.append(f"{label}: cpes must be an array or null")
+        cpes = []
+    for cpe in cpes:
+        expected.append({"kind": "cpe", "role": "associated", "value": cpe})
+
+    seen: set[str] = set()
+    actual_summary: list[tuple[Any, Any, Any]] = []
+    for index, identity in enumerate(identities):
+        identity_label = f"{label}.identities[{index}]"
+        if not isinstance(identity, dict):
+            errors.append(f"{identity_label}: identity must be an object")
+            continue
+        kind, role, value = (
+            identity.get("kind"),
+            identity.get("role"),
+            identity.get("value"),
+        )
+        actual_summary.append((kind, role, value))
+        allowed_identity = {"kind", "role", "value", "provenance"}
+        if kind == "purl" and role == "alternative":
+            allowed_identity.add("coordinates")
+        _error_extra_fields(identity, allowed_identity, identity_label, errors)
+        if not isinstance(value, str) or not value:
+            errors.append(f"{identity_label}: value must be a non-empty string")
+        elif kind == "purl" and not PURL_RE.fullmatch(value):
+            errors.append(f"{identity_label}: value is not a valid PURL")
+        elif kind == "cpe" and not CPE23_RE.fullmatch(value):
+            errors.append(f"{identity_label}: value is not a valid CPE")
+        if isinstance(value, str):
+            if value in seen:
+                errors.append(f"{identity_label}: duplicate identity value {value!r}")
+            seen.add(value)
+
+        provenance = identity.get("provenance")
+        if not isinstance(provenance, dict):
+            errors.append(f"{identity_label}: provenance must be an object")
+            continue
+
+        if kind == "purl" and role == "primary":
+            allowed_provenance = {
+                "availability",
+                "source",
+                "review",
+                "confidence",
+                "sources",
+            }
+            _error_extra_fields(
+                provenance, allowed_provenance, f"{identity_label}.provenance", errors
+            )
+            if provenance.get("availability") != "available":
+                errors.append(f"{identity_label}: primary provenance must be available")
+            source = provenance.get("source")
+            if source not in PRIMARY_SOURCES:
+                errors.append(
+                    f"{identity_label}: unsupported primary source {source!r}"
+                )
+            review = provenance.get("review")
+            if not isinstance(review, dict):
+                errors.append(f"{identity_label}: primary review is required")
+            else:
+                _error_extra_fields(
+                    review,
+                    {"status", "reviewer", "reviewed_at"},
+                    f"{identity_label}.provenance.review",
+                    errors,
+                )
+                status = review.get("status")
+                if status not in REVIEW_STATUSES:
+                    errors.append(
+                        f"{identity_label}: unsupported review status {status!r}"
+                    )
+                if (
+                    "reviewer" not in review
+                    or review.get("reviewer") is not None
+                    and (
+                        not isinstance(review.get("reviewer"), str)
+                        or not review.get("reviewer")
+                    )
+                ):
+                    errors.append(
+                        f"{identity_label}: reviewer must be a non-empty string or null"
+                    )
+                if "reviewed_at" in review and not _valid_timestamp(
+                    review["reviewed_at"]
+                ):
+                    errors.append(
+                        f"{identity_label}: reviewed_at must be a valid ISO-8601 timestamp"
+                    )
+                if source == "auto":
+                    if status not in {"auto-unverified", "auto-verified"}:
+                        errors.append(
+                            f"{identity_label}: automatic primary has invalid review status"
+                        )
+                    if review.get("reviewer") is not None or "reviewed_at" in review:
+                        errors.append(
+                            f"{identity_label}: automatic primary cannot have human attribution"
+                        )
+                elif source == "manual":
+                    if status not in {"verified", "edited"}:
+                        errors.append(
+                            f"{identity_label}: manual primary has invalid review status"
+                        )
+                    if not isinstance(review.get("reviewer"), str) or not review.get(
+                        "reviewer"
+                    ):
+                        errors.append(
+                            f"{identity_label}: manual primary reviewer is required"
+                        )
+                    if not _valid_timestamp(review.get("reviewed_at")):
+                        errors.append(
+                            f"{identity_label}: manual primary reviewed_at is required"
+                        )
+            if source == "auto":
+                confidence = provenance.get("confidence")
+                if (
+                    isinstance(confidence, bool)
+                    or not isinstance(confidence, (int, float))
+                    or not math.isfinite(confidence)
+                ):
+                    errors.append(
+                        f"{identity_label}: automatic confidence must be a finite number"
+                    )
+                sources = provenance.get("sources")
+                if not isinstance(sources, list) or any(
+                    not isinstance(item, str) or not item for item in sources
+                ):
+                    errors.append(
+                        f"{identity_label}: automatic sources must be an array of non-empty strings"
+                    )
+            elif "confidence" in provenance or "sources" in provenance:
+                errors.append(
+                    f"{identity_label}: manual primary cannot carry automatic confidence/sources"
+                )
+
+        elif kind == "purl" and role == "alternative":
+            alternative_index = (
+                len(
+                    [
+                        x
+                        for x in actual_summary
+                        if x[0] == "purl" and x[1] == "alternative"
+                    ]
+                )
+                - 1
+            )
+            source_alternative = (
+                alternatives[alternative_index]
+                if 0 <= alternative_index < len(alternatives)
+                else None
+            )
+            if isinstance(source_alternative, str):
+                if provenance != {"availability": "unavailable"}:
+                    errors.append(
+                        f"{identity_label}: bare alternative provenance must be exactly unavailable"
+                    )
+                if "coordinates" in identity:
+                    errors.append(
+                        f"{identity_label}: bare alternative cannot have coordinates"
+                    )
+            elif isinstance(source_alternative, dict):
+                exact_provenance = {
+                    "availability": "available",
+                    "source": source_alternative.get("source"),
+                    "confidence": source_alternative.get("confidence"),
+                }
+                exact_coordinates = {
+                    key: source_alternative.get(key)
+                    for key in ("type", "namespace", "pkg_name")
+                }
+                if provenance != exact_provenance:
+                    errors.append(
+                        f"{identity_label}: detailed alternative provenance does not exactly match source"
+                    )
+                if identity.get("coordinates") != exact_coordinates:
+                    errors.append(
+                        f"{identity_label}: detailed alternative coordinates do not exactly match source"
+                    )
+                if provenance.get("source") not in ALTERNATIVE_SOURCES:
+                    errors.append(f"{identity_label}: unsupported alternative source")
+                confidence = provenance.get("confidence")
+                if (
+                    isinstance(confidence, bool)
+                    or not isinstance(confidence, (int, float))
+                    or not math.isfinite(confidence)
+                ):
+                    errors.append(
+                        f"{identity_label}: alternative confidence must be a finite number"
+                    )
+            else:
+                errors.append(
+                    f"{identity_label}: alternative has no valid legacy source"
+                )
+
+        elif kind == "cpe" and role == "associated":
+            if set(identity) != {"kind", "role", "value", "provenance"}:
+                errors.append(f"{identity_label}: CPE contains forbidden fields")
+            if provenance != {"availability": "unavailable"}:
+                errors.append(
+                    f"{identity_label}: CPE provenance must be exactly unavailable"
+                )
+        else:
+            errors.append(
+                f"{identity_label}: unsupported identity kind/role {kind!r}/{role!r}"
+            )
+
+    expected_summary = [
+        (item["kind"], item["role"], item["value"]) for item in expected
+    ]
+    if actual_summary != expected_summary:
+        errors.append(
+            f"{label}: identities do not exactly match ordered legacy identities"
+        )
+    if isinstance(purl, str) and purl in _purl_list(alternatives):
+        errors.append(f"{label}: primary PURL must not appear as an alternative")
+    if unmapped:
+        if entry.get("status") != "unmapped":
+            errors.append(f"{label}: unmapped package status must be unmapped")
+        for key in ("purl", "type", "namespace", "pkg_name"):
+            if entry.get(key) is not None:
+                errors.append(f"{label}: unmapped package must clear {key}")
+        if alternatives:
+            errors.append(f"{label}: unmapped package must clear alternative_purls")
+        if any(
+            item[:2] in {("purl", "primary"), ("purl", "alternative")}
+            for item in actual_summary
+        ):
+            errors.append(f"{label}: unmapped package must not publish PURL identities")
+
+
+def _load_mapping_contributions(
+    directory: Path, errors: list[str]
+) -> list[dict[str, Any]]:
+    try:
+        return [data for data, _ in merge_mappings._load_contributions(directory)]
+    except ValueError as exc:
+        errors.append(str(exc))
+        return []
+
+
+def validate_source_payloads(
+    auto_path: Path, manual_path: Path, contrib_dir: Path, errors: list[str]
+) -> bool:
+    try:
+        auto = _load(auto_path)
+        manual = _load(manual_path)
+        merge_mappings._validate_source_payload(auto, str(_rel(auto_path)), kind="auto")
+        merge_mappings._validate_source_payload(
+            manual, str(_rel(manual_path)), kind="manual"
+        )
+        merge_mappings._load_contributions(contrib_dir)
+    except ValueError as exc:
+        errors.append(str(exc))
+    return auto_path.exists() and manual_path.exists()
 
 
 def validate_source_cpes(
+    manual_path: Path, contrib_dir: Path, errors: list[str]
+) -> tuple[bool, int]:
+    checked = 0
+    try:
+        manual = _load(manual_path)
+        for name, entry in merge_mappings._validate_source_payload(
+            manual, str(_rel(manual_path)), kind="manual"
+        ).items():
+            if entry.get("cpes") is not None:
+                checked += 1
+        for contribution, _ in merge_mappings._load_contributions(contrib_dir):
+            checked += sum(
+                entry.get("cpes") is not None
+                for entry in contribution["packages"].values()
+            )
+    except ValueError as exc:
+        errors.append(str(exc))
+    return manual_path.exists() or contrib_dir.exists(), checked
+
+
+CANONICAL_MAPPING_FIELDS = (
+    "purl",
+    "type",
+    "namespace",
+    "pkg_name",
+    "alternative_purls",
+    "cpes",
+    "unmapped",
+    "status",
+    "source",
+    "approved_by",
+    "approved_at",
+)
+INDEX_CANONICAL_FIELDS = (
+    "purl",
+    "type",
+    "namespace",
+    "pkg_name",
+    "alternative_purls",
+    "cpes",
+    "unmapped",
+    "status",
+)
+
+
+def replay_source_mappings(
+    auto_path: Path,
     manual_path: Path,
     contrib_dir: Path,
     errors: list[str],
-) -> tuple[bool, int]:
-    checked = 0
-    if manual_path.exists():
-        try:
-            manual = _load(manual_path)
-        except json.JSONDecodeError as exc:
-            errors.append(f"{_rel(manual_path)}: invalid JSON: {exc}")
-            manual = {}
-        for name, entry in (manual.get("packages") or {}).items():
-            if isinstance(entry, dict) and "cpes" in entry:
-                checked += 1
-                _validate_cpes(entry.get("cpes"), f"{_rel(manual_path)}:{name}", errors)
+) -> dict[str, dict] | None:
+    """Reconstruct canonical identities and ownership from source layers."""
+    try:
+        auto_data = _load(auto_path)
+        manual_data = _load(manual_path)
+        contributions = merge_mappings._load_contributions(contrib_dir)
+        return merge_mappings._build_published_packages(
+            auto_data,
+            manual_data,
+            contributions,
+            {},
+            auto_label=str(_rel(auto_path)),
+            manual_label=str(_rel(manual_path)),
+            contributions_label=contrib_dir,
+        )
+    except ValueError as exc:
+        errors.append(str(exc))
+        return None
 
-    for contrib in _load_mapping_contributions(contrib_dir, errors):
-        filename = contrib.get("_filename", "<contribution>")
-        for name, entry in (contrib.get("packages") or {}).items():
-            if isinstance(entry, dict) and "cpes" in entry:
-                checked += 1
-                _validate_cpes(
-                    entry.get("cpes"), f"{_rel(contrib_dir)}/{filename}:{name}", errors
-                )
-    return manual_path.exists() or contrib_dir.exists(), checked
+
+def _canonical_shape(
+    entry: dict[str, Any], *, current: bool, index: bool = False
+) -> dict[str, Any]:
+    fields = INDEX_CANONICAL_FIELDS if index else CANONICAL_MAPPING_FIELDS
+    shaped = {
+        key: entry[key]
+        for key in fields
+        if key in entry
+        and not (
+            index
+            and key in {"alternative_purls", "cpes", "unmapped"}
+            and entry[key] is None
+        )
+        and not (not current and key == "unmapped" and entry[key] is False)
+    }
+    if current and "identities" in entry:
+        shaped["identities"] = entry["identities"]
+    return shaped
+
+
+def _compare_to_source(
+    actual_packages: dict[str, Any],
+    expected_packages: dict[str, dict],
+    label: str,
+    errors: list[str],
+    *,
+    current: bool,
+    index: bool = False,
+) -> None:
+    if set(actual_packages) != set(expected_packages):
+        errors.append(f"{label}: package set does not match source mapping layers")
+    for name in actual_packages.keys() & expected_packages.keys():
+        actual = actual_packages[name]
+        if not isinstance(actual, dict):
+            continue
+        actual_shape = _canonical_shape(actual, current=current, index=index)
+        expected_shape = _canonical_shape(
+            expected_packages[name], current=current, index=index
+        )
+        if actual_shape != expected_shape:
+            errors.append(
+                f"{label}:{name}: canonical mapping identities/ownership do not match source layers"
+            )
 
 
 def validate_mapping_alternatives(
@@ -128,154 +535,269 @@ def validate_mapping_alternatives(
     contrib_dir: Path,
     mappings_path: Path,
     errors: list[str],
+    auto_path: Path = DEFAULT_AUTO_MAPPINGS,
+    expected_packages: dict[str, dict] | None = None,
 ) -> bool:
-    """Ensure reviewed alternative removals survive the mappings merge."""
     if not mappings_path.exists():
         errors.append(f"{_rel(mappings_path)}: missing; run mappings:merge first")
         return False
     try:
         merged = _load(mappings_path)
-    except json.JSONDecodeError as exc:
-        errors.append(f"{_rel(mappings_path)}: invalid JSON: {exc}")
+    except ValueError as exc:
+        errors.append(str(exc))
         return True
+    version = _validate_schema_version(
+        merged, str(_rel(mappings_path)), SUPPORTED_BUNDLE_SCHEMAS, errors
+    )
+    if expected_packages is None:
+        expected_packages = replay_source_mappings(
+            auto_path, manual_path, contrib_dir, errors
+        )
 
-    expected: dict[str, list[str]] = {}
-    if manual_path.exists():
-        try:
-            manual = _load(manual_path)
-        except json.JSONDecodeError:
-            manual = {}
-        for name, override in (manual.get("packages") or {}).items():
-            if isinstance(override, dict) and "alternative_purls" in override:
-                expected[name] = _purl_list(override.get("alternative_purls"))
-
-    for contrib in _load_mapping_contributions(contrib_dir, errors):
-        for name, override in (contrib.get("packages") or {}).items():
-            if isinstance(override, dict) and "alternative_purls" in override:
-                expected[name] = _purl_list(override.get("alternative_purls"))
-
-    packages = merged.get("packages") or {}
+    packages = merged.get("packages")
     if not isinstance(packages, dict):
         errors.append(f"{_rel(mappings_path)}: packages must be an object")
         return True
+    if merged.get("package_count") != len(packages):
+        errors.append(f"{_rel(mappings_path)}: package_count does not match packages")
     for name, entry in packages.items():
-        if isinstance(entry, dict) and "cpes" in entry:
-            _validate_cpes(entry.get("cpes"), f"{_rel(mappings_path)}:{name}", errors)
-    for name, wanted in expected.items():
-        got = _purl_list((packages.get(name) or {}).get("alternative_purls"))
-        if got != wanted:
+        if not isinstance(name, str) or not name or not isinstance(entry, dict):
             errors.append(
-                f"{_rel(mappings_path)}:{name}: alternative_purls merged as "
-                f"{got!r}, expected latest reviewed list {wanted!r}"
+                f"{_rel(mappings_path)}:{name}: invalid package identifier or entry"
             )
+            continue
+        entry_label = f"{_rel(mappings_path)}:{name}"
+        _validate_cpes(entry.get("cpes"), entry_label, errors)
+        _validate_published_confidences(entry, entry_label, errors)
+        if version == CURRENT_BUNDLE_SCHEMA:
+            _validate_identity_contract(entry, f"{_rel(mappings_path)}:{name}", errors)
+    if expected_packages is not None and version is not None:
+        _compare_to_source(
+            packages,
+            expected_packages,
+            str(_rel(mappings_path)),
+            errors,
+            current=version == CURRENT_BUNDLE_SCHEMA,
+        )
     return True
 
 
+def _expected_index_entry(
+    name: str, detail: dict, detail_path: str, *, current: bool
+) -> dict:
+    entry = merge_mappings._index_package(name, detail, detail_path)
+    if not current:
+        entry.pop("identities", None)
+    return entry
+
+
 def validate_split_mappings(
-    index_path: Path, detail_dir: Path, errors: list[str]
+    index_path: Path,
+    detail_dir: Path,
+    errors: list[str],
+    bundle_path: Path | None = None,
+    expected_packages: dict[str, dict] | None = None,
 ) -> bool:
-    """Validate mappings-index.json plus sharded package detail files."""
     if not index_path.exists():
         errors.append(f"{_rel(index_path)}: missing; run mappings:merge first")
         return False
     try:
         index = _load(index_path)
-    except json.JSONDecodeError as exc:
-        errors.append(f"{_rel(index_path)}: invalid JSON: {exc}")
+        bundle = _load(bundle_path) if bundle_path and bundle_path.exists() else None
+    except ValueError as exc:
+        errors.append(str(exc))
         return True
-    packages = index.get("packages")
-    if not isinstance(packages, dict):
+    index_version = _validate_schema_version(
+        index, str(_rel(index_path)), SUPPORTED_INDEX_SCHEMAS, errors
+    )
+    index_packages = index.get("packages")
+    if not isinstance(index_packages, dict):
         errors.append(f"{_rel(index_path)}: packages must be an object")
         return True
-    seen_detail_paths: set[str] = set()
-    for name, pkg_index in packages.items():
-        if not isinstance(pkg_index, dict):
+    bundle_packages = bundle.get("packages") if isinstance(bundle, dict) else None
+    bundle_version = None
+    if bundle is not None:
+        bundle_version = _validate_schema_version(
+            bundle, str(_rel(bundle_path)), SUPPORTED_BUNDLE_SCHEMAS, errors
+        )
+        expected_bundle_version = (
+            CURRENT_BUNDLE_SCHEMA
+            if index_version == CURRENT_INDEX_SCHEMA
+            else CURRENT_BUNDLE_SCHEMA - 1
+        )
+        if bundle_version != expected_bundle_version:
+            errors.append(
+                "bundle and index schema versions do not form a supported pair"
+            )
+        if not isinstance(bundle_packages, dict):
+            errors.append(f"{_rel(bundle_path)}: packages must be an object")
+            bundle_packages = {}
+        if set(bundle_packages) != set(index_packages):
+            errors.append("bundle and index package sets do not match")
+        bundle_header = {
+            key: value
+            for key, value in bundle.items()
+            if key not in {"packages", "schema_version"}
+        }
+        index_header = {
+            key: value
+            for key, value in index.items()
+            if key not in {"packages", "schema_version"}
+        }
+        if bundle_header != index_header:
+            errors.append("bundle and index metadata do not match")
+
+    referenced: set[Path] = set()
+    shard_packages: dict[str, dict] = {}
+    for name, index_entry in index_packages.items():
+        if not isinstance(index_entry, dict):
             errors.append(f"{_rel(index_path)}:{name}: index entry must be an object")
             continue
-        _validate_cpes(pkg_index.get("cpes"), f"{_rel(index_path)}:{name}", errors)
-        detail_path = pkg_index.get("detail_path")
-        if not isinstance(detail_path, str):
+        path_value = index_entry.get("detail_path")
+        if not isinstance(path_value, str) or not path_value:
             errors.append(f"{_rel(index_path)}:{name}: detail_path is required")
             continue
-        seen_detail_paths.add(detail_path)
-        path = ROOT / "web" / "public" / detail_path
+        referenced.add(index_path.parent / path_value)
+    for path in sorted(referenced):
         if not path.exists():
-            errors.append(
-                f"{_rel(index_path)}:{name}: missing detail file {detail_path}"
-            )
+            errors.append(f"{_rel(path)}: referenced shard is missing")
             continue
         try:
-            detail = _load(path)
-        except json.JSONDecodeError as exc:
-            errors.append(f"{_rel(path)}: invalid JSON: {exc}")
+            shard = _load(path)
+        except ValueError as exc:
+            errors.append(str(exc))
             continue
-        shard_packages = detail.get("packages")
-        if not isinstance(shard_packages, dict):
+        shard_version = _validate_schema_version(
+            shard, str(_rel(path)), SUPPORTED_DETAIL_SCHEMAS, errors
+        )
+        expected_detail_version = (
+            CURRENT_DETAIL_SCHEMA
+            if index_version == CURRENT_INDEX_SCHEMA
+            else CURRENT_DETAIL_SCHEMA - 1
+        )
+        if shard_version is not None and shard_version != expected_detail_version:
+            errors.append(
+                f"{_rel(path)}: index/detail schema versions do not form a supported pair"
+            )
+        packages = shard.get("packages")
+        if not isinstance(packages, dict):
             errors.append(f"{_rel(path)}: packages must be an object")
             continue
-        package_detail = shard_packages.get(name)
-        if not isinstance(package_detail, dict):
-            errors.append(f"{_rel(path)}: missing package {name!r} referenced by index")
+        for name, detail in packages.items():
+            if name in shard_packages:
+                errors.append(f"{_rel(path)}: duplicate sharded package {name!r}")
+            elif isinstance(detail, dict):
+                shard_packages[name] = detail
+            else:
+                errors.append(f"{_rel(path)}:{name}: detail entry must be an object")
+    if set(shard_packages) != set(index_packages):
+        errors.append("index and shard package sets do not match")
+
+    for name, index_entry in index_packages.items():
+        detail = shard_packages.get(name)
+        if not isinstance(index_entry, dict) or not isinstance(detail, dict):
             continue
-        if package_detail.get("name") != name:
+        label = f"{_rel(index_path)}:{name}"
+        if detail.get("name") != name:
+            errors.append(f"{label}: detail name does not match package key")
+        if index_version == CURRENT_INDEX_SCHEMA:
+            _validate_identity_contract(index_entry, label, errors)
+            _validate_identity_contract(detail, f"{label}:detail", errors)
+        _validate_cpes(index_entry.get("cpes"), label, errors)
+        _validate_cpes(detail.get("cpes"), f"{label}:detail", errors)
+        _validate_published_confidences(index_entry, label, errors)
+        _validate_published_confidences(detail, f"{label}:detail", errors)
+        detail_path = index_entry["detail_path"]
+        expected_index = _expected_index_entry(
+            name,
+            {key: value for key, value in detail.items() if key != "name"},
+            detail_path,
+            current=index_version == CURRENT_INDEX_SCHEMA,
+        )
+        if index_entry != expected_index:
             errors.append(
-                f"{_rel(path)}:{name}: detail name {package_detail.get('name')!r}, expected {name!r}"
+                f"{label}: index entry does not exactly match detail legacy/typed fields"
             )
-        _validate_cpes(package_detail.get("cpes"), f"{_rel(path)}:{name}", errors)
-        index_cpes = pkg_index.get("cpes") or []
-        detail_cpes = package_detail.get("cpes") or []
-        if index_cpes != detail_cpes:
-            errors.append(
-                f"{_rel(index_path)}:{name}: index cpes {index_cpes!r} "
-                f"do not match detail cpes {detail_cpes!r}"
-            )
-    if detail_dir.exists():
-        expected = {
-            str((ROOT / "web" / "public" / p).resolve()) for p in seen_detail_paths
-        }
-        for path in detail_dir.glob("*.json"):
-            if str(path.resolve()) not in expected:
+        if isinstance(bundle_packages, dict) and name in bundle_packages:
+            expected_detail = {**bundle_packages[name], "name": name}
+            if detail != expected_detail:
                 errors.append(
-                    f"{_rel(path)}: stale detail file not referenced by index"
+                    f"{label}: detail does not exactly match canonical bundle record"
                 )
+
+    if expected_packages is not None and index_version is not None:
+        current = index_version == CURRENT_INDEX_SCHEMA
+        _compare_to_source(
+            index_packages,
+            expected_packages,
+            str(_rel(index_path)),
+            errors,
+            current=current,
+            index=True,
+        )
+        _compare_to_source(
+            shard_packages,
+            expected_packages,
+            f"{_rel(detail_dir)} shards",
+            errors,
+            current=current,
+        )
+
+    if detail_dir.exists():
+        actual_paths = set(detail_dir.glob("*.json"))
+        if actual_paths != referenced:
+            errors.append("detail directory contains missing or stale shard files")
     return True
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--auto-mappings", type=Path, default=DEFAULT_AUTO_MAPPINGS)
+    parser.add_argument("--manual-mappings", type=Path, default=DEFAULT_MANUAL_MAPPINGS)
+    parser.add_argument(
+        "--mapping-contributions", type=Path, default=DEFAULT_MAPPING_CONTRIB_DIR
+    )
     parser.add_argument("--mappings", type=Path, default=DEFAULT_MAPPINGS_BUNDLE)
     parser.add_argument("--mappings-index", type=Path, default=DEFAULT_MAPPINGS_INDEX)
     parser.add_argument(
         "--mappings-detail-dir", type=Path, default=DEFAULT_MAPPINGS_DETAIL_DIR
     )
-    parser.add_argument(
-        "--mapping-contributions", type=Path, default=DEFAULT_MAPPING_CONTRIB_DIR
-    )
-    parser.add_argument("--manual-mappings", type=Path, default=DEFAULT_MANUAL_MAPPINGS)
     args = parser.parse_args()
-
     errors: list[str] = []
-    _, n_source_cpe = validate_source_cpes(
+    validate_source_payloads(
+        args.auto_mappings, args.manual_mappings, args.mapping_contributions, errors
+    )
+    _, checked = validate_source_cpes(
         args.manual_mappings, args.mapping_contributions, errors
     )
-    has_mappings = validate_mapping_alternatives(
-        args.manual_mappings, args.mapping_contributions, args.mappings, errors
+    expected_packages = replay_source_mappings(
+        args.auto_mappings,
+        args.manual_mappings,
+        args.mapping_contributions,
+        errors,
     )
-    has_split_mappings = validate_split_mappings(
-        args.mappings_index, args.mappings_detail_dir, errors
+    validate_mapping_alternatives(
+        args.manual_mappings,
+        args.mapping_contributions,
+        args.mappings,
+        errors,
+        args.auto_mappings,
+        expected_packages,
     )
-
+    validate_split_mappings(
+        args.mappings_index,
+        args.mappings_detail_dir,
+        errors,
+        args.mappings,
+        expected_packages,
+    )
     if errors:
         print(f"✗ {len(errors)} mapping validation error(s):", file=sys.stderr)
-        for line in errors:
-            print(f"  - {line}", file=sys.stderr)
-        sys.exit(1)
-
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        raise SystemExit(1)
     print(
-        f"✓ identity mappings valid: "
-        f"{n_source_cpe} source CPE mapping(s) checked, "
-        f"mapping removals {'valid' if has_mappings else 'absent'}, "
-        f"split mapping payload {'valid' if has_split_mappings else 'absent'}"
+        f"✓ identity mappings valid: source schemas, {checked} CPE mappings, bundle/index/shards, and typed provenance"
     )
 
 

--- a/tests/test_identity_payload.py
+++ b/tests/test_identity_payload.py
@@ -1,0 +1,785 @@
+from __future__ import annotations
+
+import copy
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import merge_mappings, validate
+
+GENERATED_AT = "2026-02-03T04:05:06+00:00"
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class IdentityPayloadTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        self.auto = self.root / "auto.json"
+        self.manual = self.root / "manual.json"
+        self.contributions = self.root / "contributions"
+        self.downloads = self.root / "downloads.json"
+        self.contributions.mkdir()
+        self._write_json(
+            self.auto,
+            {
+                "schema_version": 1,
+                "generated_at": "2026-01-01T00:00:00Z",
+                "channel": "conda-forge",
+                "packages": {
+                    "auto-detailed": {
+                        "purl": "pkg:pypi/demo",
+                        "type": "pypi",
+                        "namespace": None,
+                        "pkg_name": "demo",
+                        "confidence": 0.99,
+                        "sources": ["recipe-source", "artifact"],
+                        "auto_verified": True,
+                        "alternative_purls": [
+                            {
+                                "purl": "pkg:github/example/demo",
+                                "type": "github",
+                                "namespace": "example",
+                                "pkg_name": "demo",
+                                "confidence": 0.85,
+                                "source": "recipe-source",
+                            }
+                        ],
+                        "cpes": ["cpe:2.3:a:example:demo"],
+                    },
+                    "reviewed": {
+                        "purl": "pkg:pypi/project-old",
+                        "type": "pypi",
+                        "namespace": None,
+                        "pkg_name": "project-old",
+                        "confidence": 0.7,
+                        "sources": ["recipe-deps"],
+                    },
+                    "reject-me": {
+                        "purl": "pkg:pypi/rejected",
+                        "type": "pypi",
+                        "namespace": None,
+                        "pkg_name": "rejected",
+                        "confidence": 0.5,
+                        "sources": [],
+                        "alternative_purls": ["pkg:github/example/rejected"],
+                    },
+                },
+            },
+        )
+        self._write_json(
+            self.manual,
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00Z",
+                "packages": {
+                    "reviewed": {
+                        "purl": "pkg:github/reviewer/project",
+                        "type": "github",
+                        "namespace": "reviewer",
+                        "pkg_name": "project",
+                        "alternative_purls": ["pkg:pypi/project"],
+                        "approved_by": "package-reviewer",
+                        "approved_at": "2026-01-02T03:04:05Z",
+                    }
+                },
+            },
+        )
+        self._write_json(
+            self.contributions / "review.json",
+            {
+                "schema_version": 1,
+                "author": "current-reviewer",
+                "timestamp": "2026-01-03T04:05:06Z",
+                "packages": {
+                    "reviewed": {"cpes": ["cpe:2.3:a:reviewer:project"]},
+                    "contributed": {
+                        "purl": "pkg:github/example/contributed",
+                        "type": "github",
+                        "namespace": "example",
+                        "pkg_name": "contributed",
+                    },
+                    "reject-me": {"unmapped": True},
+                },
+            },
+        )
+        self._write_json(self.downloads, {"packages": []})
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    @staticmethod
+    def _write_json(path: Path, value: object) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(value))
+
+    def _generate(self, output_root: Path) -> tuple[Path, Path, Path]:
+        bundle = output_root / "mappings.json"
+        index = output_root / "mappings-index.json"
+        details = output_root / "mapping_packages"
+        merge_mappings.main(
+            self.auto,
+            self.manual,
+            self.contributions,
+            self.downloads,
+            bundle,
+            index,
+            details,
+            generated_at=GENERATED_AT,
+        )
+        return bundle, index, details
+
+    def test_generator_attests_each_identity_and_preserves_legacy_fields(self) -> None:
+        bundle_path, index_path, detail_dir = self._generate(self.root / "out")
+        bundle = json.loads(bundle_path.read_text())
+        index = json.loads(index_path.read_text())
+        reviewed = bundle["packages"]["reviewed"]
+
+        self.assertEqual((bundle["schema_version"], index["schema_version"]), (2, 3))
+        self.assertEqual(reviewed["status"], "verified")
+        self.assertEqual(reviewed["approved_by"], "current-reviewer")
+        # Identity provenance remains with the primary-owning manual layer.
+        self.assertEqual(
+            reviewed["identities"][0]["provenance"]["review"],
+            {
+                "status": "verified",
+                "reviewer": "package-reviewer",
+                "reviewed_at": "2026-01-02T03:04:05Z",
+            },
+        )
+        self.assertEqual(
+            reviewed["identities"][1]["provenance"],
+            {"availability": "unavailable"},
+        )
+        self.assertEqual(
+            reviewed["identities"][2]["provenance"],
+            {"availability": "unavailable"},
+        )
+        errors: list[str] = []
+        validate.validate_mapping_alternatives(
+            self.manual, self.contributions, bundle_path, errors, self.auto
+        )
+        validate.validate_split_mappings(index_path, detail_dir, errors, bundle_path)
+        self.assertEqual(errors, [])
+
+    def test_auto_to_unmapped_clears_rejected_identity(self) -> None:
+        bundle_path, _, _ = self._generate(self.root / "unmapped")
+        rejected = json.loads(bundle_path.read_text())["packages"]["reject-me"]
+        self.assertTrue(rejected["unmapped"])
+        self.assertEqual(rejected["status"], "unmapped")
+        self.assertEqual(rejected["alternative_purls"], [])
+        for key in ("purl", "type", "namespace", "pkg_name"):
+            self.assertIsNone(rejected[key])
+        self.assertFalse(
+            any(identity["kind"] == "purl" for identity in rejected["identities"])
+        )
+
+    def test_new_primary_uses_only_current_reviewer(self) -> None:
+        self._write_json(
+            self.contributions / "later.json",
+            {
+                "schema_version": 1,
+                "author": "new-owner",
+                "timestamp": "2026-01-04T04:05:06Z",
+                "packages": {
+                    "reviewed": {
+                        "purl": "pkg:github/new/project",
+                        "type": "github",
+                        "namespace": "new",
+                        "pkg_name": "project",
+                    }
+                },
+            },
+        )
+        bundle_path, _, _ = self._generate(self.root / "owner")
+        reviewed = json.loads(bundle_path.read_text())["packages"]["reviewed"]
+        self.assertEqual(reviewed["approved_by"], "new-owner")
+        self.assertEqual(
+            reviewed["identities"][0]["provenance"]["review"],
+            {
+                "status": "verified",
+                "reviewer": "new-owner",
+                "reviewed_at": "2026-01-04T04:05:06Z",
+            },
+        )
+
+    def test_source_schema_negative_mutations(self) -> None:
+        base = json.loads(self.auto.read_text())
+        mutations = {
+            "unknown schema": lambda value: value.update(schema_version=99),
+            "non-object packages": lambda value: value.update(packages=[]),
+            "empty identifier": lambda value: value["packages"].update(
+                {"": value["packages"].pop("reviewed")}
+            ),
+            "malformed primary PURL": lambda value: value["packages"][
+                "reviewed"
+            ].update(purl="not-a-purl"),
+            "string alternatives": lambda value: value["packages"]["reviewed"].update(
+                alternative_purls="pkg:pypi/nope"
+            ),
+            "malformed alternative": lambda value: value["packages"]["reviewed"].update(
+                alternative_purls=["bad"]
+            ),
+            "duplicate alternative": lambda value: value["packages"]["reviewed"].update(
+                alternative_purls=["pkg:pypi/a", "pkg:pypi/a"]
+            ),
+            "primary as alternative": lambda value: value["packages"][
+                "reviewed"
+            ].update(alternative_purls=["pkg:pypi/project-old"]),
+            "malformed detailed alternative": lambda value: value["packages"][
+                "reviewed"
+            ].update(alternative_purls=[{"purl": "pkg:pypi/a"}]),
+            "malformed CPE": lambda value: value["packages"]["reviewed"].update(
+                cpes=["cpe:bad"]
+            ),
+            "duplicate CPE": lambda value: value["packages"]["reviewed"].update(
+                cpes=["cpe:2.3:a:a:b", "cpe:2.3:a:a:b"]
+            ),
+            "reserved filename": lambda value: value.update(_filename="wins.json"),
+        }
+        for label, mutate in mutations.items():
+            with self.subTest(label=label):
+                value = copy.deepcopy(base)
+                mutate(value)
+                with self.assertRaises(ValueError):
+                    merge_mappings._validate_source_payload(value, label, kind="auto")
+
+        manual_without_owner = json.loads(self.manual.read_text())
+        manual_without_owner["packages"]["reviewed"].pop("approved_by")
+        manual_without_owner["packages"]["reviewed"].pop("approved_at")
+        with self.assertRaises(ValueError):
+            merge_mappings._validate_source_payload(
+                manual_without_owner, "manual", kind="manual"
+            )
+
+        contribution = json.loads((self.contributions / "review.json").read_text())
+        for key, invalid in (("author", ""), ("timestamp", "not-a-date")):
+            with self.subTest(attribution=key):
+                value = copy.deepcopy(contribution)
+                value[key] = invalid
+                with self.assertRaises(ValueError):
+                    merge_mappings._validate_source_payload(
+                        value, "contribution", kind="contribution"
+                    )
+
+        for non_finite in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(non_finite=non_finite):
+                value = copy.deepcopy(base)
+                value["packages"]["reviewed"]["confidence"] = non_finite
+                with self.assertRaisesRegex(ValueError, "finite number"):
+                    merge_mappings._validate_source_payload(
+                        value, "non-finite", kind="auto"
+                    )
+                value = copy.deepcopy(base)
+                value["packages"]["auto-detailed"]["alternative_purls"][0][
+                    "confidence"
+                ] = non_finite
+                with self.assertRaisesRegex(ValueError, "finite number"):
+                    merge_mappings._validate_source_payload(
+                        value, "non-finite alternative", kind="auto"
+                    )
+
+        duplicate_json = self.root / "duplicate.json"
+        duplicate_json.write_text(
+            '{"schema_version":1,"schema_version":1,"packages":{}}'
+        )
+        with self.assertRaisesRegex(ValueError, "duplicate JSON key"):
+            merge_mappings._load_json(duplicate_json)
+        for token in ("NaN", "Infinity", "-Infinity"):
+            nonstandard_json = self.root / f"nonstandard-{token}.json"
+            nonstandard_json.write_text(
+                f'{{"schema_version":1,"packages":{{}},"confidence":{token}}}'
+            )
+            with self.assertRaisesRegex(ValueError, "non-standard numeric value"):
+                merge_mappings._load_json(nonstandard_json)
+
+    def test_identity_contract_negative_mutations(self) -> None:
+        bundle_path, _, _ = self._generate(self.root / "identity-negative")
+        packages = json.loads(bundle_path.read_text())["packages"]
+        primary = packages["auto-detailed"]
+        reviewed = packages["reviewed"]
+
+        def mutate_primary(path: tuple, value: object, base: dict = primary) -> dict:
+            result = copy.deepcopy(base)
+            target: object = result
+            for key in path[:-1]:
+                target = target[key]  # type: ignore[index]
+            target[path[-1]] = value  # type: ignore[index]
+            return result
+
+        cases = [
+            (
+                "primary availability",
+                mutate_primary(
+                    ("identities", 0, "provenance", "availability"), "unavailable"
+                ),
+            ),
+            (
+                "primary source",
+                mutate_primary(("identities", 0, "provenance", "source"), "mystery"),
+            ),
+            (
+                "review status",
+                mutate_primary(
+                    ("identities", 0, "provenance", "review", "status"), "mystery"
+                ),
+            ),
+            (
+                "reviewer type",
+                mutate_primary(
+                    ("identities", 0, "provenance", "review", "reviewer"), 7
+                ),
+            ),
+            (
+                "invented attribution when legacy attribution is absent",
+                mutate_primary(
+                    ("identities", 0, "provenance", "review", "reviewer"),
+                    "borrowed-reviewer",
+                ),
+            ),
+            (
+                "confidence type",
+                mutate_primary(("identities", 0, "provenance", "confidence"), True),
+            ),
+            (
+                "confidence non-finite",
+                mutate_primary(
+                    ("identities", 0, "provenance", "confidence"), float("inf")
+                ),
+            ),
+            (
+                "sources type",
+                mutate_primary(("identities", 0, "provenance", "sources"), "recipe"),
+            ),
+            (
+                "identity forbidden field",
+                mutate_primary(("identities", 0, "extra"), True),
+            ),
+            ("primary invalid PURL", mutate_primary(("identities", 0, "value"), "bad")),
+            ("primary empty", mutate_primary(("identities", 0, "value"), "")),
+            (
+                "duplicate identity",
+                mutate_primary(("identities", 1, "value"), "pkg:pypi/demo"),
+            ),
+            (
+                "detailed alternative exact provenance",
+                mutate_primary(("identities", 1, "provenance", "confidence"), 0.1),
+            ),
+            (
+                "CPE unavailable only",
+                mutate_primary(
+                    ("identities", 2, "provenance"), {"availability": "available"}
+                ),
+            ),
+        ]
+        manual_bad = copy.deepcopy(reviewed)
+        manual_bad["identities"][0]["provenance"]["review"]["reviewed_at"] = "yesterday"
+        cases.append(("timestamp", manual_bad))
+        bare_bad = copy.deepcopy(reviewed)
+        bare_bad["identities"][1]["provenance"] = {
+            "availability": "unavailable",
+            "source": "manual",
+        }
+        cases.append(("bare alternative exact provenance", bare_bad))
+        primary_alt = copy.deepcopy(reviewed)
+        primary_alt["alternative_purls"] = [primary_alt["purl"]]
+        primary_alt["identities"][1]["value"] = primary_alt["purl"]
+        cases.append(("primary as alternative", primary_alt))
+        for label, entry in cases:
+            with self.subTest(label=label):
+                errors: list[str] = []
+                validate._validate_identity_contract(entry, label, errors)
+                self.assertTrue(errors, label)
+
+        unmapped = packages["reject-me"]
+        for label, mutate in (
+            ("unmapped status", lambda value: value.update(status="verified")),
+            (
+                "unmapped coordinates",
+                lambda value: value.update(purl="pkg:pypi/rejected"),
+            ),
+            (
+                "unmapped alternatives",
+                lambda value: value.update(alternative_purls=["pkg:pypi/rejected"]),
+            ),
+        ):
+            with self.subTest(label=label):
+                entry = copy.deepcopy(unmapped)
+                mutate(entry)
+                errors = []
+                validate._validate_identity_contract(entry, label, errors)
+                self.assertTrue(errors, label)
+
+    def test_bundle_index_shard_cross_checks_reject_every_mismatch_class(self) -> None:
+        bundle_path, index_path, detail_dir = self._generate(self.root / "cross")
+
+        def assert_invalid(mutator) -> None:
+            case = self.root / f"case-{len(list(self.root.glob('case-*')))}"
+            shutil.copytree(bundle_path.parent, case)
+            case_bundle = case / "mappings.json"
+            case_index = case / "mappings-index.json"
+            mutator(case_bundle, case_index, case / "mapping_packages")
+            errors: list[str] = []
+            validate.validate_split_mappings(
+                case_index, case / "mapping_packages", errors, case_bundle
+            )
+            self.assertTrue(errors)
+
+        def mutate_json(path: Path, callback) -> None:
+            value = json.loads(path.read_text())
+            callback(value)
+            self._write_json(path, value)
+
+        first_name = next(iter(json.loads(index_path.read_text())["packages"]))
+        shard_rel = json.loads(index_path.read_text())["packages"][first_name][
+            "detail_path"
+        ]
+        assert_invalid(
+            lambda bundle, index, details: mutate_json(
+                index, lambda value: value["packages"].pop(first_name)
+            )
+        )
+        assert_invalid(
+            lambda bundle, index, details: mutate_json(
+                index, lambda value: value.update(channel="wrong")
+            )
+        )
+        assert_invalid(
+            lambda bundle, index, details: mutate_json(
+                index,
+                lambda value: value["packages"][first_name].update(version="wrong"),
+            )
+        )
+        assert_invalid(
+            lambda bundle, index, details: mutate_json(
+                index.parent / shard_rel,
+                lambda value: value["packages"][first_name].update(summary="wrong"),
+            )
+        )
+        assert_invalid(
+            lambda bundle, index, details: mutate_json(
+                index, lambda value: value["packages"][first_name].update(identities=[])
+            )
+        )
+        assert_invalid(
+            lambda bundle, index, details: mutate_json(
+                index.parent / shard_rel,
+                lambda value: value.update(schema_version=1),
+            )
+        )
+
+    def test_validator_rejects_wrong_primary_owner_even_when_legacy_owner_differs(
+        self,
+    ) -> None:
+        bundle_path, _, _ = self._generate(self.root / "wrong-owner")
+        bundle = json.loads(bundle_path.read_text())
+        # This is structurally valid and deliberately differs from the latest
+        # legacy CPE-only attribution; only source-layer ownership catches it.
+        bundle["packages"]["reviewed"]["identities"][0]["provenance"]["review"][
+            "reviewer"
+        ] = "plausible-but-wrong"
+        self._write_json(bundle_path, bundle)
+        errors: list[str] = []
+        validate.validate_mapping_alternatives(
+            self.manual, self.contributions, bundle_path, errors, self.auto
+        )
+        self.assertTrue(any("do not match source layers" in error for error in errors))
+
+    def test_source_replay_rejects_consistent_generated_identity_mutations(
+        self,
+    ) -> None:
+        bundle_path, index_path, detail_dir = self._generate(
+            self.root / "source-replay"
+        )
+        expected_errors: list[str] = []
+        expected = validate.replay_source_mappings(
+            self.auto, self.manual, self.contributions, expected_errors
+        )
+        self.assertEqual(expected_errors, [])
+        self.assertIsNotNone(expected)
+
+        cases = {
+            "primary": ("auto-detailed", 0, "pkg:pypi/tampered-primary"),
+            "alternative": ("auto-detailed", 1, "pkg:github/example/tampered-alt"),
+            "cpe": ("auto-detailed", 2, "cpe:2.3:a:example:tampered"),
+        }
+        for label, (name, identity_index, replacement) in cases.items():
+            with self.subTest(label=label):
+                case = self.root / f"consistent-{label}"
+                shutil.copytree(bundle_path.parent, case)
+                bundle = json.loads((case / "mappings.json").read_text())
+                index = json.loads((case / "mappings-index.json").read_text())
+                detail_path = index["packages"][name]["detail_path"]
+                shard_path = case / detail_path
+                shard = json.loads(shard_path.read_text())
+                records = [
+                    bundle["packages"][name],
+                    index["packages"][name],
+                    shard["packages"][name],
+                ]
+                for record in records:
+                    record["identities"][identity_index]["value"] = replacement
+                    if label == "primary":
+                        record["purl"] = replacement
+                    elif label == "alternative":
+                        record["alternative_purls"][0]["purl"] = replacement
+                    else:
+                        record["cpes"][0] = replacement
+                self._write_json(case / "mappings.json", bundle)
+                self._write_json(case / "mappings-index.json", index)
+                self._write_json(shard_path, shard)
+
+                errors: list[str] = []
+                validate.validate_mapping_alternatives(
+                    self.manual,
+                    self.contributions,
+                    case / "mappings.json",
+                    errors,
+                    self.auto,
+                    expected,
+                )
+                validate.validate_split_mappings(
+                    case / "mappings-index.json",
+                    case / "mapping_packages",
+                    errors,
+                    case / "mappings.json",
+                    expected,
+                )
+                self.assertTrue(
+                    any("do not match source layers" in error for error in errors),
+                    errors,
+                )
+
+    def test_contribution_sort_uses_utc_instants_and_filename_tiebreaker(self) -> None:
+        def contribution(author: str, timestamp: str, purl: str) -> dict:
+            return {
+                "schema_version": 1,
+                "author": author,
+                "timestamp": timestamp,
+                "packages": {
+                    "reviewed": {
+                        "purl": purl,
+                        "type": "pypi",
+                        "namespace": None,
+                        "pkg_name": purl.rsplit("/", 1)[-1],
+                    }
+                },
+            }
+
+        reversed_lexical = self.root / "reversed-lexical"
+        self._write_json(
+            reversed_lexical / "a.json",
+            contribution(
+                "earlier-instant",
+                "2026-01-01T01:00:00+02:00",
+                "pkg:pypi/earlier",
+            ),
+        )
+        self._write_json(
+            reversed_lexical / "z.json",
+            contribution(
+                "later-instant",
+                "2026-01-01T00:30:00+00:00",
+                "pkg:pypi/later",
+            ),
+        )
+        ordered = merge_mappings._load_contributions(reversed_lexical)
+        self.assertEqual(
+            [item[0]["author"] for item in ordered],
+            [
+                "earlier-instant",
+                "later-instant",
+            ],
+        )
+
+        equivalent = self.root / "equivalent-offsets"
+        self._write_json(
+            equivalent / "a.json",
+            contribution("first-name", "2026-01-01T01:00:00+01:00", "pkg:pypi/a"),
+        )
+        self._write_json(
+            equivalent / "b.json",
+            contribution("second-name", "2026-01-01T00:00:00Z", "pkg:pypi/b"),
+        )
+        ordered = merge_mappings._load_contributions(equivalent)
+        self.assertEqual([item[1] for item in ordered], ["a.json", "b.json"])
+
+        naive = contribution("naive", "2026-01-01T00:00:00", "pkg:pypi/naive")
+        with self.assertRaisesRegex(ValueError, "valid ISO-8601 timestamp"):
+            merge_mappings._validate_source_payload(naive, "naive", kind="contribution")
+
+    def test_complete_previous_schema_bundle_index_and_detail_are_valid(self) -> None:
+        bundle_path, index_path, detail_dir = self._generate(self.root / "legacy")
+        bundle = json.loads(bundle_path.read_text())
+        index = json.loads(index_path.read_text())
+        bundle["schema_version"] = 1
+        index["schema_version"] = 2
+        for entry in bundle["packages"].values():
+            entry.pop("identities")
+        for entry in index["packages"].values():
+            entry.pop("identities")
+        self._write_json(bundle_path, bundle)
+        self._write_json(index_path, index)
+        for shard_path in detail_dir.glob("*.json"):
+            shard = json.loads(shard_path.read_text())
+            shard["schema_version"] = 1
+            for entry in shard["packages"].values():
+                entry.pop("identities")
+            self._write_json(shard_path, shard)
+
+        errors: list[str] = []
+        expected = validate.replay_source_mappings(
+            self.auto, self.manual, self.contributions, errors
+        )
+        validate.validate_mapping_alternatives(
+            self.manual,
+            self.contributions,
+            bundle_path,
+            errors,
+            self.auto,
+            expected,
+        )
+        validate.validate_split_mappings(
+            index_path, detail_dir, errors, bundle_path, expected
+        )
+        self.assertEqual(errors, [])
+
+    def test_unknown_published_schema_is_rejected_but_previous_is_supported(
+        self,
+    ) -> None:
+        errors: list[str] = []
+        self.assertEqual(
+            validate._validate_schema_version(
+                {"schema_version": 1},
+                "legacy",
+                validate.SUPPORTED_BUNDLE_SCHEMAS,
+                errors,
+            ),
+            1,
+        )
+        self.assertEqual(errors, [])
+        validate._validate_schema_version(
+            {"schema_version": 99}, "future", validate.SUPPORTED_BUNDLE_SCHEMAS, errors
+        )
+        self.assertTrue(
+            any("unsupported schema_version 99" in error for error in errors)
+        )
+
+
+class RealDataLegacyCompatibilityTest(unittest.TestCase):
+    def test_checked_in_legacy_index_and_all_shards_validate_without_row_mismatches(
+        self,
+    ) -> None:
+        index_path = ROOT / "web" / "public" / "mappings-index.json"
+        detail_dir = ROOT / "web" / "public" / "mapping_packages"
+        index = merge_mappings._load_json(index_path)
+        first_shard = merge_mappings._load_json(next(detail_dir.glob("*.json")))
+        if index.get("schema_version") != 2 or first_shard.get("schema_version") != 1:
+            self.skipTest(
+                "checked-in payload is no longer the previous-schema snapshot"
+            )
+        errors: list[str] = []
+        expected = validate.replay_source_mappings(
+            ROOT / "mappings" / "auto.json",
+            ROOT / "mappings" / "manual.json",
+            ROOT / "mappings" / "contributions",
+            errors,
+        )
+        validate.validate_split_mappings(
+            index_path, detail_dir, errors, expected_packages=expected
+        )
+        self.assertEqual(index.get("package_count"), len(expected))
+        self.assertEqual(errors, [])
+
+    def test_identity_only_packages_keep_legacy_status_and_attribution_snapshot(
+        self,
+    ) -> None:
+        contributions = merge_mappings._load_contributions(
+            ROOT / "mappings" / "contributions"
+        )
+        last_contribution_is_identity_only: dict[str, bool] = {}
+        for contribution, _ in contributions:
+            for name, entry in contribution["packages"].items():
+                last_contribution_is_identity_only[name] = set(entry) == {"cpes"}
+        identity_only_names = {
+            name
+            for name, is_identity_only in last_contribution_is_identity_only.items()
+            if is_identity_only
+        }
+        self.assertTrue(identity_only_names)
+
+        auto = merge_mappings._load_json(ROOT / "mappings" / "auto.json")["packages"]
+        manual_payload = merge_mappings._load_json(ROOT / "mappings" / "manual.json")
+        missing = object()
+        expected = {
+            name: {
+                "status": "auto-verified"
+                if entry.get("auto_verified")
+                else "auto-unverified",
+                "source": "auto",
+                "approved_by": missing,
+                "approved_at": missing,
+            }
+            for name, entry in auto.items()
+        }
+
+        def apply(packages: dict, attribution: dict) -> None:
+            for name, override in packages.items():
+                state = expected.setdefault(
+                    name,
+                    {
+                        "status": missing,
+                        "source": missing,
+                        "approved_by": missing,
+                        "approved_at": missing,
+                    },
+                )
+                state["status"] = override.get("status", "verified")
+                state["source"] = "manual"
+                for key, value in attribution.items():
+                    if value is not None:
+                        state[key] = value
+
+        apply(
+            manual_payload["packages"],
+            {
+                "approved_by": manual_payload.get("updated_by"),
+                "approved_at": manual_payload.get("updated_at"),
+            },
+        )
+        for contribution, _ in contributions:
+            apply(
+                contribution["packages"],
+                {
+                    "approved_by": contribution["author"],
+                    "approved_at": contribution["timestamp"],
+                },
+            )
+
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory)
+            merge_mappings.main(
+                ROOT / "mappings" / "auto.json",
+                ROOT / "mappings" / "manual.json",
+                ROOT / "mappings" / "contributions",
+                ROOT / "mappings" / "top_downloads.json",
+                output / "mappings.json",
+                output / "mappings-index.json",
+                output / "mapping_packages",
+                generated_at=GENERATED_AT,
+            )
+            actual = json.loads((output / "mappings.json").read_text())["packages"]
+        for name in identity_only_names:
+            with self.subTest(package=name):
+                for key in ("status", "source", "approved_by", "approved_at"):
+                    wanted = expected[name][key]
+                    if wanted is missing:
+                        self.assertNotIn(key, actual[name])
+                    else:
+                        self.assertEqual(actual[name].get(key), wanted)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/package.json
+++ b/web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
+    "test": "node --test src/data/loader.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/web/src/data/loader.test.mjs
+++ b/web/src/data/loader.test.mjs
@@ -1,0 +1,305 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { after, before, test } from "node:test";
+import { createServer } from "vite";
+
+let server;
+let loader;
+const responses = new Map();
+const realFetch = globalThis.fetch;
+
+before(async () => {
+  server = await createServer({
+    server: { middlewareMode: true },
+    appType: "custom",
+    logLevel: "error",
+  });
+  loader = await server.ssrLoadModule("/src/data/loader.ts");
+  globalThis.fetch = async (url) => {
+    const key = String(url);
+    if (!responses.has(key)) throw new Error(`Unexpected test fetch: ${key}`);
+    const value = responses.get(key);
+    return new Response(JSON.stringify(value), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  };
+});
+
+after(async () => {
+  globalThis.fetch = realFetch;
+  await server?.close();
+});
+
+function metadata(schemaVersion, packages) {
+  return {
+    schema_version: schemaVersion,
+    generated_at: "2026-01-01T00:00:00Z",
+    auto_generated_at: "2026-01-01T00:00:00Z",
+    manual_updated_at: null,
+    channel: "conda-forge",
+    package_count: Object.keys(packages).length,
+    packages,
+  };
+}
+
+function alternative(owner, confidence) {
+  return {
+    purl: `pkg:github/${owner}/demo`,
+    type: "github",
+    namespace: owner,
+    pkg_name: "demo",
+    confidence,
+    source: "recipe-source",
+  };
+}
+
+function alternativeIdentity(value, confidence) {
+  return {
+    kind: "purl",
+    role: "alternative",
+    value: value.purl,
+    coordinates: {
+      type: value.type,
+      namespace: value.namespace,
+      pkg_name: value.pkg_name,
+    },
+    provenance: {
+      availability: "available",
+      source: value.source,
+      confidence,
+    },
+  };
+}
+
+function fixture(name, detailPath) {
+  const alternatives = [alternative("one", 0.8), alternative("two", 0.7)];
+  const identities = [
+    {
+      kind: "purl",
+      role: "primary",
+      value: "pkg:pypi/demo",
+      provenance: {
+        availability: "available",
+        source: "auto",
+        confidence: 0.9,
+        sources: ["recipe-source"],
+        review: { status: "auto-verified", reviewer: null },
+      },
+    },
+    alternativeIdentity(alternatives[0], 0.8),
+    alternativeIdentity(alternatives[1], 0.7),
+    {
+      kind: "cpe",
+      role: "associated",
+      value: "cpe:2.3:a:example:demo",
+      provenance: { availability: "unavailable" },
+    },
+  ];
+  const common = {
+    name,
+    version: "1.0",
+    purl: "pkg:pypi/demo",
+    type: "pypi",
+    namespace: null,
+    pkg_name: "demo",
+    status: "auto-verified",
+    download_count: 42,
+    alternative_purls: alternatives,
+    cpes: ["cpe:2.3:a:example:demo"],
+    identities,
+    auto: {
+      purl: "pkg:pypi/demo",
+      type: "pypi",
+      namespace: null,
+      pkg_name: "demo",
+      confidence: 0.9,
+      sources: ["recipe-source"],
+      alternative_purls: structuredClone(alternatives),
+    },
+  };
+  const index = { ...structuredClone(common), detail_path: detailPath };
+  const detail = {
+    ...structuredClone(common),
+    build: "py_0",
+    subdir: "noarch",
+    url: "https://example.invalid/demo.conda",
+    confidence: 0.9,
+    sources: ["recipe-source"],
+    homepage: null,
+    repo: null,
+    recipe_url: null,
+    summary: "demo",
+    source_url: null,
+    note: null,
+    fetched_at: "2026-01-01T00:00:00Z",
+    auto_verified: true,
+    verification_sources: ["recipe-inference"],
+    source: "auto",
+  };
+  return { index, detail };
+}
+
+let sequence = 0;
+async function loadCurrentCase(mutateDetail = () => {}) {
+  const id = sequence++;
+  const name = `demo-${id}`;
+  const indexPath = `./hostile-index-${id}.json`;
+  const detailPath = `hostile-detail-${id}.json`;
+  const { index, detail } = fixture(name, detailPath);
+  mutateDetail(detail);
+  responses.set(indexPath, metadata(3, { [name]: index }));
+  responses.set(`./${detailPath}`, { schema_version: 2, packages: { [name]: detail } });
+  const decodedIndex = await loader.loadMappingsIndex(indexPath);
+  return loader.loadMappingPackageDetail(decodedIndex.packages[name]);
+}
+
+test("current index and detail accept an identical normalized identity contract", async () => {
+  const detail = await loadCurrentCase();
+  assert.equal(detail.purl, "pkg:pypi/demo");
+});
+
+test("hostile current shards cannot replace an internally valid index identity contract", async (t) => {
+  const cases = {
+    "reviewer payload: mutually different primary PURLs": (detail) => {
+      detail.purl = "pkg:pypi/replacement";
+      detail.identities[0].value = detail.purl;
+    },
+    "reviewer payload: mutually different identity provenance": (detail) => {
+      detail.identities[0].provenance.confidence = 0.25;
+    },
+    "alternative value": (detail) => {
+      detail.alternative_purls[0].purl = "pkg:github/attacker/demo";
+      detail.identities[1].value = detail.alternative_purls[0].purl;
+    },
+    "alternative ordering": (detail) => {
+      detail.alternative_purls.reverse();
+      const primary = detail.identities[0];
+      const cpe = detail.identities.at(-1);
+      detail.identities = [primary, detail.identities[2], detail.identities[1], cpe];
+    },
+    "CPE value": (detail) => {
+      detail.cpes[0] = "cpe:2.3:a:attacker:demo";
+      detail.identities.at(-1).value = detail.cpes[0];
+    },
+    status: (detail) => {
+      detail.status = "auto-unverified";
+    },
+    "legacy package type": (detail) => {
+      detail.type = "npm";
+    },
+    "legacy package namespace": (detail) => {
+      detail.namespace = "attacker";
+    },
+    "legacy package name coordinates": (detail) => {
+      detail.pkg_name = "replacement";
+    },
+    version: (detail) => {
+      detail.version = "2.0";
+    },
+    "download metadata": (detail) => {
+      detail.download_count = 99;
+    },
+    "automatic mapping metadata": (detail) => {
+      detail.auto.confidence = 0.1;
+    },
+  };
+  for (const [label, mutate] of Object.entries(cases)) {
+    await t.test(label, async () => {
+      await assert.rejects(loadCurrentCase(mutate), /identity contract mismatch/);
+    });
+  }
+});
+
+function legacyBundle(id) {
+  const name = `legacy-${id}`;
+  const { detail } = fixture(name, "unused.json");
+  delete detail.identities;
+  return metadata(1, { [name]: detail });
+}
+
+test("legacy schemas reject malformed required metadata and field types", async (t) => {
+  const cases = {
+    "boolean generated_at": (payload) => {
+      payload.generated_at = true;
+    },
+    "numeric channel": (payload) => {
+      payload.channel = 7;
+    },
+    "object package_count": (payload) => {
+      payload.package_count = {};
+    },
+    "missing required summary": (payload) => {
+      delete Object.values(payload.packages)[0].summary;
+    },
+    "boolean confidence": (payload) => {
+      Object.values(payload.packages)[0].confidence = true;
+    },
+    "object sources": (payload) => {
+      Object.values(payload.packages)[0].sources = {};
+    },
+    "numeric status": (payload) => {
+      Object.values(payload.packages)[0].status = 1;
+    },
+    "object source": (payload) => {
+      Object.values(payload.packages)[0].source = {};
+    },
+    "numeric optional auto_verified": (payload) => {
+      Object.values(payload.packages)[0].auto_verified = 1;
+    },
+    "object nullable note": (payload) => {
+      Object.values(payload.packages)[0].note = {};
+    },
+    "boolean alternative confidence": (payload) => {
+      Object.values(payload.packages)[0].alternative_purls[0].confidence = false;
+    },
+    "missing auto confidence": (payload) => {
+      const entry = Object.values(payload.packages)[0];
+      entry.auto = {
+        purl: entry.purl,
+        type: entry.type,
+        namespace: entry.namespace,
+        pkg_name: entry.pkg_name,
+        sources: entry.sources,
+      };
+    },
+  };
+  for (const [label, mutate] of Object.entries(cases)) {
+    await t.test(label, async () => {
+      const id = sequence++;
+      const payload = legacyBundle(id);
+      mutate(payload);
+      const bundlePath = `./malformed-legacy-${id}.json`;
+      responses.set(bundlePath, payload);
+      await assert.rejects(loader.loadMappings(bundlePath));
+    });
+  }
+});
+
+test("browser decoder accepts every entry in the checked-in 33,287-entry legacy snapshot", async () => {
+  const publicDir = path.resolve("public");
+  const index = JSON.parse(await readFile(path.join(publicDir, "mappings-index.json"), "utf8"));
+  assert.equal(index.schema_version, 2);
+  assert.equal(index.package_count, 33_287);
+
+  responses.set("./real-legacy-index.json", index);
+  const detailPaths = new Set(Object.values(index.packages).map((entry) => entry.detail_path));
+  await Promise.all(
+    [...detailPaths].map(async (detailPath) => {
+      const payload = JSON.parse(await readFile(path.join(publicDir, detailPath), "utf8"));
+      responses.set(`./${detailPath}`, payload);
+    }),
+  );
+
+  const decoded = await loader.loadMappingsIndex("./real-legacy-index.json");
+  const firstByShard = new Map();
+  for (const entry of Object.values(decoded.packages)) {
+    if (!firstByShard.has(entry.detail_path)) firstByShard.set(entry.detail_path, entry);
+  }
+  await Promise.all(
+    [...firstByShard.values()].map((entry) => loader.loadMappingPackageDetail(entry)),
+  );
+  assert.equal(Object.keys(decoded.packages).length, 33_287);
+  assert.equal(firstByShard.size, detailPaths.size);
+});

--- a/web/src/data/loader.ts
+++ b/web/src/data/loader.ts
@@ -1,5 +1,6 @@
 import { fetchJsonWithProgress } from "./progressFetch";
 import type {
+  MappingDetailPayload,
   MappingPackageIndex,
   MappingsIndexPayload,
   MappingsPayload,
@@ -8,44 +9,691 @@ import type {
 
 const DEFAULT_PATH = "./mappings.json";
 const DEFAULT_INDEX_PATH = "./mappings-index.json";
+const SUPPORTED_BUNDLE_SCHEMAS = new Set([1, 2]);
+const SUPPORTED_INDEX_SCHEMAS = new Set([2, 3]);
+const SUPPORTED_DETAIL_SCHEMAS = new Set([1, 2]);
+const PURL_PATTERN = /^pkg:[a-z][a-z0-9.+-]*\/[^\s?#]+(?:\?[^\s#]+)?(?:#[^\s]+)?$/;
+const CPE_PATTERN = /^cpe:2\.3:[aho*\-]:[^:]+:[^:]+(?::[^:]*){0,10}$/;
+const REVIEW_STATUSES = new Set([
+  "auto-unverified",
+  "auto-verified",
+  "verified",
+  "unmapped",
+  "edited",
+]);
+const ALTERNATIVE_SOURCES = new Set([
+  "recipe-source",
+  "recipe-deps",
+  "recipe-source+recipe-deps",
+  "parselmouth-artifact",
+]);
+
+const FULL_ENTRY_KEYS = [
+  "name",
+  "version",
+  "build",
+  "subdir",
+  "url",
+  "purl",
+  "type",
+  "namespace",
+  "pkg_name",
+  "confidence",
+  "sources",
+  "homepage",
+  "repo",
+  "recipe_url",
+  "summary",
+  "source_url",
+  "note",
+  "fetched_at",
+  "status",
+  "source",
+  "unmapped",
+  "approved_by",
+  "approved_at",
+  "alternative_purls",
+  "auto_verified",
+  "verification_sources",
+  "cpes",
+  "identities",
+  "auto",
+  "download_count",
+] as const;
+const INDEX_ENTRY_KEYS = [
+  "name",
+  "version",
+  "purl",
+  "type",
+  "namespace",
+  "pkg_name",
+  "status",
+  "download_count",
+  "alternative_purls",
+  "unmapped",
+  "cpes",
+  "identities",
+  "auto",
+  "detail_path",
+] as const;
 
 const jsonCache = new Map<string, Promise<unknown>>();
+type IndexDecode = {
+  schemaVersion: number;
+  name: string;
+  detailPath: string;
+  includeAuto: boolean;
+  includeDownloadCount: boolean;
+  identityContract: string;
+};
+const indexDecodeByPackage = new WeakMap<object, IndexDecode>();
 
-async function loadJsonCached<T>(path: string): Promise<T> {
+async function loadJsonCached(path: string): Promise<unknown> {
   const cached = jsonCache.get(path);
-  if (cached) return cached as Promise<T>;
-  const promise = fetchJsonWithProgress<T>(path, { cache: "no-cache" });
+  if (cached) return cached;
+  const promise = fetchJsonWithProgress<unknown>(path, { cache: "no-cache" });
   jsonCache.set(path, promise);
   promise.catch(() => jsonCache.delete(path));
   return promise;
 }
 
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be a JSON object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function hasOwn(value: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function required(value: Record<string, unknown>, key: string, label: string): unknown {
+  if (!hasOwn(value, key)) throw new Error(`${label}.${key} is required`);
+  return value[key];
+}
+
+function stringValue(value: unknown, label: string, allowEmpty = true): string {
+  if (typeof value !== "string" || (!allowEmpty && value.length === 0)) {
+    throw new Error(`${label} must be ${allowEmpty ? "a string" : "a non-empty string"}`);
+  }
+  return value;
+}
+
+function nullableString(value: unknown, label: string): string | null {
+  if (value === null) return null;
+  return stringValue(value, label);
+}
+
+function finiteNumber(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${label} must be a finite number`);
+  }
+  return value;
+}
+
+function nullableFiniteNumber(value: unknown, label: string): number | null {
+  if (value === null) return null;
+  return finiteNumber(value, label);
+}
+
+function stringArray(value: unknown, label: string): string[] {
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
+    throw new Error(`${label} must be an array of strings`);
+  }
+  return value;
+}
+
+function hasOnlyKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+): boolean {
+  return Object.keys(value).every((key) => allowed.includes(key));
+}
+
+function requireOnlyKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  label: string,
+): void {
+  if (!hasOnlyKeys(value, allowed)) {
+    throw new Error(`${label} contains unsupported fields`);
+  }
+}
+
+function decodeVersionedPayload(
+  value: unknown,
+  label: string,
+  supported: Set<number>,
+  metadata: boolean,
+): Record<string, unknown> {
+  const payload = record(value, label);
+  if (
+    typeof payload.schema_version !== "number" ||
+    !Number.isInteger(payload.schema_version) ||
+    !supported.has(payload.schema_version)
+  ) {
+    throw new Error(
+      `${label} has unsupported schema_version ${String(payload.schema_version)}; ` +
+        `supported versions are ${[...supported].join(", ")}`,
+    );
+  }
+  const packages = record(payload.packages, `${label}.packages`);
+  if (metadata) {
+    nullableString(required(payload, "generated_at", label), `${label}.generated_at`);
+    nullableString(
+      required(payload, "auto_generated_at", label),
+      `${label}.auto_generated_at`,
+    );
+    nullableString(
+      required(payload, "manual_updated_at", label),
+      `${label}.manual_updated_at`,
+    );
+    stringValue(required(payload, "channel", label), `${label}.channel`, false);
+    const packageCount = finiteNumber(
+      required(payload, "package_count", label),
+      `${label}.package_count`,
+    );
+    if (!Number.isInteger(packageCount) || packageCount < 0) {
+      throw new Error(`${label}.package_count must be a non-negative integer`);
+    }
+    if (packageCount !== Object.keys(packages).length) {
+      throw new Error(`${label}.package_count does not match packages`);
+    }
+  }
+  return payload;
+}
+
+function decodePurl(value: unknown, label: string): string {
+  const purl = stringValue(value, label, false);
+  if (!PURL_PATTERN.test(purl)) throw new Error(`${label} must be a valid PURL`);
+  return purl;
+}
+
+function decodeNullablePurl(value: unknown, label: string): string | null {
+  return value === null ? null : decodePurl(value, label);
+}
+
+function decodeAlternative(
+  value: unknown,
+  label: string,
+  allowBare: boolean,
+): string | Record<string, unknown> {
+  if (typeof value === "string") {
+    if (!allowBare) throw new Error(`${label} must be a detailed PURL alternative`);
+    return decodePurl(value, label);
+  }
+  const alternative = record(value, label);
+  const keys = ["purl", "type", "namespace", "pkg_name", "confidence", "source"];
+  requireOnlyKeys(alternative, keys, label);
+  for (const key of keys) required(alternative, key, label);
+  decodePurl(alternative.purl, `${label}.purl`);
+  stringValue(alternative.type, `${label}.type`, false);
+  nullableString(alternative.namespace, `${label}.namespace`);
+  stringValue(alternative.pkg_name, `${label}.pkg_name`, false);
+  finiteNumber(alternative.confidence, `${label}.confidence`);
+  stringValue(alternative.source, `${label}.source`, false);
+  return alternative;
+}
+
+function decodeAlternatives(
+  value: unknown,
+  label: string,
+  allowBare: boolean,
+): (string | Record<string, unknown>)[] {
+  if (value === null || value === undefined) return [];
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array or null`);
+  const seen = new Set<string>();
+  return value.map((item, index) => {
+    const decoded = decodeAlternative(item, `${label}[${index}]`, allowBare);
+    const purl = typeof decoded === "string" ? decoded : (decoded.purl as string);
+    if (seen.has(purl)) throw new Error(`${label}[${index}] duplicates ${purl}`);
+    seen.add(purl);
+    return decoded;
+  });
+}
+
+function decodeCpes(value: unknown, label: string): string[] {
+  if (value === null || value === undefined) return [];
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array or null`);
+  const seen = new Set<string>();
+  return value.map((item, index) => {
+    if (typeof item !== "string" || !CPE_PATTERN.test(item)) {
+      throw new Error(`${label}[${index}] must be a valid CPE 2.3 prefix`);
+    }
+    if (seen.has(item)) throw new Error(`${label}[${index}] duplicates ${item}`);
+    seen.add(item);
+    return item;
+  });
+}
+
+function decodeAutoMapping(value: unknown, label: string): void {
+  const auto = record(value, label);
+  const keys = [
+    "purl",
+    "type",
+    "namespace",
+    "pkg_name",
+    "confidence",
+    "sources",
+    "alternative_purls",
+  ];
+  requireOnlyKeys(auto, keys, label);
+  for (const key of ["purl", "type", "namespace", "pkg_name", "confidence", "sources"]) {
+    required(auto, key, label);
+  }
+  decodeNullablePurl(auto.purl, `${label}.purl`);
+  nullableString(auto.type, `${label}.type`);
+  nullableString(auto.namespace, `${label}.namespace`);
+  nullableString(auto.pkg_name, `${label}.pkg_name`);
+  finiteNumber(auto.confidence, `${label}.confidence`);
+  stringArray(auto.sources, `${label}.sources`);
+  if (hasOwn(auto, "alternative_purls")) {
+    decodeAlternatives(auto.alternative_purls, `${label}.alternative_purls`, false);
+  }
+}
+
+function decodeIdentity(value: unknown, label: string): void {
+  const identity = record(value, label);
+  const identityValue = stringValue(identity.value, `${label}.value`, false);
+  if (identity.kind === "purl" && !PURL_PATTERN.test(identityValue)) {
+    throw new Error(`${label}.value must be a valid PURL`);
+  }
+  if (identity.kind === "cpe" && !CPE_PATTERN.test(identityValue)) {
+    throw new Error(`${label}.value must be a valid CPE 2.3 prefix`);
+  }
+  const allowedIdentityKeys =
+    identity.kind === "purl" && identity.role === "alternative"
+      ? ["kind", "role", "value", "coordinates", "provenance"]
+      : ["kind", "role", "value", "provenance"];
+  requireOnlyKeys(identity, allowedIdentityKeys, label);
+  const provenance = record(identity.provenance, `${label}.provenance`);
+  if (identity.kind === "purl" && identity.role === "primary") {
+    if (provenance.availability !== "available") {
+      throw new Error(`${label} primary provenance must be available`);
+    }
+    const review = record(provenance.review, `${label}.provenance.review`);
+    if (provenance.source === "auto") {
+      if (
+        !hasOnlyKeys(provenance, [
+          "availability",
+          "source",
+          "confidence",
+          "sources",
+          "review",
+        ]) ||
+        !hasOnlyKeys(review, ["status", "reviewer"]) ||
+        typeof provenance.confidence !== "number" ||
+        !Number.isFinite(provenance.confidence) ||
+        !Array.isArray(provenance.sources) ||
+        !provenance.sources.every((source) => typeof source === "string") ||
+        !["auto-unverified", "auto-verified"].includes(String(review.status)) ||
+        review.reviewer !== null
+      ) {
+        throw new Error(`${label} has malformed automatic primary provenance`);
+      }
+    } else if (provenance.source === "manual") {
+      if (
+        !hasOnlyKeys(provenance, ["availability", "source", "review"]) ||
+        !hasOnlyKeys(review, ["status", "reviewer", "reviewed_at"]) ||
+        !["verified", "edited"].includes(String(review.status)) ||
+        typeof review.reviewer !== "string" ||
+        review.reviewer.length === 0 ||
+        typeof review.reviewed_at !== "string" ||
+        !/(?:Z|[+-]\d{2}:\d{2})$/.test(review.reviewed_at) ||
+        !Number.isFinite(Date.parse(review.reviewed_at))
+      ) {
+        throw new Error(`${label} has malformed manual primary provenance`);
+      }
+    } else {
+      throw new Error(`${label} has unsupported primary source`);
+    }
+  } else if (identity.kind === "purl" && identity.role === "alternative") {
+    if (provenance.availability === "available") {
+      const coordinates = record(identity.coordinates, `${label}.coordinates`);
+      if (
+        !hasOnlyKeys(provenance, ["availability", "source", "confidence"]) ||
+        !hasOnlyKeys(coordinates, ["type", "namespace", "pkg_name"]) ||
+        typeof coordinates.type !== "string" ||
+        coordinates.type.length === 0 ||
+        (coordinates.namespace !== null && typeof coordinates.namespace !== "string") ||
+        typeof coordinates.pkg_name !== "string" ||
+        coordinates.pkg_name.length === 0 ||
+        !ALTERNATIVE_SOURCES.has(String(provenance.source)) ||
+        typeof provenance.confidence !== "number" ||
+        !Number.isFinite(provenance.confidence)
+      ) {
+        throw new Error(`${label} has malformed detailed alternative provenance`);
+      }
+    } else if (
+      provenance.availability !== "unavailable" ||
+      !hasOnlyKeys(provenance, ["availability"]) ||
+      "coordinates" in identity
+    ) {
+      throw new Error(`${label} has unsupported alternative provenance`);
+    }
+  } else if (identity.kind === "cpe" && identity.role === "associated") {
+    if (
+      provenance.availability !== "unavailable" ||
+      !hasOnlyKeys(provenance, ["availability"])
+    ) {
+      throw new Error(`${label} CPE provenance must be unavailable`);
+    }
+  } else {
+    throw new Error(`${label} has unsupported identity kind/role`);
+  }
+}
+
+type IdentitySummary = { kind: "purl" | "cpe"; role: string; value: string };
+
+function decodeLegacyIdentityFields(
+  entry: Record<string, unknown>,
+  label: string,
+): IdentitySummary[] {
+  const expected: IdentitySummary[] = [];
+  const purl = decodeNullablePurl(required(entry, "purl", label), `${label}.purl`);
+  nullableString(required(entry, "type", label), `${label}.type`);
+  nullableString(required(entry, "namespace", label), `${label}.namespace`);
+  nullableString(required(entry, "pkg_name", label), `${label}.pkg_name`);
+  const alternatives = decodeAlternatives(
+    entry.alternative_purls,
+    `${label}.alternative_purls`,
+    true,
+  );
+  const cpes = decodeCpes(entry.cpes, `${label}.cpes`);
+  const unmapped = hasOwn(entry, "unmapped") ? entry.unmapped : false;
+  if (typeof unmapped !== "boolean") throw new Error(`${label}.unmapped must be a boolean`);
+  if (hasOwn(entry, "auto")) decodeAutoMapping(entry.auto, `${label}.auto`);
+
+  const seenPurls = new Set<string>();
+  if (purl !== null) {
+    if (unmapped) throw new Error(`${label} cannot be unmapped with a primary PURL`);
+    seenPurls.add(purl);
+    expected.push({ kind: "purl", role: "primary", value: purl });
+  }
+  alternatives.forEach((alternative, index) => {
+    const value =
+      typeof alternative === "string" ? alternative : (alternative.purl as string);
+    if (seenPurls.has(value)) {
+      throw new Error(`${label}.alternative_purls[${index}] duplicates ${value}`);
+    }
+    seenPurls.add(value);
+    expected.push({ kind: "purl", role: "alternative", value });
+  });
+  if (unmapped && alternatives.length > 0) {
+    throw new Error(`${label} cannot be unmapped with alternative PURLs`);
+  }
+  expected.push(...cpes.map((value) => ({ kind: "cpe" as const, role: "associated", value })));
+  return expected;
+}
+
+function decodeCommonEntry(
+  entry: Record<string, unknown>,
+  name: string,
+  label: string,
+): IdentitySummary[] {
+  if (stringValue(required(entry, "name", label), `${label}.name`, false) !== name) {
+    throw new Error(`${label}.name must match package key ${name}`);
+  }
+  stringValue(required(entry, "version", label), `${label}.version`);
+  const status = stringValue(required(entry, "status", label), `${label}.status`);
+  if (!REVIEW_STATUSES.has(status)) throw new Error(`${label}.status is unsupported`);
+  if (hasOwn(entry, "download_count")) {
+    nullableFiniteNumber(entry.download_count, `${label}.download_count`);
+  }
+  return decodeLegacyIdentityFields(entry, label);
+}
+
+function decodeIndexEntry(
+  entry: Record<string, unknown>,
+  name: string,
+  current: boolean,
+  label: string,
+): void {
+  requireOnlyKeys(entry, INDEX_ENTRY_KEYS, label);
+  const expected = decodeCommonEntry(entry, name, label);
+  stringValue(required(entry, "detail_path", label), `${label}.detail_path`, false);
+  decodeCurrentIdentities(entry, expected, current, label);
+}
+
+function decodeFullEntry(
+  entry: Record<string, unknown>,
+  name: string,
+  current: boolean,
+  label: string,
+): void {
+  requireOnlyKeys(entry, FULL_ENTRY_KEYS, label);
+  const expected = decodeCommonEntry(entry, name, label);
+  for (const key of ["build", "subdir", "url"] as const) {
+    if (hasOwn(entry, key)) stringValue(entry[key], `${label}.${key}`);
+  }
+  finiteNumber(required(entry, "confidence", label), `${label}.confidence`);
+  stringArray(required(entry, "sources", label), `${label}.sources`);
+  for (const key of [
+    "homepage",
+    "repo",
+    "recipe_url",
+    "summary",
+    "source_url",
+    "note",
+    "fetched_at",
+  ] as const) {
+    nullableString(required(entry, key, label), `${label}.${key}`);
+  }
+  const source = stringValue(required(entry, "source", label), `${label}.source`);
+  if (source !== "auto" && source !== "manual") {
+    throw new Error(`${label}.source must be auto or manual`);
+  }
+  for (const key of ["approved_by", "approved_at"] as const) {
+    if (hasOwn(entry, key)) stringValue(entry[key], `${label}.${key}`);
+  }
+  if (hasOwn(entry, "auto_verified") && typeof entry.auto_verified !== "boolean") {
+    throw new Error(`${label}.auto_verified must be a boolean`);
+  }
+  if (hasOwn(entry, "verification_sources") && entry.verification_sources !== null) {
+    stringArray(entry.verification_sources, `${label}.verification_sources`);
+  }
+  decodeCurrentIdentities(entry, expected, current, label);
+}
+
+function decodeCurrentIdentities(
+  entry: Record<string, unknown>,
+  expected: IdentitySummary[],
+  current: boolean,
+  label: string,
+): void {
+  if (!current) {
+    if (hasOwn(entry, "identities")) {
+      throw new Error(`${label}.identities is not supported by this schema`);
+    }
+    return;
+  }
+  if (!Array.isArray(entry.identities)) {
+    throw new Error(`${label}.identities must be an array`);
+  }
+  const seenValues = new Set<string>();
+  const actual = entry.identities.map((identity, index) => {
+    const identityLabel = `${label}.identities[${index}]`;
+    decodeIdentity(identity, identityLabel);
+    const decoded = record(identity, identityLabel);
+    const value = decoded.value as string;
+    if (seenValues.has(value)) {
+      throw new Error(`${identityLabel} duplicates identity value ${value}`);
+    }
+    seenValues.add(value);
+    return { kind: decoded.kind, role: decoded.role, value };
+  });
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`${label}.identities must exactly match legacy identity values and order`);
+  }
+
+  const alternatives = decodeAlternatives(
+    entry.alternative_purls,
+    `${label}.alternative_purls`,
+    true,
+  );
+  let alternativeIndex = 0;
+  for (const identity of entry.identities) {
+    const decoded = record(identity, `${label}.identities`);
+    if (decoded.kind !== "purl" || decoded.role !== "alternative") continue;
+    const legacy = alternatives[alternativeIndex++];
+    if (typeof legacy === "object") {
+      const coordinates = record(decoded.coordinates, `${label}.identity.coordinates`);
+      const provenance = record(decoded.provenance, `${label}.identity.provenance`);
+      if (
+        coordinates.type !== legacy.type ||
+        coordinates.namespace !== legacy.namespace ||
+        coordinates.pkg_name !== legacy.pkg_name ||
+        provenance.availability !== "available" ||
+        provenance.source !== legacy.source ||
+        provenance.confidence !== legacy.confidence
+      ) {
+        throw new Error(
+          `${label}.identities alternative does not match legacy coordinates/provenance`,
+        );
+      }
+    } else if (
+      JSON.stringify(decoded.provenance) !==
+        JSON.stringify({ availability: "unavailable" }) ||
+      "coordinates" in decoded
+    ) {
+      throw new Error(`${label}.identities bare alternative has unexpected provenance`);
+    }
+  }
+}
+
+type PackageShape = "index" | "full";
+
+function decodePackages(
+  payload: Record<string, unknown>,
+  currentVersion: number,
+  label: string,
+  shape: PackageShape,
+): void {
+  const packages = record(payload.packages, `${label}.packages`);
+  const current = payload.schema_version === currentVersion;
+  for (const [name, rawEntry] of Object.entries(packages)) {
+    if (name.length === 0) throw new Error(`${label} has an empty package name`);
+    const entryLabel = `${label}.packages.${name}`;
+    const entry = record(rawEntry, entryLabel);
+    if (shape === "index") decodeIndexEntry(entry, name, current, entryLabel);
+    else decodeFullEntry(entry, name, current, entryLabel);
+  }
+}
+
+function normalizedIndexIdentityContract(
+  entry: Record<string, unknown>,
+  includeAuto = hasOwn(entry, "auto"),
+  includeDownloadCount = hasOwn(entry, "download_count"),
+): string {
+  const contract: Record<string, unknown> = {
+    name: entry.name,
+    version: entry.version,
+    purl: entry.purl,
+    type: entry.type,
+    namespace: entry.namespace,
+    pkg_name: entry.pkg_name,
+    status: entry.status,
+    unmapped: entry.unmapped === true,
+    alternative_purls: entry.alternative_purls ?? [],
+    cpes: entry.cpes ?? [],
+    identities: entry.identities,
+  };
+  if (includeDownloadCount) contract.download_count = entry.download_count;
+  if (includeAuto) contract.auto = entry.auto;
+  return JSON.stringify(contract);
+}
+
 export async function loadMappings(path = DEFAULT_PATH): Promise<MappingsPayload> {
-  return loadJsonCached<MappingsPayload>(path);
+  const payload = decodeVersionedPayload(
+    await loadJsonCached(path),
+    "mapping bundle",
+    SUPPORTED_BUNDLE_SCHEMAS,
+    true,
+  );
+  decodePackages(payload, 2, "mapping bundle", "full");
+  return payload as MappingsPayload;
 }
 
 export async function loadMappingsIndex(
   path = DEFAULT_INDEX_PATH,
 ): Promise<MappingsIndexPayload> {
-  return loadJsonCached<MappingsIndexPayload>(path);
+  const payload = decodeVersionedPayload(
+    await loadJsonCached(path),
+    "mapping index",
+    SUPPORTED_INDEX_SCHEMAS,
+    true,
+  );
+  decodePackages(payload, 3, "mapping index", "index");
+  const packages = record(payload.packages, "mapping index.packages");
+  for (const [name, rawEntry] of Object.entries(packages)) {
+    const entry = record(rawEntry, `mapping index.packages.${name}`);
+    const includeAuto = hasOwn(entry, "auto");
+    const includeDownloadCount = hasOwn(entry, "download_count");
+    indexDecodeByPackage.set(entry, {
+      schemaVersion: payload.schema_version as number,
+      name,
+      detailPath: entry.detail_path as string,
+      includeAuto,
+      includeDownloadCount,
+      identityContract: normalizedIndexIdentityContract(
+        entry,
+        includeAuto,
+        includeDownloadCount,
+      ),
+    });
+  }
+  return payload as MappingsIndexPayload;
 }
 
 export async function loadMappingPackageDetail(
-  pkgOrPath: MappingPackageIndex | string,
+  pkg: MappingPackageIndex,
 ): Promise<PackageEntry> {
-  if (typeof pkgOrPath === "string") {
-    return loadJsonCached<PackageEntry>(pkgOrPath);
+  const decodedIndex = indexDecodeByPackage.get(pkg);
+  if (decodedIndex === undefined) {
+    throw new Error(`Mapping package ${pkg.name} was not decoded from an index`);
   }
-  const path = `./${pkgOrPath.detail_path}`;
-  const data = await loadJsonCached<
-    PackageEntry | { packages: Record<string, PackageEntry> }
-  >(path);
-  if ("packages" in data) {
-    const detail = data.packages[pkgOrPath.name];
-    if (!detail) throw new Error(`Missing ${pkgOrPath.name} in ${path}`);
-    return detail;
+  const currentIndexContract = normalizedIndexIdentityContract(
+    pkg as unknown as Record<string, unknown>,
+  );
+  if (
+    pkg.name !== decodedIndex.name ||
+    pkg.detail_path !== decodedIndex.detailPath ||
+    currentIndexContract !== decodedIndex.identityContract
+  ) {
+    throw new Error(`Mapping index entry ${decodedIndex.name} changed after decoding`);
   }
-  return data;
+
+  const path = `./${decodedIndex.detailPath}`;
+  const payload = decodeVersionedPayload(
+    await loadJsonCached(path),
+    `mapping detail ${path}`,
+    SUPPORTED_DETAIL_SCHEMAS,
+    false,
+  );
+  decodePackages(payload, 2, `mapping detail ${path}`, "full");
+  const expectedDetailVersion = decodedIndex.schemaVersion === 3 ? 2 : 1;
+  if (payload.schema_version !== expectedDetailVersion) {
+    throw new Error(
+      `mapping index/detail schema mismatch: index ${decodedIndex.schemaVersion} requires detail ${expectedDetailVersion}`,
+    );
+  }
+  const data = payload as unknown as MappingDetailPayload;
+  const detail = data.packages[decodedIndex.name];
+  if (!detail) throw new Error(`Missing ${decodedIndex.name} in ${path}`);
+  if (
+    decodedIndex.schemaVersion === 3 &&
+    normalizedIndexIdentityContract(
+      detail as unknown as Record<string, unknown>,
+      decodedIndex.includeAuto,
+      decodedIndex.includeDownloadCount,
+    ) !== decodedIndex.identityContract
+  ) {
+    throw new Error(
+      `Mapping index/detail identity contract mismatch for ${decodedIndex.name}`,
+    );
+  }
+  return detail;
 }
 
 export function packagesAsList<T extends { name: string }>(payload: {

--- a/web/src/data/types.ts
+++ b/web/src/data/types.ts
@@ -17,6 +17,85 @@ export type PurlAlternative = {
   source: string;
 };
 
+export type ReviewStatus =
+  | "auto-unverified"
+  | "auto-verified"
+  | "verified"
+  | "unmapped"
+  | "edited";
+
+export type AutomaticPrimaryIdentity = {
+  kind: "purl";
+  role: "primary";
+  value: string;
+  provenance: {
+    availability: "available";
+    source: "auto";
+    confidence: number;
+    sources: string[];
+    review: {
+      status: "auto-unverified" | "auto-verified";
+      reviewer: null;
+    };
+  };
+};
+
+export type ManualPrimaryIdentity = {
+  kind: "purl";
+  role: "primary";
+  value: string;
+  provenance: {
+    availability: "available";
+    source: "manual";
+    review: {
+      status: "verified" | "edited";
+      reviewer: string;
+      reviewed_at: string;
+    };
+  };
+};
+
+export type BareAlternativeIdentity = {
+  kind: "purl";
+  role: "alternative";
+  value: string;
+  provenance: { availability: "unavailable" };
+};
+
+export type DetailedAlternativeIdentity = {
+  kind: "purl";
+  role: "alternative";
+  value: string;
+  coordinates: {
+    type: string;
+    namespace: string | null;
+    pkg_name: string;
+  };
+  provenance: {
+    availability: "available";
+    source:
+      | "recipe-source"
+      | "recipe-deps"
+      | "recipe-source+recipe-deps"
+      | "parselmouth-artifact";
+    confidence: number;
+  };
+};
+
+export type CpeIdentity = {
+  kind: "cpe";
+  role: "associated";
+  value: string;
+  provenance: { availability: "unavailable" };
+};
+
+export type PublishedIdentity =
+  | AutomaticPrimaryIdentity
+  | ManualPrimaryIdentity
+  | BareAlternativeIdentity
+  | DetailedAlternativeIdentity
+  | CpeIdentity;
+
 export type ManualOverride = {
   purl: string | null;
   type: string | null;
@@ -48,7 +127,7 @@ export type PackageEntry = {
   source_url: string | null;
   note: string | null;
   fetched_at: string | null;
-  status: "auto-unverified" | "auto-verified" | "verified" | "unmapped" | "edited";
+  status: ReviewStatus;
   source: "auto" | "manual";
   unmapped?: boolean;
   approved_by?: string;
@@ -58,6 +137,8 @@ export type PackageEntry = {
   verification_sources?: string[] | null;
   /** CPE 2.3 vendor/product prefixes for downstream NVD matching. */
   cpes?: string[] | null;
+  /** Versioned public per-identity provenance (absent on legacy schemas). */
+  identities?: PublishedIdentity[];
   /** the original auto guess, kept for diff display when an override exists */
   auto?: AutoMapping;
   /** total downloads on prefix.dev for this package (null if not ranked) */
@@ -77,24 +158,52 @@ export type MappingPackageIndex = Pick<
   | "alternative_purls"
   | "unmapped"
   | "cpes"
+  | "identities"
   | "auto"
 > & {
   detail_path: string;
 };
 
-export type MappingsPayload = {
-  schema_version: number;
+type MappingPayloadMetadata = {
   generated_at: string | null;
   auto_generated_at: string | null;
   manual_updated_at: string | null;
   channel: string;
   package_count: number;
+};
+
+export type LegacyMappingsPayload = MappingPayloadMetadata & {
+  schema_version: 1;
   packages: Record<string, PackageEntry>;
 };
 
-export type MappingsIndexPayload = Omit<MappingsPayload, "packages"> & {
+export type CurrentMappingsPayload = MappingPayloadMetadata & {
+  schema_version: 2;
+  packages: Record<string, PackageEntry & { identities: PublishedIdentity[] }>;
+};
+
+export type MappingsPayload = LegacyMappingsPayload | CurrentMappingsPayload;
+
+export type LegacyMappingsIndexPayload = MappingPayloadMetadata & {
+  schema_version: 2;
   packages: Record<string, MappingPackageIndex>;
 };
+
+export type CurrentMappingsIndexPayload = MappingPayloadMetadata & {
+  schema_version: 3;
+  packages: Record<MappingPackageIndex["name"], MappingPackageIndex & { identities: PublishedIdentity[] }>;
+};
+
+export type MappingsIndexPayload =
+  | LegacyMappingsIndexPayload
+  | CurrentMappingsIndexPayload;
+
+export type MappingDetailPayload =
+  | { schema_version: 1; packages: Record<string, PackageEntry> }
+  | {
+      schema_version: 2;
+      packages: Record<string, PackageEntry & { identities: PublishedIdentity[] }>;
+    };
 
 export type Edit = {
   type: string;


### PR DESCRIPTION
## Why

The published mapping currently has one review status for a whole package. That makes it look as though alternative PURLs and CPEs were reviewed together with the primary PURL, even when they came from different sources. It also drops useful source and confidence information from detailed alternative PURLs.

Basilisk needs to show where each identity came from without inventing review information. This adds that distinction to the published payload while keeping the existing fields available during migration.

## What changes

- Adds an ordered `identities` list that distinguishes the primary PURL, alternative PURLs, and associated CPEs.
- Keeps review status, reviewer, and review time on the primary PURL only.
- Preserves source and confidence for alternatives when upstream has them. Bare alternatives and CPEs explicitly report that provenance is unavailable.
- Handles unmapped packages without publishing the rejected automatic identity.
- Keeps the existing package-level fields so current consumers have a migration window.
- Advances the published schema versions and rejects unknown future versions instead of guessing.
- Rebuilds the expected identities from the mapping source files during validation, then checks the bundle, index, and shards against that source-derived result.
- Adds strict browser decoding for current and previous schemas.
- Runs the contract tests and validation before the GitHub Pages deployment.

The deployed GitHub Pages payload is the supported publication surface. Generated index and shard files are intentionally not committed in this PR; the Pages workflow regenerates them before deployment.

Linear: [PFX-1826](https://linear.app/prefix-dev/issue/PFX-1826/publish-per-identity-provenance-from-purl-associator)

## Rollout

Do not merge this before Basilisk PFX-1777 is deployed. The current Basilisk importer accepts index schema 2, while this publishes schema 3.

After PFX-1777 is live:

1. Merge this PR and wait for the Pages deployment.
2. Run or wait for Basilisk `mappings_sync`.
3. Verify the identity counts and provenance import. The successful sync will request a matching refresh.

No manual purl-associator data-generation step is needed after merge.

## Testing

- 13 Python contract and compatibility tests passed after rebasing onto current main.
- The real checked-in legacy snapshot and a regenerated 33,706-package mapping set passed the compatibility checks.
- Full mapping generation and validation passed during implementation.
- Browser runtime tests, web build and type checking, Worker type checking, Ruff, and `app:check` passed.
- Hostile cases cover malformed identities, mismatched bundle/index/shard data, non-finite confidence values, ownership changes, unmapped packages, schema pairing, and timezone-aware contribution ordering.

Existing npm audit findings remain unchanged. This PR does not update dependencies.