### PR TITLE
fix(mappings): drop inherited alternatives that collide with an overridden primary

### DIFF
--- a/scripts/merge_mappings.py
+++ b/scripts/merge_mappings.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 import math
 import re
+import sys
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -317,6 +318,39 @@ def _reviews_primary(override: dict) -> bool:
     )
 
 
+def _prune_colliding_alternatives(
+    alternatives: list, primary: Any, *, label: str
+) -> list:
+    """Drop alternatives that collide with the primary PURL or with each other.
+
+    Reviewed layers overlay field by field, so an override that promotes a PURL
+    the base layer already carried as an alternative inherits that alternative
+    untouched.  Per-file validation only ever sees one layer, so the collision
+    first exists in the merged record — dropping it here keeps a routine automap
+    demotion from failing ``scripts/validate.py`` and stalling the pipeline.
+    """
+    kept: list[Any] = []
+    seen: set[str] = set()
+    for alternative in alternatives:
+        purl = alternative if isinstance(alternative, str) else alternative["purl"]
+        if purl == primary:
+            print(
+                f"{label}: dropping inherited alternative {purl!r} now used as the "
+                "primary PURL",
+                file=sys.stderr,
+            )
+            continue
+        if purl in seen:
+            print(
+                f"{label}: dropping duplicate inherited alternative {purl!r}",
+                file=sys.stderr,
+            )
+            continue
+        seen.add(purl)
+        kept.append(alternative)
+    return kept
+
+
 def _effective_attribution(override: dict, attribution: dict, label: str) -> dict:
     reviewer = override.get("approved_by", attribution.get("approved_by"))
     reviewed_at = override.get("approved_at", attribution.get("approved_at"))
@@ -381,6 +415,11 @@ def _apply_reviewed_override(
                 "reviewed_at": current_attribution["approved_at"],
             },
         }
+
+    if result.get("alternative_purls"):
+        result["alternative_purls"] = _prune_colliding_alternatives(
+            result["alternative_purls"], result.get("purl"), label=label
+        )
 
     if name in auto_packages and "auto" not in result:
         result["auto"] = _auto_snapshot(auto_packages[name])

--- a/tests/test_identity_payload.py
+++ b/tests/test_identity_payload.py
@@ -781,5 +781,147 @@ class RealDataLegacyCompatibilityTest(unittest.TestCase):
                         self.assertEqual(actual[name].get(key), wanted)
 
 
+class OverriddenPrimaryAlternativeTest(unittest.TestCase):
+    """Reviewed layers overlay field by field, so an override that promotes a
+    PURL the auto layer already listed as an alternative inherits that
+    alternative untouched.  The merge has to resolve the collision itself —
+    per-file validation only ever sees one layer, and letting it reach
+    ``scripts/validate.py`` would fail CI on a routine automap demotion.
+    """
+
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        self.auto = self.root / "auto.json"
+        self.manual = self.root / "manual.json"
+        self.contributions = self.root / "contributions"
+        self.downloads = self.root / "downloads.json"
+        self.contributions.mkdir()
+        self._write_json(self.downloads, {"packages": []})
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    @staticmethod
+    def _write_json(path: Path, value: object) -> None:
+        path.write_text(json.dumps(value))
+
+    def _merge(self, auto_entry: dict, override: dict) -> dict:
+        self._write_json(
+            self.auto,
+            {
+                "schema_version": 1,
+                "generated_at": "2026-01-01T00:00:00Z",
+                "channel": "conda-forge",
+                "packages": {"widget": auto_entry},
+            },
+        )
+        self._write_json(
+            self.manual,
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00Z",
+                "updated_by": "package-reviewer",
+                "packages": {"widget": override},
+            },
+        )
+        self.bundle = self.root / "mappings.json"
+        self.index = self.root / "mappings-index.json"
+        self.details = self.root / "mapping_packages"
+        merge_mappings.main(
+            self.auto,
+            self.manual,
+            self.contributions,
+            self.downloads,
+            self.bundle,
+            self.index,
+            self.details,
+            generated_at=GENERATED_AT,
+        )
+        return json.loads(self.bundle.read_text())["packages"]["widget"]
+
+    def _validation_errors(self) -> list[str]:
+        errors: list[str] = []
+        validate.validate_mapping_alternatives(
+            self.manual, self.contributions, self.bundle, errors, self.auto
+        )
+        validate.validate_split_mappings(self.index, self.details, errors, self.bundle)
+        return errors
+
+    @staticmethod
+    def _auto_entry(alternatives: list) -> dict:
+        return {
+            "purl": "pkg:pypi/widget",
+            "type": "pypi",
+            "namespace": None,
+            "pkg_name": "widget",
+            "confidence": 0.9,
+            "sources": ["recipe-source"],
+            "alternative_purls": alternatives,
+        }
+
+    def test_inherited_alternative_matching_new_primary_is_dropped(self) -> None:
+        widget = self._merge(
+            self._auto_entry(["pkg:github/acme/widget"]),
+            {"purl": "pkg:github/acme/widget"},
+        )
+        self.assertEqual(widget["purl"], "pkg:github/acme/widget")
+        self.assertEqual(widget["alternative_purls"], [])
+        self.assertEqual(
+            [(item["role"], item["value"]) for item in widget["identities"]],
+            [("primary", "pkg:github/acme/widget")],
+        )
+        self.assertEqual(self._validation_errors(), [])
+
+    def test_detailed_inherited_alternative_matching_new_primary_is_dropped(
+        self,
+    ) -> None:
+        widget = self._merge(
+            self._auto_entry(
+                [
+                    {
+                        "purl": "pkg:github/acme/widget",
+                        "type": "github",
+                        "namespace": "acme",
+                        "pkg_name": "widget",
+                        "confidence": 0.6,
+                        "source": "recipe-source",
+                    }
+                ]
+            ),
+            {"purl": "pkg:github/acme/widget"},
+        )
+        self.assertEqual(widget["alternative_purls"], [])
+        self.assertEqual(self._validation_errors(), [])
+
+    def test_unrelated_inherited_alternatives_survive_the_override(self) -> None:
+        widget = self._merge(
+            self._auto_entry(["pkg:github/acme/widget", "pkg:npm/widget"]),
+            {"purl": "pkg:github/acme/widget"},
+        )
+        self.assertEqual(widget["alternative_purls"], ["pkg:npm/widget"])
+        self.assertEqual(self._validation_errors(), [])
+
+    def test_override_without_a_primary_keeps_inherited_alternatives(self) -> None:
+        widget = self._merge(
+            self._auto_entry(["pkg:github/acme/widget"]),
+            {"cpes": ["cpe:2.3:a:acme:widget"]},
+        )
+        self.assertEqual(widget["purl"], "pkg:pypi/widget")
+        self.assertEqual(widget["alternative_purls"], ["pkg:github/acme/widget"])
+        self.assertEqual(self._validation_errors(), [])
+
+    def test_override_supplied_alternatives_replace_the_inherited_list(self) -> None:
+        widget = self._merge(
+            self._auto_entry(["pkg:github/acme/widget"]),
+            {
+                "purl": "pkg:github/acme/widget",
+                "alternative_purls": ["pkg:pypi/widget"],
+            },
+        )
+        self.assertEqual(widget["alternative_purls"], ["pkg:pypi/widget"])
+        self.assertEqual(self._validation_errors(), [])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Reviewed mapping layers overlay field by field, so an override that sets `purl` and omits `alternative_purls` inherits the base layer's alternative list untouched. Nothing re-checks the merged combination, so when an override promotes a PURL the auto layer already carried as an alternative — a routine automap demotion, e.g. `pkg:pypi/widget` → `pkg:github/acme/widget` — the published entry lists that PURL as both primary and alternative.

`scripts/validate.py` does catch it, but only after the merge: duplicate identity value, and "primary PURL must not appear as an alternative". That fails the required check and stalls the bot PR instead of letting it land. 29 overrides in `mappings/manual.json` and the contributions currently have the vulnerable shape (set `purl`, omit `alternative_purls`), so this is waiting on the right automap refresh.

## What changes

`_apply_reviewed_override` now prunes the merged alternative list against the effective primary and against itself, logging each drop to stderr. It is a merge-time guard, not a redesign — the layering rules are untouched.

## After this

A demotion that promotes an existing alternative merges cleanly: the PURL appears once, as the primary, and `validate.py` passes. The collision no longer needs a human to unblock the pipeline.

The published payload is unchanged — no current override collides, and re-running `mappings:merge` over the real data produces byte-identical shards with and without the fix.

## Verification

- `mappings:test` — 18 tests pass (5 new in `OverriddenPrimaryAlternativeTest`; 3 of them fail without the fix)
- `mappings:merge` over the real data, then `mappings:validate` — clean
- `ruff check` / `ruff format --check`

Fixes #226. Stacked on #224 — review that one first; this PR targets its branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
