### PR TITLE
feat(web): surface per-identity provenance in the mapping editor

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
-    "test": "node --test src/data/loader.test.mjs",
+    "test": "node --test src/data/loader.test.mjs src/components/identityProvenance.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/web/src/components/IdentityProvenance.tsx
+++ b/web/src/components/IdentityProvenance.tsx
@@ -1,0 +1,276 @@
+import {
+  describeIdentities,
+  primaryReviewDivergence,
+  type IdentityDisplay,
+  type IdentityReviewDisplay,
+} from "../data/identityProvenance";
+import type { PublishedIdentity, ReviewStatus } from "../data/types";
+import {
+  ConfidenceBar,
+  CpeChip,
+  Glyph,
+  PurlChip,
+  SourceTag,
+  Theme,
+} from "./Primitives";
+
+type Props = {
+  theme: Theme;
+  identities: PublishedIdentity[] | null | undefined;
+  /** package-level review status, shown only to contrast it with the
+   *  per-identity review state — the two are different facts. */
+  mappingStatus: ReviewStatus | null | undefined;
+  /** true while a local draft is open: the rows describe what is published,
+   *  not what the editor above currently holds. */
+  stale?: boolean;
+};
+
+/** Published per-identity provenance (schema v3 `identities`). Renders nothing
+ *  for payloads that predate it. */
+export function IdentityProvenance({
+  theme,
+  identities,
+  mappingStatus,
+  stale = false,
+}: Props) {
+  const t = theme.t;
+  const rows = describeIdentities(identities);
+  if (rows.length === 0) return null;
+  const divergence = primaryReviewDivergence(mappingStatus, identities);
+
+  return (
+    <div
+      style={{
+        background: t.surface,
+        border: `1px solid ${t.border}`,
+        borderRadius: 12,
+        padding: 14,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          marginBottom: 10,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 11,
+            color: t.fg2,
+            fontWeight: 600,
+            letterSpacing: ".04em",
+            textTransform: "uppercase",
+          }}
+        >
+          Published identities
+        </span>
+        <span
+          style={{
+            fontSize: 10,
+            fontWeight: 700,
+            background: theme.dark ? "#0a0d11" : "#ece8df",
+            color: t.fg2,
+            padding: "0 6px",
+            borderRadius: 3,
+            fontVariantNumeric: "tabular-nums",
+          }}
+        >
+          {rows.length}
+        </span>
+        <span style={{ fontSize: 11, color: t.fg3 }}>
+          {stale
+            ? "as last published — your draft above is not reflected here"
+            : "each carries its own provenance and review state"}
+        </span>
+      </div>
+
+      {divergence && (
+        <div
+          style={{
+            display: "flex",
+            gap: 8,
+            alignItems: "flex-start",
+            marginBottom: 10,
+            padding: "8px 10px",
+            background: theme.dark ? "#2a2616" : "#fff7d6",
+            border: `1px solid ${theme.dark ? "#3a3416" : "#f0e2a3"}`,
+            borderRadius: 6,
+            fontSize: 12,
+            color: t.fg1,
+          }}
+        >
+          <span style={{ color: t.warn, display: "flex", marginTop: 2 }}>
+            <Glyph name="info" size={12} />
+          </span>
+          <span>
+            Mapping status is <strong>{divergence.mappingStatus}</strong>, but
+            the primary PURL below is{" "}
+            <strong>{divergence.identityReview.label.toLowerCase()}</strong>. A
+            reviewer signed off on the package; nobody vouched for this PURL
+            itself.
+          </span>
+        </div>
+      )}
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {rows.map((row) => (
+          <IdentityRow key={row.key} row={row} theme={theme} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function IdentityRow({ row, theme }: { row: IdentityDisplay; theme: Theme }) {
+  const t = theme.t;
+  const isPrimary = row.role === "primary";
+  return (
+    <div
+      title={row.hint}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        flexWrap: "wrap",
+        padding: "7px 10px",
+        background: isPrimary
+          ? theme.dark
+            ? "#1a2233"
+            : "#fff7d6"
+          : t.surface2,
+        border: `1px solid ${
+          isPrimary ? (theme.dark ? "#2a3a55" : "#f0e2a3") : t.border
+        }`,
+        borderRadius: 8,
+      }}
+    >
+      {row.kind === "cpe" ? (
+        <CpeChip cpe={row.value} theme={theme} />
+      ) : (
+        <PurlChip purl={row.value} theme={theme} />
+      )}
+      <RoleBadge label={row.roleLabel} emphasis={isPrimary} theme={theme} />
+      {row.source && <SourceTag source={row.source} theme={theme} />}
+      {row.confidence !== null && (
+        <ConfidenceBar score={row.confidence} theme={theme} width={50} />
+      )}
+      {row.sources.length > 0 && (
+        <span
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 4,
+            fontSize: 10.5,
+            color: t.fg3,
+          }}
+        >
+          via
+          {row.sources.map((source) => (
+            <SourceTag key={source} source={source} theme={theme} />
+          ))}
+        </span>
+      )}
+      <div style={{ flex: 1 }} />
+      {row.review ? (
+        <ReviewBadge review={row.review} theme={theme} />
+      ) : (
+        !row.hasProvenance &&
+        row.kind === "purl" && (
+          <span style={{ fontSize: 10.5, color: t.fg3, fontStyle: "italic" }}>
+            no provenance recorded
+          </span>
+        )
+      )}
+    </div>
+  );
+}
+
+function RoleBadge({
+  label,
+  emphasis,
+  theme,
+}: {
+  label: string;
+  emphasis: boolean;
+  theme: Theme;
+}) {
+  const t = theme.t;
+  return (
+    <span
+      style={{
+        fontSize: 9.5,
+        fontWeight: 700,
+        letterSpacing: ".06em",
+        textTransform: "uppercase",
+        color: emphasis ? (theme.dark ? "#ffd432" : "#866400") : t.fg2,
+        background: emphasis
+          ? theme.dark
+            ? "#2a2616"
+            : "#ffeec4"
+          : "transparent",
+        padding: emphasis ? "2px 6px" : 0,
+        borderRadius: 3,
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+/** Review state of one identity. Kept visually distinct from `StatusPill`,
+ *  which reports the package-level mapping status: an automatic identity must
+ *  never read as if a person had verified it. */
+function ReviewBadge({
+  review,
+  theme,
+}: {
+  review: IdentityReviewDisplay;
+  theme: Theme;
+}) {
+  const tones = {
+    verified: {
+      bg: theme.dark ? "#1a2a18" : "#eef7e3",
+      fg: theme.dark ? "#9adf6d" : "#5b9b2c",
+    },
+    edited: {
+      bg: theme.dark ? "#1a2233" : "#e3ecff",
+      fg: theme.dark ? "#9aaaff" : "#3957ff",
+    },
+    "auto-verified": {
+      bg: theme.dark ? "#162726" : "#dff8f4",
+      fg: theme.dark ? "#69d7c8" : "#15776d",
+    },
+    "auto-unverified": {
+      bg: theme.dark ? "#2a2616" : "#fff4d2",
+      fg: theme.dark ? "#f5c542" : "#866400",
+    },
+  } as const;
+  const tone = tones[review.status];
+  return (
+    <span
+      title={review.hint}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 5,
+        fontSize: 10,
+        fontWeight: 600,
+        padding: "2px 7px",
+        borderRadius: 4,
+        background: tone.bg,
+        color: tone.fg,
+        letterSpacing: "0.02em",
+        fontFamily: "Inter, sans-serif",
+        whiteSpace: "nowrap",
+      }}
+    >
+      <Glyph name={review.humanReviewed ? "check" : "sparkle"} size={10} />
+      {review.label}
+      {review.reviewer && (
+        <span style={{ fontWeight: 500, opacity: 0.85 }}>@{review.reviewer}</span>
+      )}
+    </span>
+  );
+}

--- a/web/src/components/MappingEditor.tsx
+++ b/web/src/components/MappingEditor.tsx
@@ -6,6 +6,7 @@ import {
   purlsFromAlternatives,
 } from "../data/purlAlternatives";
 import type { Edit, PackageEntry } from "../data/types";
+import { IdentityProvenance } from "./IdentityProvenance";
 import {
   DraftButton,
   DraftCheckbox,
@@ -544,6 +545,20 @@ export function MappingEditor({
             onAdd={addCpe}
           />
         </Section>
+
+        {p.identities && p.identities.length > 0 && (
+          <Section
+            title="Identity provenance"
+            subtitle="Where each published identity came from and how it was reviewed. The mapping status above is a sign-off on the package; an identity's review state is about that identity alone."
+          >
+            <IdentityProvenance
+              theme={theme}
+              identities={p.identities}
+              mappingStatus={p.status}
+              stale={isEdited}
+            />
+          </Section>
+        )}
 
         {p.status === "verified" && p.approved_by && !isEdited && (
           <Section title="Verification">

--- a/web/src/components/identityProvenance.test.mjs
+++ b/web/src/components/identityProvenance.test.mjs
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createServer } from "vite";
+
+let server;
+let describe;
+let component;
+
+before(async () => {
+  server = await createServer({
+    server: { middlewareMode: true },
+    appType: "custom",
+    logLevel: "error",
+  });
+  describe = await server.ssrLoadModule("/src/data/identityProvenance.ts");
+  component = await server.ssrLoadModule("/src/components/IdentityProvenance.tsx");
+});
+
+after(async () => {
+  await server?.close();
+});
+
+// The real theme comes from a hook; the shape is all these components read.
+const theme = {
+  dark: false,
+  setDark: () => {},
+  t: {
+    page: "#fff",
+    surface: "#fff",
+    surface2: "#fff",
+    inset: "#eee",
+    fg1: "#000",
+    fg2: "#333",
+    fg3: "#777",
+    border: "#ddd",
+    borderStrong: "#ccc",
+    accent: "#ffd432",
+    accentFg: "#001d38",
+    link: "#3957ff",
+    rowHover: "#eee",
+    rowSelected: "#eee",
+    good: "#5b9b2c",
+    bad: "#d94e1f",
+    warn: "#b07d00",
+  },
+};
+
+const manualPrimary = {
+  kind: "purl",
+  role: "primary",
+  value: "pkg:pypi/demo",
+  provenance: {
+    availability: "available",
+    source: "manual",
+    review: {
+      status: "verified",
+      reviewer: "octocat",
+      reviewed_at: "2026-02-03T10:11:12Z",
+    },
+  },
+};
+
+const autoPrimary = {
+  kind: "purl",
+  role: "primary",
+  value: "pkg:pypi/demo",
+  provenance: {
+    availability: "available",
+    source: "auto",
+    confidence: 0.72,
+    sources: ["recipe-source"],
+    review: { status: "auto-unverified", reviewer: null },
+  },
+};
+
+const recipeAlternative = {
+  kind: "purl",
+  role: "alternative",
+  value: "pkg:github/demo-org/demo",
+  coordinates: { type: "github", namespace: "demo-org", pkg_name: "demo" },
+  provenance: {
+    availability: "available",
+    source: "recipe-source",
+    confidence: 0.8,
+  },
+};
+
+const bareAlternative = {
+  kind: "purl",
+  role: "alternative",
+  value: "pkg:npm/demo",
+  provenance: { availability: "unavailable" },
+};
+
+const cpeIdentity = {
+  kind: "cpe",
+  role: "associated",
+  value: "cpe:2.3:a:example:demo",
+  provenance: { availability: "unavailable" },
+};
+
+function render(identities, mappingStatus, stale = false) {
+  return renderToStaticMarkup(
+    createElement(component.IdentityProvenance, {
+      theme,
+      identities,
+      mappingStatus,
+      stale,
+    }),
+  );
+}
+
+test("a manual verified primary names its reviewer", () => {
+  const [row] = describe.describeIdentities([manualPrimary]);
+  assert.equal(row.source, "manual");
+  assert.equal(row.review.status, "verified");
+  assert.equal(row.review.humanReviewed, true);
+  assert.equal(row.review.reviewer, "octocat");
+  assert.equal(row.review.reviewedAt, "2026-02-03");
+  assert.equal(row.confidence, null);
+
+  const html = render([manualPrimary], "verified");
+  assert.match(html, /Verified/);
+  assert.match(html, /@octocat/);
+  assert.match(html, /primary/);
+  // Mapping status and identity review agree: no divergence callout.
+  assert.doesNotMatch(html, /nobody vouched/);
+});
+
+test("an auto-unverified primary shows its confidence and never reads as human-verified", () => {
+  const [row] = describe.describeIdentities([autoPrimary]);
+  assert.equal(row.source, "auto");
+  assert.equal(row.confidence, 0.72);
+  assert.deepEqual(row.sources, ["recipe-source"]);
+  assert.equal(row.review.humanReviewed, false);
+  assert.equal(row.review.label, "Auto, unreviewed");
+
+  const html = render([autoPrimary], "auto-unverified");
+  assert.match(html, /Auto, unreviewed/);
+  assert.match(html, /72/);
+  assert.match(html, /recipe-source/);
+  assert.doesNotMatch(html, /@/);
+});
+
+test("a recipe-source alternative shows provenance without a review state", () => {
+  const [row] = describe.describeIdentities([recipeAlternative]);
+  assert.equal(row.role, "alternative");
+  assert.equal(row.roleLabel, "alt");
+  assert.equal(row.source, "recipe-source");
+  assert.equal(row.confidence, 0.8);
+  assert.equal(row.review, null);
+
+  const html = render([recipeAlternative], "auto-verified");
+  assert.match(html, /recipe-source/);
+  assert.match(html, /80/);
+  assert.match(html, /alt/);
+  assert.doesNotMatch(html, /Verified/);
+});
+
+test("a human-blessed mapping with an auto primary reports both facts", () => {
+  const divergence = describe.primaryReviewDivergence("verified", [
+    autoPrimary,
+    recipeAlternative,
+  ]);
+  assert.equal(divergence.mappingStatus, "verified");
+  assert.equal(divergence.identityReview.status, "auto-unverified");
+
+  const html = render([autoPrimary, recipeAlternative], "verified");
+  assert.match(html, /Mapping status is/);
+  assert.match(html, /nobody vouched for this PURL itself/);
+  assert.match(html, /Auto, unreviewed/);
+});
+
+test("agreeing statuses and non-human mapping statuses raise no divergence", () => {
+  assert.equal(describe.primaryReviewDivergence("verified", [manualPrimary]), null);
+  assert.equal(
+    describe.primaryReviewDivergence("auto-unverified", [autoPrimary]),
+    null,
+  );
+  assert.equal(describe.primaryReviewDivergence("verified", []), null);
+});
+
+test("identities without provenance render as unrecorded rather than defaulted", () => {
+  const [alternative, cpe] = describe.describeIdentities([
+    bareAlternative,
+    cpeIdentity,
+  ]);
+  assert.equal(alternative.hasProvenance, false);
+  assert.equal(alternative.source, null);
+  assert.equal(alternative.confidence, null);
+  assert.equal(cpe.hasProvenance, false);
+  assert.equal(cpe.roleLabel, "cpe");
+
+  const html = render([bareAlternative, cpeIdentity], "verified");
+  assert.match(html, /no provenance recorded/);
+  assert.doesNotMatch(html, /confidence/);
+});
+
+test("payloads without identities render nothing", () => {
+  assert.deepEqual(describe.describeIdentities(undefined), []);
+  assert.deepEqual(describe.describeIdentities(null), []);
+  assert.equal(render(undefined, "auto-verified"), "");
+  assert.equal(render([], "auto-verified"), "");
+});
+
+test("an open draft marks the published rows as stale", () => {
+  assert.match(render([manualPrimary], "verified", true), /not reflected here/);
+  assert.doesNotMatch(render([manualPrimary], "verified", false), /not reflected here/);
+});

--- a/web/src/data/identityProvenance.ts
+++ b/web/src/data/identityProvenance.ts
@@ -1,0 +1,165 @@
+import type { PublishedIdentity, ReviewStatus } from "./types";
+
+/** How a single identity was reviewed — deliberately *not* the package-level
+ *  `status`. A mapping a human blessed routinely still carries an
+ *  automatically derived, individually unreviewed primary identity. */
+export type IdentityReviewDisplay = {
+  status: "verified" | "edited" | "auto-verified" | "auto-unverified";
+  label: string;
+  /** true only when a named person signed off on this identity. */
+  humanReviewed: boolean;
+  reviewer: string | null;
+  /** date part of the review timestamp, null when none was published. */
+  reviewedAt: string | null;
+  hint: string;
+};
+
+export type IdentityDisplay = {
+  key: string;
+  kind: "purl" | "cpe";
+  role: "primary" | "alternative" | "associated";
+  value: string;
+  roleLabel: string;
+  /** provenance source as published; null when the payload records none. */
+  source: string | null;
+  confidence: number | null;
+  /** evidence the automatic pipeline used, empty when not published. */
+  sources: string[];
+  review: IdentityReviewDisplay | null;
+  /** false when the payload marks this identity's provenance unavailable. */
+  hasProvenance: boolean;
+  hint: string;
+};
+
+const ROLE_LABELS = {
+  primary: "primary",
+  alternative: "alt",
+  associated: "cpe",
+} as const;
+
+const REVIEW_LABELS = {
+  verified: "Verified",
+  edited: "Edited",
+  "auto-verified": "Auto-verified",
+  "auto-unverified": "Auto, unreviewed",
+} as const;
+
+function reviewDisplay(
+  status: IdentityReviewDisplay["status"],
+  reviewer: string | null,
+  reviewedAt: string | null,
+): IdentityReviewDisplay {
+  const humanReviewed = status === "verified" || status === "edited";
+  const who = reviewer ? `@${reviewer}` : "a reviewer";
+  const when = reviewedAt ? ` on ${reviewedAt}` : "";
+  const hint = humanReviewed
+    ? status === "edited"
+      ? `Edited and approved by ${who}${when}.`
+      : `Reviewed and approved by ${who}${when}.`
+    : status === "auto-verified"
+      ? "Derived automatically and cross-checked against another source. No person reviewed it."
+      : "Derived automatically. Nothing has confirmed it — neither a person nor a second source.";
+  return {
+    status,
+    label: REVIEW_LABELS[status],
+    humanReviewed,
+    reviewer,
+    reviewedAt,
+    hint,
+  };
+}
+
+function dateOf(timestamp: string | null | undefined): string | null {
+  return timestamp ? timestamp.slice(0, 10) : null;
+}
+
+export function describeIdentity(identity: PublishedIdentity): IdentityDisplay {
+  const base = {
+    key: `${identity.kind}:${identity.value}`,
+    kind: identity.kind,
+    role: identity.role,
+    value: identity.value,
+    roleLabel: ROLE_LABELS[identity.role],
+    source: null,
+    confidence: null,
+    sources: [] as string[],
+    review: null,
+    hasProvenance: false,
+    hint: "",
+  } satisfies IdentityDisplay;
+
+  if (identity.kind === "cpe") {
+    return {
+      ...base,
+      hint: "CPE prefix recorded for downstream NVD matching. The payload publishes no provenance for CPEs.",
+    };
+  }
+
+  if (identity.role === "primary") {
+    const provenance = identity.provenance;
+    if (provenance.source === "auto") {
+      return {
+        ...base,
+        source: "auto",
+        confidence: provenance.confidence,
+        sources: provenance.sources,
+        review: reviewDisplay(provenance.review.status, null, null),
+        hasProvenance: true,
+        hint: "Primary PURL derived by the automatic pipeline.",
+      };
+    }
+    return {
+      ...base,
+      source: "manual",
+      review: reviewDisplay(
+        provenance.review.status,
+        provenance.review.reviewer,
+        dateOf(provenance.review.reviewed_at),
+      ),
+      hasProvenance: true,
+      hint: "Primary PURL set by a reviewer.",
+    };
+  }
+
+  if (identity.provenance.availability === "available") {
+    return {
+      ...base,
+      source: identity.provenance.source,
+      confidence: identity.provenance.confidence,
+      hasProvenance: true,
+      hint: `Alternative PURL derived from ${identity.provenance.source}.`,
+    };
+  }
+
+  return {
+    ...base,
+    hint: "Alternative PURL recorded without provenance — it predates per-identity provenance or was added by hand.",
+  };
+}
+
+/** Absent (v2-era payloads) and empty both yield an empty list; callers render
+ *  nothing rather than inventing defaults. */
+export function describeIdentities(
+  identities: PublishedIdentity[] | null | undefined,
+): IdentityDisplay[] {
+  return (identities ?? []).map(describeIdentity);
+}
+
+/** The package-level `status` records a reviewer's sign-off on the mapping;
+ *  the primary identity's review records who vouched for the PURL itself.
+ *  A human-blessed mapping routinely carries an automatically derived,
+ *  individually unreviewed primary — hundreds of packages in the corpus are in
+ *  that state — so the UI must never let one stand in for the other. Returns
+ *  both facts when the mapping claims human review the primary identity does
+ *  not have, and null otherwise. */
+export function primaryReviewDivergence(
+  mappingStatus: ReviewStatus | null | undefined,
+  identities: PublishedIdentity[] | null | undefined,
+): { mappingStatus: ReviewStatus; identityReview: IdentityReviewDisplay } | null {
+  const primary = describeIdentities(identities).find(
+    (identity) => identity.kind === "purl" && identity.role === "primary",
+  );
+  if (!primary?.review || primary.review.humanReviewed) return null;
+  if (mappingStatus !== "verified" && mappingStatus !== "edited") return null;
+  return { mappingStatus, identityReview: primary.review };
+}


### PR DESCRIPTION
## Why

Schema v3 (#224) publishes an `identities` array for every package, and the browser loader already validates all of it — role, provenance source, confidence, the evidence the pipeline used, and the primary's review block. None of it reaches the screen. A reviewer opening a package sees one status pill and has no way to tell whether the primary PURL was set by a person or guessed by the pipeline.

The distinction is the point. The package-level mapping `status` and a primary identity's `review.status` are different facts: a human-blessed mapping routinely contains an automatically derived, individually unreviewed primary. In the current corpus that is 682 packages with `status: verified` whose primary PURL is `auto` / `auto-unverified`, plus 2 more where it is `auto-verified`. Rendering either as a stand-in for the other tells reviewers something untrue about who vouched for what.

## What changes

- Adds an **Identity provenance** section to the mapping editor listing every published identity: the PURL or CPE chip, its role (primary / alt / cpe), its provenance source, confidence when published, the evidence sources behind an automatic primary, and — primaries only — its own review badge.
- Keeps the two review facts apart. The mapping status pill stays where it is; identity review badges are visually distinct and an automatic identity never renders as human-verified. Where the mapping claims human review the primary identity does not have, the section says so in one line instead of leaving the reader to spot it.
- Puts the semantics in a plain module (`web/src/data/identityProvenance.ts`) that turns published identities into display descriptors, so the rules are testable without a DOM and the component stays presentational.
- Degrades quietly: v2-era packages without `identities` render no section at all, and identities the payload marks provenance-unavailable (bare alternatives, CPEs) say "no provenance recorded" rather than showing a default confidence or review state.
- While a local draft is open the rows are labelled as last-published, since the editor above may already disagree with them.

Display only — no change to the payload, the loader, or the contribution flow.

## Testing

- `npm test` in `web/`: 8 new tests alongside the existing loader suite, covering a manual verified primary (names its reviewer), an auto-unverified primary (shows confidence, renders no reviewer and no human-verified wording), a recipe-source alternative (provenance without a review state), the verified-mapping / auto-primary divergence, absent and provenance-less identities, and the stale-draft label. They render the real component through Vite's SSR loader, the same way the existing loader tests load modules.
- `npm run build` (`tsc --noEmit` + `vite build`) clean.
- Smoke-rendered against a locally regenerated v3 payload (33,726 packages) for one package of each corpus shape: `aardvark-dns` (verified mapping, auto-unverified primary — divergence callout), `a2a-sdk` (manual verified primary plus a provenance-less alternative), `21cmfast` (auto-verified primary with evidence sources), `pikepdf` (verified mapping, auto-verified primary), `automake` (CPE-only), `7za` (no identities — section hidden). No generated payload files are committed.

One pre-existing failure in `web/src/data/loader.test.mjs` is untouched by this PR: the checked-in snapshot test asserts a 33,287-package count while `web/public/mappings-index.json` on main now holds 33,726, so it fails on main as well. No CI workflow currently runs the web test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
