### PR TITLE
fix(mappings): use portable CUPS CPEs for libcups

### DIFF
--- a/mappings/contributions/2026-09-03T10-14-47-000Z--tdejager--cups2.json
+++ b/mappings/contributions/2026-09-03T10-14-47-000Z--tdejager--cups2.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "title": "Correct libcups CPE mapping",
+  "author": "tdejager",
+  "author_name": "Tim de Jager",
+  "timestamp": "2026-09-03T10:14:47.000Z",
+  "packages": {
+    "libcups": {
+      "cpes": [
+        "cpe:2.3:a:cups:cups",
+        "cpe:2.3:a:openprinting:cups"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
`conda-forge/libcups` uses the portable CUPS 2.x release line. Its current mapping also includes `cpe:2.3:a:apple:cups`, which NVD uses for Apple's separate 499.x macOS release train. For CVE-2022-26691, that makes downstream matching present 499.4 alongside OpenPrinting's applicable 2.4.2 fix.

This contribution removes the Apple CPE while retaining `cpe:2.3:a:cups:cups` and `cpe:2.3:a:openprinting:cups`. Generated mapping output is intentionally not committed because the Pages and validation workflows rebuild it.

## Testing

- `pixi run -e lite mappings:merge`
- confirmed `packages.libcups.cpes` contains only the generic CUPS and OpenPrinting identities
- `pixi run -e lite mappings:validate`