### PR TITLE
feat: make CPE coverage and provenance explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,29 @@ The core object is a conda-forge package identity record:
       "kind": "cpe",
       "role": "associated",
       "value": "cpe:2.3:a:gnu:ncurses",
-      "provenance": { "availability": "unavailable" }
+      "provenance": {
+        "availability": "available",
+        "source": "manual",
+        "review": {
+          "status": "verified",
+          "reviewer": "nichmor",
+          "reviewed_at": "2026-05-25T00:00:00Z"
+        }
+      }
+    },
+    {
+      "kind": "cpe",
+      "role": "associated",
+      "value": "cpe:2.3:a:invisible-island:ncurses",
+      "provenance": {
+        "availability": "available",
+        "source": "manual",
+        "review": {
+          "status": "verified",
+          "reviewer": "nichmor",
+          "reviewed_at": "2026-05-25T00:00:00Z"
+        }
+      }
     }
   ]
 }
@@ -74,12 +96,17 @@ view for downstream consumers:
   alternatives retain their own `source` and `confidence`; bare string
   alternatives use `availability: "unavailable"`. They never inherit the
   primary PURL's review object.
-- `kind: "cpe", role: "associated"` identifies a CPE prefix. The current source
-  model does not retain CPE-level attribution, so its provenance is explicitly
-  `unavailable` and never inferred from primary review state.
+- `kind: "cpe", role: "associated"` identifies a CPE prefix. Its provenance
+  identifies the automatic or reviewed source layer that last replaced the
+  package's CPE list, including that layer's review state and attribution.
 
 Identity order is deterministic: primary PURL, alternatives in source order,
 then CPEs in source order. A missing primary PURL produces no primary identity.
+
+Coverage is identity-based. A package has no identity only when `identities` is
+empty; a missing primary PURL can still leave alternative PURLs or CPEs. The
+legacy `unmapped` field records an intentional no-PURL decision, not the absence
+of every identity.
 Every published confidence is a finite JSON number; `NaN` and infinities are
 rejected. Contribution precedence compares timezone-aware timestamps as UTC
 instants, with the on-disk filename as the deterministic tie-breaker.
@@ -99,15 +126,13 @@ instants, with the on-disk filename as the deterministic tie-breaker.
 
 ### Payload versions and compatibility
 
-PFX-1826 advances `mappings.json` from schema 1 to **2**,
-`mappings-index.json` from schema 2 to **3**, and mapping detail shards from
-schema 1 to **2**. These versions add `identities` without removing or changing
-legacy `purl`, `alternative_purls`, `cpes`, `status`, or attribution fields.
-This additive compatibility window lets existing clients continue reading the
-legacy fields while provenance-aware clients migrate to `identities`. New
-clients should reject unknown future schema versions rather than guessing.
-The validator accepts the immediately preceding schemas during this window but
-requires and validates the per-identity contract on current schemas.
+PFX-1826 introduced `identities` in bundle schema 2, index schema 3, and detail
+schema 2. CPE provenance advances those payloads to bundle schema **3**, index
+schema **4**, and detail schema **3**. Legacy `purl`, `alternative_purls`,
+`cpes`, `status`, and attribution fields remain unchanged. New clients should
+reject unknown future schema versions rather than guessing. The validator and
+web decoder accept the earlier payload generations but require attributed CPE
+provenance on current schemas.
 
 The payload deployed by the Pages workflow is canonical. The checked-in
 `mappings-index.json` and shard files are build inputs/cache for the app, not a
@@ -182,9 +207,9 @@ pixi run -e lite mappings:validate
 The GitHub Pages app is a PURL editing UI:
 
 - users can review, edit, approve, or mark PURL mappings as unmapped
-- staged PURL edits are saved locally until submitted
+- staged identity edits are saved locally until submitted
 - submitted edits open PRs containing one new file under `mappings/contributions/`
-- CPEs are displayed read-only as package identity metadata
+- CPEs can be reviewed and edited alongside PURL mappings
 - no CVE dashboard, OpenVEX review, AI CVE queue, or deep-inspection routes are
   served from this repository
 

--- a/scripts/merge_mappings.py
+++ b/scripts/merge_mappings.py
@@ -26,9 +26,9 @@ DEFAULT_OUT = ROOT / "web" / "public" / "mappings.json"
 DEFAULT_INDEX_OUT = ROOT / "web" / "public" / "mappings-index.json"
 DEFAULT_DETAIL_DIR = ROOT / "web" / "public" / "mapping_packages"
 
-BUNDLE_SCHEMA_VERSION = 2
-INDEX_SCHEMA_VERSION = 3
-DETAIL_SCHEMA_VERSION = 2
+BUNDLE_SCHEMA_VERSION = 3
+INDEX_SCHEMA_VERSION = 4
+DETAIL_SCHEMA_VERSION = 3
 SOURCE_SCHEMA_VERSION = 1
 REVIEW_STATUSES = {"auto-unverified", "auto-verified", "verified", "unmapped", "edited"}
 PRIMARY_SOURCES = {"auto", "manual"}
@@ -54,6 +54,7 @@ REVIEWED_MAPPING_FIELDS = (
 )
 PRIMARY_REVIEW_FIELDS = ("purl", "type", "namespace", "pkg_name", "unmapped", "status")
 _INTERNAL_PRIMARY = "_primary_identity_provenance"
+_INTERNAL_CPES = "_cpe_identity_provenance"
 
 
 def _duplicate_safe_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -192,7 +193,7 @@ def _validate_alternatives(value: Any, label: str, primary: Any) -> None:
 def _validate_package_entry(entry: Any, label: str, *, auto: bool) -> None:
     if not isinstance(entry, dict):
         raise ValueError(f"{label} must be an object")
-    if _INTERNAL_PRIMARY in entry or "_filename" in entry:
+    if _INTERNAL_PRIMARY in entry or _INTERNAL_CPES in entry or "_filename" in entry:
         raise ValueError(f"{label} uses a reserved internal field")
     purl = entry.get("purl")
     if purl is not None:
@@ -251,7 +252,7 @@ def _validate_source_payload(
             "approved_at": payload.get("updated_at"),
         }
         for name, entry in packages.items():
-            if _reviews_primary(entry):
+            if _reviews_primary(entry) or entry.get("cpes") is not None:
                 _effective_attribution(entry, attribution, f"{label}:{name}")
     if kind == "contribution":
         _require_string(payload.get("author"), f"{label}.author")
@@ -371,11 +372,17 @@ def _apply_reviewed_override(
 ) -> None:
     base = merged.get(name, {"name": name})
     reviews_primary = _reviews_primary(override)
+    reviews_cpes = override.get("cpes") is not None
     patch = {
         key: override[key]
         for key in REVIEWED_MAPPING_FIELDS
         if key in override and override[key] is not None
     }
+    current_attribution = (
+        _effective_attribution(override, attribution, label)
+        if reviews_primary or reviews_cpes
+        else None
+    )
 
     # Preserve the legacy package-level merge behavior during the additive
     # window: every reviewed layer marks the package manual/verified and owns
@@ -391,7 +398,7 @@ def _apply_reviewed_override(
         # the historical package-level fields omitted it. Contributions carry
         # the same current attribution at file level. Do not rewrite legacy
         # attribution merely to make the additive identity view convenient.
-        current_attribution = _effective_attribution(override, attribution, label)
+        assert current_attribution is not None
         if override.get("unmapped") is True:
             result.update(
                 {
@@ -414,6 +421,24 @@ def _apply_reviewed_override(
                 "reviewer": current_attribution["approved_by"],
                 "reviewed_at": current_attribution["approved_at"],
             },
+        }
+
+    if reviews_cpes:
+        assert current_attribution is not None
+        review_status = override.get("status")
+        if review_status not in {"verified", "edited"}:
+            review_status = "verified"
+        result[_INTERNAL_CPES] = {
+            cpe: {
+                "availability": "available",
+                "source": "manual",
+                "review": {
+                    "status": review_status,
+                    "reviewer": current_attribution["approved_by"],
+                    "reviewed_at": current_attribution["approved_at"],
+                },
+            }
+            for cpe in override["cpes"]
         }
 
     if result.get("alternative_purls"):
@@ -462,20 +487,25 @@ def _identity_records(entry: dict) -> list[dict]:
                 },
             }
         identities.append(identity)
+    cpe_provenance = entry.get(_INTERNAL_CPES, {})
     for cpe in entry.get("cpes") or []:
         identities.append(
             {
                 "kind": "cpe",
                 "role": "associated",
                 "value": cpe,
-                "provenance": {"availability": "unavailable"},
+                "provenance": cpe_provenance[cpe],
             }
         )
     return identities
 
 
 def _with_identities(entry: dict) -> dict:
-    result = {key: value for key, value in entry.items() if key != _INTERNAL_PRIMARY}
+    result = {
+        key: value
+        for key, value in entry.items()
+        if key not in {_INTERNAL_PRIMARY, _INTERNAL_CPES}
+    }
     result["identities"] = _identity_records(entry)
     return result
 
@@ -553,11 +583,20 @@ def _build_published_packages(
             "sources": entry["sources"],
             "review": {"status": status, "reviewer": None},
         }
+        cpe_provenance = {
+            cpe: {
+                "availability": "available",
+                "source": "auto",
+                "review": {"status": status, "reviewer": None},
+            }
+            for cpe in entry.get("cpes") or []
+        }
         merged[name] = {
             **entry,
             "status": status,
             "source": "auto",
             _INTERNAL_PRIMARY: primary,
+            _INTERNAL_CPES: cpe_provenance,
         }
 
     legacy_attribution = {

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -20,12 +20,12 @@ DEFAULT_MAPPINGS_DETAIL_DIR = ROOT / "web" / "public" / "mapping_packages"
 
 CPE23_RE = merge_mappings.CPE23_RE
 PURL_RE = merge_mappings.PURL_RE
-SUPPORTED_BUNDLE_SCHEMAS = {1, 2}
-SUPPORTED_INDEX_SCHEMAS = {2, 3}
-SUPPORTED_DETAIL_SCHEMAS = {1, 2}
-CURRENT_BUNDLE_SCHEMA = 2
-CURRENT_INDEX_SCHEMA = 3
-CURRENT_DETAIL_SCHEMA = 2
+SUPPORTED_BUNDLE_SCHEMAS = {1, 2, 3}
+SUPPORTED_INDEX_SCHEMAS = {2, 3, 4}
+SUPPORTED_DETAIL_SCHEMAS = {1, 2, 3}
+CURRENT_BUNDLE_SCHEMA = 3
+CURRENT_INDEX_SCHEMA = 4
+CURRENT_DETAIL_SCHEMA = 3
 REVIEW_STATUSES = merge_mappings.REVIEW_STATUSES
 PRIMARY_SOURCES = merge_mappings.PRIMARY_SOURCES
 ALTERNATIVE_SOURCES = merge_mappings.ALTERNATIVE_SOURCES
@@ -355,10 +355,44 @@ def _validate_identity_contract(
         elif kind == "cpe" and role == "associated":
             if set(identity) != {"kind", "role", "value", "provenance"}:
                 errors.append(f"{identity_label}: CPE contains forbidden fields")
-            if provenance != {"availability": "unavailable"}:
-                errors.append(
-                    f"{identity_label}: CPE provenance must be exactly unavailable"
+            _error_extra_fields(
+                provenance,
+                {"availability", "source", "review"},
+                f"{identity_label}.provenance",
+                errors,
+            )
+            if provenance.get("availability") != "available":
+                errors.append(f"{identity_label}: CPE provenance must be available")
+            source = provenance.get("source")
+            if source not in PRIMARY_SOURCES:
+                errors.append(f"{identity_label}: unsupported CPE source {source!r}")
+            review = provenance.get("review")
+            if not isinstance(review, dict):
+                errors.append(f"{identity_label}: CPE review is required")
+            else:
+                _error_extra_fields(
+                    review,
+                    {"status", "reviewer", "reviewed_at"},
+                    f"{identity_label}.provenance.review",
+                    errors,
                 )
+                status = review.get("status")
+                if source == "auto":
+                    if (
+                        status not in {"auto-unverified", "auto-verified"}
+                        or review.get("reviewer") is not None
+                        or "reviewed_at" in review
+                    ):
+                        errors.append(
+                            f"{identity_label}: automatic CPE review is malformed"
+                        )
+                elif (
+                    status not in {"verified", "edited"}
+                    or not isinstance(review.get("reviewer"), str)
+                    or not review.get("reviewer")
+                    or not _valid_timestamp(review.get("reviewed_at"))
+                ):
+                    errors.append(f"{identity_label}: manual CPE review is malformed")
         else:
             errors.append(
                 f"{identity_label}: unsupported identity kind/role {kind!r}/{role!r}"
@@ -621,9 +655,7 @@ def validate_split_mappings(
             bundle, str(_rel(bundle_path)), SUPPORTED_BUNDLE_SCHEMAS, errors
         )
         expected_bundle_version = (
-            CURRENT_BUNDLE_SCHEMA
-            if index_version == CURRENT_INDEX_SCHEMA
-            else CURRENT_BUNDLE_SCHEMA - 1
+            index_version - 1 if index_version is not None else None
         )
         if bundle_version != expected_bundle_version:
             errors.append(
@@ -671,9 +703,7 @@ def validate_split_mappings(
             shard, str(_rel(path)), SUPPORTED_DETAIL_SCHEMAS, errors
         )
         expected_detail_version = (
-            CURRENT_DETAIL_SCHEMA
-            if index_version == CURRENT_INDEX_SCHEMA
-            else CURRENT_DETAIL_SCHEMA - 1
+            index_version - 1 if index_version is not None else None
         )
         if shard_version is not None and shard_version != expected_detail_version:
             errors.append(
@@ -712,7 +742,7 @@ def validate_split_mappings(
             name,
             {key: value for key, value in detail.items() if key != "name"},
             detail_path,
-            current=index_version == CURRENT_INDEX_SCHEMA,
+            current=index_version >= CURRENT_INDEX_SCHEMA - 1,
         )
         if index_entry != expected_index:
             errors.append(

--- a/tests/test_identity_payload.py
+++ b/tests/test_identity_payload.py
@@ -137,7 +137,7 @@ class IdentityPayloadTest(unittest.TestCase):
         index = json.loads(index_path.read_text())
         reviewed = bundle["packages"]["reviewed"]
 
-        self.assertEqual((bundle["schema_version"], index["schema_version"]), (2, 3))
+        self.assertEqual((bundle["schema_version"], index["schema_version"]), (3, 4))
         self.assertEqual(reviewed["status"], "verified")
         self.assertEqual(reviewed["approved_by"], "current-reviewer")
         # Identity provenance remains with the primary-owning manual layer.
@@ -155,7 +155,23 @@ class IdentityPayloadTest(unittest.TestCase):
         )
         self.assertEqual(
             reviewed["identities"][2]["provenance"],
-            {"availability": "unavailable"},
+            {
+                "availability": "available",
+                "source": "manual",
+                "review": {
+                    "status": "verified",
+                    "reviewer": "current-reviewer",
+                    "reviewed_at": "2026-01-03T04:05:06Z",
+                },
+            },
+        )
+        self.assertEqual(
+            bundle["packages"]["auto-detailed"]["identities"][2]["provenance"],
+            {
+                "availability": "available",
+                "source": "auto",
+                "review": {"status": "auto-verified", "reviewer": None},
+            },
         )
         errors: list[str] = []
         validate.validate_mapping_alternatives(
@@ -252,6 +268,17 @@ class IdentityPayloadTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             merge_mappings._validate_source_payload(
                 manual_without_owner, "manual", kind="manual"
+            )
+
+        cpe_without_owner = {
+            "schema_version": 1,
+            "packages": {
+                "cpe-only": {"cpes": ["cpe:2.3:a:example:demo"]},
+            },
+        }
+        with self.assertRaises(ValueError):
+            merge_mappings._validate_source_payload(
+                cpe_without_owner, "manual CPE", kind="manual"
             )
 
         contribution = json.loads((self.contributions / "review.json").read_text())
@@ -368,9 +395,10 @@ class IdentityPayloadTest(unittest.TestCase):
                 mutate_primary(("identities", 1, "provenance", "confidence"), 0.1),
             ),
             (
-                "CPE unavailable only",
+                "CPE provenance required",
                 mutate_primary(
-                    ("identities", 2, "provenance"), {"availability": "available"}
+                    ("identities", 2, "provenance"),
+                    {"availability": "unavailable"},
                 ),
             ),
         ]
@@ -614,19 +642,25 @@ class IdentityPayloadTest(unittest.TestCase):
         bundle_path, index_path, detail_dir = self._generate(self.root / "legacy")
         bundle = json.loads(bundle_path.read_text())
         index = json.loads(index_path.read_text())
-        bundle["schema_version"] = 1
-        index["schema_version"] = 2
+        bundle["schema_version"] = 2
+        index["schema_version"] = 3
         for entry in bundle["packages"].values():
-            entry.pop("identities")
+            for identity in entry["identities"]:
+                if identity["kind"] == "cpe":
+                    identity["provenance"] = {"availability": "unavailable"}
         for entry in index["packages"].values():
-            entry.pop("identities")
+            for identity in entry["identities"]:
+                if identity["kind"] == "cpe":
+                    identity["provenance"] = {"availability": "unavailable"}
         self._write_json(bundle_path, bundle)
         self._write_json(index_path, index)
         for shard_path in detail_dir.glob("*.json"):
             shard = json.loads(shard_path.read_text())
-            shard["schema_version"] = 1
+            shard["schema_version"] = 2
             for entry in shard["packages"].values():
-                entry.pop("identities")
+                for identity in entry["identities"]:
+                    if identity["kind"] == "cpe":
+                        identity["provenance"] = {"availability": "unavailable"}
             self._write_json(shard_path, shard)
 
         errors: list[str] = []
@@ -652,12 +686,12 @@ class IdentityPayloadTest(unittest.TestCase):
         errors: list[str] = []
         self.assertEqual(
             validate._validate_schema_version(
-                {"schema_version": 1},
-                "legacy",
+                {"schema_version": 2},
+                "previous",
                 validate.SUPPORTED_BUNDLE_SCHEMAS,
                 errors,
             ),
-            1,
+            2,
         )
         self.assertEqual(errors, [])
         validate._validate_schema_version(

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
-    "test": "node --test src/data/loader.test.mjs src/components/identityProvenance.test.mjs",
+    "test": "node --test --test-concurrency=1 src/data/loader.test.mjs src/data/identityCoverage.test.mjs src/components/identityProvenance.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,7 +5,10 @@ import { LoadingToast } from "./components/LoadingToast";
 import { LocalDraftBanner } from "./components/LocalDraftBanner";
 import { LoginModal } from "./components/LoginModal";
 import { MappingEditor } from "./components/MappingEditor";
-import { PackageTable } from "./components/PackageTable";
+import {
+  PackageTable,
+  type PackageTableFilters,
+} from "./components/PackageTable";
 import { PRDrawer } from "./components/PRDrawer";
 import { Btn, Glyph, useTheme } from "./components/Primitives";
 import { repoFullName } from "./config";
@@ -30,9 +33,9 @@ export function App() {
   const edits = usePurlEditStore((state) => state.edits);
   const setEdits = usePurlEditStore((state) => state.setEdits);
   const [q, setQ] = useState("");
-  const [filters, setFilters] = useState({
-    unmappedOnly: false,
-    unverifiedOnly: false,
+  const [filters, setFilters] = useState<PackageTableFilters>({
+    coverage: "all",
+    review: "all",
     ecosystem: "all",
   });
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -351,7 +354,7 @@ export function App() {
           }}
         >
           <Glyph name="edit" size={13} />
-          You can stage local PURL mapping changes without signing in. CPEs are shown as read-only identity metadata.
+          You can stage local PURL and CPE mapping changes without signing in.
           <button
             onClick={() => setLoginOpen(true)}
             style={{

--- a/web/src/components/BulkPanel.tsx
+++ b/web/src/components/BulkPanel.tsx
@@ -1,3 +1,4 @@
+import { effectiveMappingStatus } from "../data/identityCoverage";
 import type { Edit, MappingPackageIndex } from "../data/types";
 import { Btn, PurlChip, StatusPill, Theme } from "./Primitives";
 
@@ -170,11 +171,7 @@ export function BulkPanel({
           {selectedPackages.slice(0, 200).map((p) => {
             const e = edits[p.name];
             const purl = e?.purl ?? p.purl;
-            const status = e
-              ? "edited"
-              : p.status === "unmapped" || p.purl === null
-                ? "unmapped"
-                : p.status;
+            const status = effectiveMappingStatus(p, e);
             return (
               <div
                 key={p.name}

--- a/web/src/components/IdentityProvenance.tsx
+++ b/web/src/components/IdentityProvenance.tsx
@@ -25,8 +25,8 @@ type Props = {
   stale?: boolean;
 };
 
-/** Published per-identity provenance (schema v3 `identities`). Renders nothing
- *  for payloads that predate it. */
+/** Published per-identity provenance. Renders nothing for payloads that
+ *  predate the identity contract. */
 export function IdentityProvenance({
   theme,
   identities,
@@ -176,8 +176,7 @@ function IdentityRow({ row, theme }: { row: IdentityDisplay; theme: Theme }) {
       {row.review ? (
         <ReviewBadge review={row.review} theme={theme} />
       ) : (
-        !row.hasProvenance &&
-        row.kind === "purl" && (
+        !row.hasProvenance && (
           <span style={{ fontSize: 10.5, color: t.fg3, fontStyle: "italic" }}>
             no provenance recorded
           </span>

--- a/web/src/components/MappingEditor.tsx
+++ b/web/src/components/MappingEditor.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useState } from "react";
+import { effectiveMappingStatus } from "../data/identityCoverage";
 import { PURL_TYPES } from "../data/loader";
 import {
   alternativeMetas,
@@ -73,7 +74,7 @@ export function MappingEditor({
             No package selected
           </div>
           <div style={{ fontSize: 13, color: t.fg3 }}>
-            Pick a conda-forge package on the left to view identity metadata and edit its PURL mapping.
+            Pick a conda-forge package on the left to view and edit its identity metadata.
           </div>
         </div>
       </div>
@@ -108,14 +109,16 @@ export function MappingEditor({
     purl: edit?.purl ?? p.purl ?? auto.purl ?? "",
     alternative_purls: edit?.alternative_purls ?? currentAlternativePurls,
     cpes: edit?.cpes,
-    unmapped: edit?.unmapped ?? p.unmapped ?? p.purl === null,
+    unmapped: edit?.unmapped ?? p.unmapped ?? p.status === "unmapped",
     note: edit?.note ?? "",
   };
   const effCpes = eff.cpes ?? p.cpes ?? [];
 
   const isEdited = !!edit;
+  const displayStatus = effectiveMappingStatus(p, edit);
   const isVerified =
-    (p.status === "verified" || p.status === "auto-verified") && !isEdited;
+    (displayStatus === "verified" || displayStatus === "auto-verified") &&
+    !isEdited;
 
   function updatePart(patch: Partial<Edit>): void {
     const editsMapping =
@@ -238,13 +241,7 @@ export function MappingEditor({
                 v{p.version}
               </span>
               <StatusPill
-                status={
-                  isEdited
-                    ? "edited"
-                    : p.status === "unmapped" || p.purl === null
-                      ? "unmapped"
-                      : p.status
-                }
+                status={displayStatus}
                 theme={theme}
               />
             </div>
@@ -515,7 +512,7 @@ export function MappingEditor({
               <span
                 style={{ fontSize: 11.5, color: t.fg2, marginLeft: 6 }}
               >
-                (mark as intentionally unmapped — won't appear as missing)
+                (record a reviewed no-PURL decision)
               </span>
             </span>
           </label>

--- a/web/src/components/PackageTable.tsx
+++ b/web/src/components/PackageTable.tsx
@@ -1,6 +1,13 @@
 import { useMemo, useRef, useState } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import type { Edit, MappingPackageIndex, PackageEntry } from "../data/types";
+import type { Edit, MappingPackageIndex, ReviewStatus } from "../data/types";
+import {
+  effectiveCpes,
+  effectiveMappingStatus,
+  packageIdentityCoverage,
+  needsPurlDecision,
+  type IdentityCoverage,
+} from "../data/identityCoverage";
 import { ECOSYSTEMS } from "../data/loader";
 import { EcosystemChip, FilterChip, Glyph, StatusPill, Theme } from "./Primitives";
 
@@ -16,14 +23,15 @@ export type SortDir = "asc" | "desc";
 type EcosystemFilter = "all" | (string & {});
 type EditsByName = Record<string, Edit>;
 type TablePackage = MappingPackageIndex;
-type EffectiveStatus = PackageEntry["status"];
-type CountKey = "all" | "unmapped" | "unverified" | "verified" | "edited";
+type EffectiveStatus = ReviewStatus;
+type ReviewFilter = "all" | "no-purl-decision" | "unverified";
+type CountKey = "all" | IdentityCoverage | Exclude<ReviewFilter, "all">;
 type PackageCounts = Record<CountKey, number>;
 type PackagePredicate = (p: TablePackage, edits: EditsByName) => boolean;
 
-type Filters = {
-  unmappedOnly: boolean;
-  unverifiedOnly: boolean;
+export type PackageTableFilters = {
+  coverage: "all" | IdentityCoverage;
+  review: ReviewFilter;
   ecosystem: EcosystemFilter;
 };
 
@@ -37,15 +45,10 @@ type Props = {
   setFocusedId: (id: string | null) => void;
   q: string;
   setQ: (v: string) => void;
-  filters: Filters;
-  setFilters: (f: Filters) => void;
+  filters: PackageTableFilters;
+  setFilters: (f: PackageTableFilters) => void;
 };
 
-function effectiveStatus(p: TablePackage, edits: EditsByName): EffectiveStatus {
-  if (edits[p.name]) return "edited";
-  if (p.purl === null || p.status === "unmapped") return "unmapped";
-  return p.status;
-}
 
 function effectivePurl(p: TablePackage, edits: EditsByName): string {
   return edits[p.name]?.purl ?? p.purl ?? "";
@@ -63,27 +66,36 @@ function matchesEcosystem(
   return !ecosystem || ecosystem === "all" || effectiveType(p, edits) === ecosystem;
 }
 
-const isUnmapped: PackagePredicate = (p, edits) =>
-  p.status === "unmapped" || p.purl === null || Boolean(edits[p.name]?.unmapped);
-
-const isUnverified: PackagePredicate = (p) => p.status === "auto-unverified";
-
-const isVerified: PackagePredicate = (p) =>
-  p.status === "verified" || p.status === "auto-verified";
-
-const COUNT_BUCKETS = {
-  unmapped: isUnmapped,
-  unverified: isUnverified,
-  verified: isVerified,
-} satisfies Record<Exclude<CountKey, "all" | "edited">, PackagePredicate>;
+const isUnverified: PackagePredicate = (p, edits) =>
+  effectiveMappingStatus(p, edits[p.name]) === "auto-unverified";
 
 const EMPTY_COUNTS = {
   all: 0,
-  unmapped: 0,
+  none: 0,
+  purl: 0,
+  cpe: 0,
+  "purl+cpe": 0,
+  "no-purl-decision": 0,
   unverified: 0,
-  verified: 0,
-  edited: 0,
 } satisfies PackageCounts;
+
+const COVERAGE_FILTERS: Array<{
+  coverage: IdentityCoverage;
+  label: string;
+}> = [
+  { coverage: "none", label: "No identity" },
+  { coverage: "purl", label: "PURL only" },
+  { coverage: "cpe", label: "CPE only" },
+  { coverage: "purl+cpe", label: "PURL + CPE" },
+];
+
+const REVIEW_FILTERS: Array<{
+  review: Exclude<ReviewFilter, "all">;
+  label: string;
+}> = [
+  { review: "no-purl-decision", label: "No PURL decision" },
+  { review: "unverified", label: "Unverified" },
+];
 
 const STATUS_RANK: Record<EffectiveStatus, number> = {
   edited: 0,
@@ -114,13 +126,21 @@ export function PackageTable({
   const filtered = useMemo(() => {
     const ql = q.trim().toLowerCase();
     const out = packages.filter((p) => {
-      if (filters.unmappedOnly && !isUnmapped(p, edits)) return false;
-      if (filters.unverifiedOnly && isVerified(p, edits) && !edits[p.name])
+      if (
+        filters.coverage !== "all" &&
+        packageIdentityCoverage(p, edits[p.name]) !== filters.coverage
+      )
         return false;
+      if (
+        filters.review === "no-purl-decision" &&
+        !needsPurlDecision(p, edits[p.name])
+      )
+        return false;
+      if (filters.review === "unverified" && !isUnverified(p, edits)) return false;
       if (!matchesEcosystem(p, edits, filters.ecosystem)) return false;
       if (!ql) return true;
-      const purl = edits[p.name]?.purl ?? p.purl ?? "";
-      const cpes = (p.cpes ?? []).join(" ");
+      const purl = effectivePurl(p, edits);
+      const cpes = effectiveCpes(p, edits[p.name]).join(" ");
       return (
         p.name.toLowerCase().includes(ql) ||
         purl.toLowerCase().includes(ql) ||
@@ -151,8 +171,8 @@ export function PackageTable({
           break;
         case "status":
           cmp =
-            (STATUS_RANK[effectiveStatus(a, edits)] ?? 99) -
-            (STATUS_RANK[effectiveStatus(b, edits)] ?? 99);
+            (STATUS_RANK[effectiveMappingStatus(a, edits[a.name])] ?? 99) -
+            (STATUS_RANK[effectiveMappingStatus(b, edits[b.name])] ?? 99);
           break;
       }
       return cmp * dir;
@@ -166,12 +186,9 @@ export function PackageTable({
     );
     const c: PackageCounts = { ...EMPTY_COUNTS, all: scoped.length };
     for (const p of scoped) {
-      if (edits[p.name]) c.edited++;
-      for (const [key, matches] of Object.entries(COUNT_BUCKETS) as Array<
-        [Exclude<CountKey, "all" | "edited">, PackagePredicate]
-      >) {
-        if (matches(p, edits)) c[key]++;
-      }
+      c[packageIdentityCoverage(p, edits[p.name])]++;
+      if (isUnverified(p, edits)) c.unverified++;
+      if (needsPurlDecision(p, edits[p.name])) c["no-purl-decision"]++;
     }
     return c;
   }, [packages, edits, filters.ecosystem]);
@@ -368,51 +385,55 @@ export function PackageTable({
         <div style={{ display: "flex", gap: 5, flexWrap: "wrap" }}>
           <FilterChip
             theme={theme}
-            active={
-              !filters.unmappedOnly && !filters.unverifiedOnly
-            }
+            active={filters.coverage === "all" && filters.review === "all"}
             onClick={() =>
               setFilters({
                 ...filters,
-                unmappedOnly: false,
-                unverifiedOnly: false,
+                coverage: "all",
+                review: "all",
               })
             }
           >
             All <Count active={false} theme={theme}>{counts.all}</Count>
           </FilterChip>
-          <FilterChip
-            theme={theme}
-            active={filters.unmappedOnly}
-            onClick={() =>
-              setFilters({
-                ...filters,
-                unmappedOnly: !filters.unmappedOnly,
-                unverifiedOnly: false,
-              })
-            }
-          >
-            Unmapped{" "}
-            <Count active={filters.unmappedOnly} theme={theme}>
-              {counts.unmapped}
-            </Count>
-          </FilterChip>
-          <FilterChip
-            theme={theme}
-            active={filters.unverifiedOnly}
-            onClick={() =>
-              setFilters({
-                ...filters,
-                unverifiedOnly: !filters.unverifiedOnly,
-                unmappedOnly: false,
-              })
-            }
-          >
-            Unverified{" "}
-            <Count active={filters.unverifiedOnly} theme={theme}>
-              {counts.unverified}
-            </Count>
-          </FilterChip>
+          {COVERAGE_FILTERS.map(({ coverage, label }) => (
+            <FilterChip
+              key={coverage}
+              theme={theme}
+              active={filters.coverage === coverage}
+              onClick={() =>
+                setFilters({
+                  ...filters,
+                  coverage: filters.coverage === coverage ? "all" : coverage,
+                  review: "all",
+                })
+              }
+            >
+              {label}{" "}
+              <Count active={filters.coverage === coverage} theme={theme}>
+                {counts[coverage]}
+              </Count>
+            </FilterChip>
+          ))}
+          {REVIEW_FILTERS.map(({ review, label }) => (
+            <FilterChip
+              key={review}
+              theme={theme}
+              active={filters.review === review}
+              onClick={() =>
+                setFilters({
+                  ...filters,
+                  review: filters.review === review ? "all" : review,
+                  coverage: "all",
+                })
+              }
+            >
+              {label}{" "}
+              <Count active={filters.review === review} theme={theme}>
+                {counts[review]}
+              </Count>
+            </FilterChip>
+          ))}
 
           <select
             value={filters.ecosystem}
@@ -538,16 +559,16 @@ export function PackageTable({
             style={{
               height: virtualizer.getTotalSize(),
               position: "relative",
-              width: "100%",
             }}
           >
             {virtualizer.getVirtualItems().map((vi) => {
               const p = filtered[vi.index];
               const checked = selectedSet.has(p.name);
               const focused = focusedId === p.name;
-              const status = effectiveStatus(p, edits);
+              const status = effectiveMappingStatus(p, edits[p.name]);
               const purl = effectivePurl(p, edits);
               const eco = effectiveType(p, edits);
+              const cpes = effectiveCpes(p, edits[p.name]);
               return (
                 <div
                   key={p.name}
@@ -644,17 +665,17 @@ export function PackageTable({
                     )}
                   </code>
                   <code
-                    title={(p.cpes ?? []).join("\n")}
+                    title={cpes.join("\n")}
                     style={{
                       fontFamily: "JetBrains Mono, monospace",
                       fontSize: 10.5,
-                      color: p.cpes?.length ? t.fg2 : t.fg3,
+                      color: cpes.length ? t.fg2 : t.fg3,
                       overflow: "hidden",
                       textOverflow: "ellipsis",
                       whiteSpace: "nowrap",
                     }}
                   >
-                    {p.cpes?.length ? p.cpes.join(", ") : "—"}
+                    {cpes.length ? cpes.join(", ") : "—"}
                   </code>
                   <span style={{ overflow: "hidden" }}>
                     <StatusPill

--- a/web/src/components/Primitives.tsx
+++ b/web/src/components/Primitives.tsx
@@ -169,7 +169,7 @@ export function StatusPill({
       fg: theme.dark ? "#f5c542" : "#866400",
     },
     unmapped: {
-      label: "Unmapped",
+      label: "No PURL",
       bg: theme.dark ? "#2a1818" : "#ffe1d8",
       fg: theme.dark ? "#ff8e6a" : "#a8401b",
     },

--- a/web/src/components/identityProvenance.test.mjs
+++ b/web/src/components/identityProvenance.test.mjs
@@ -10,7 +10,7 @@ let component;
 
 before(async () => {
   server = await createServer({
-    server: { middlewareMode: true },
+    server: { middlewareMode: true, hmr: false },
     appType: "custom",
     logLevel: "error",
   });
@@ -98,6 +98,21 @@ const cpeIdentity = {
   kind: "cpe",
   role: "associated",
   value: "cpe:2.3:a:example:demo",
+  provenance: {
+    availability: "available",
+    source: "manual",
+    review: {
+      status: "verified",
+      reviewer: "cpe-reviewer",
+      reviewed_at: "2026-02-04T05:06:07Z",
+    },
+  },
+};
+
+const legacyCpeIdentity = {
+  kind: "cpe",
+  role: "associated",
+  value: "cpe:2.3:a:example:legacy",
   provenance: { availability: "unavailable" },
 };
 
@@ -159,6 +174,20 @@ test("a recipe-source alternative shows provenance without a review state", () =
   assert.doesNotMatch(html, /Verified/);
 });
 
+test("a CPE shows its source and review attribution", () => {
+  const [row] = describe.describeIdentities([cpeIdentity]);
+  assert.equal(row.source, "manual");
+  assert.equal(row.review.status, "verified");
+  assert.equal(row.review.reviewer, "cpe-reviewer");
+  assert.equal(row.review.reviewedAt, "2026-02-04");
+  assert.equal(row.hasProvenance, true);
+
+  const html = render([cpeIdentity], "verified");
+  assert.match(html, /manual/);
+  assert.match(html, /@cpe-reviewer/);
+  assert.match(html, /Verified/);
+});
+
 test("a human-blessed mapping with an auto primary reports both facts", () => {
   const divergence = describe.primaryReviewDivergence("verified", [
     autoPrimary,
@@ -185,7 +214,7 @@ test("agreeing statuses and non-human mapping statuses raise no divergence", () 
 test("identities without provenance render as unrecorded rather than defaulted", () => {
   const [alternative, cpe] = describe.describeIdentities([
     bareAlternative,
-    cpeIdentity,
+    legacyCpeIdentity,
   ]);
   assert.equal(alternative.hasProvenance, false);
   assert.equal(alternative.source, null);
@@ -193,7 +222,7 @@ test("identities without provenance render as unrecorded rather than defaulted",
   assert.equal(cpe.hasProvenance, false);
   assert.equal(cpe.roleLabel, "cpe");
 
-  const html = render([bareAlternative, cpeIdentity], "verified");
+  const html = render([bareAlternative, legacyCpeIdentity], "verified");
   assert.match(html, /no provenance recorded/);
   assert.doesNotMatch(html, /confidence/);
 });

--- a/web/src/data/identityCoverage.test.mjs
+++ b/web/src/data/identityCoverage.test.mjs
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+import { createServer } from "vite";
+
+let server;
+let coverage;
+
+before(async () => {
+  server = await createServer({
+    server: { middlewareMode: true, hmr: false },
+    appType: "custom",
+    logLevel: "error",
+  });
+  coverage = await server.ssrLoadModule("/src/data/identityCoverage.ts");
+});
+
+after(async () => {
+  await server?.close();
+});
+
+function pkg(fields = {}) {
+  return {
+    name: "demo",
+    status: "auto-unverified",
+    purl: null,
+    alternative_purls: [],
+    cpes: [],
+    ...fields,
+  };
+}
+
+function edit(fields = {}) {
+  return {
+    type: "",
+    namespace: "",
+    pkgName: "",
+    purl: "",
+    alternative_purls: [],
+    unmapped: false,
+    note: "",
+    ...fields,
+  };
+}
+
+test("coverage distinguishes every PURL and CPE combination", () => {
+  assert.equal(coverage.packageIdentityCoverage(pkg()), "none");
+  assert.equal(
+    coverage.packageIdentityCoverage(pkg({ purl: "pkg:pypi/demo" })),
+    "purl",
+  );
+  assert.equal(
+    coverage.packageIdentityCoverage(pkg({ cpes: ["cpe:2.3:a:example:demo"] })),
+    "cpe",
+  );
+  assert.equal(
+    coverage.packageIdentityCoverage(
+      pkg({ purl: "pkg:pypi/demo", cpes: ["cpe:2.3:a:example:demo"] }),
+    ),
+    "purl+cpe",
+  );
+});
+
+test("alternative PURLs count as identities without a primary", () => {
+  assert.equal(
+    coverage.packageIdentityCoverage(pkg({ alternative_purls: ["pkg:npm/demo"] })),
+    "purl",
+  );
+});
+
+test("current identities are authoritative over legacy coverage fields", () => {
+  assert.equal(
+    coverage.packageIdentityCoverage(
+      pkg({
+        purl: "pkg:pypi/stale",
+        identities: [
+          {
+            kind: "cpe",
+            role: "associated",
+            value: "cpe:2.3:a:example:demo",
+            provenance: { availability: "unavailable" },
+          },
+        ],
+      }),
+    ),
+    "cpe",
+  );
+});
+
+test("draft replacements determine effective coverage", () => {
+  const published = pkg({ purl: "pkg:pypi/demo" });
+  assert.equal(
+    coverage.packageIdentityCoverage(published, edit({ unmapped: true })),
+    "none",
+  );
+  assert.equal(
+    coverage.packageIdentityCoverage(
+      published,
+      edit({ unmapped: true, cpes: ["cpe:2.3:a:example:demo"] }),
+    ),
+    "cpe",
+  );
+  assert.equal(
+    coverage.packageIdentityCoverage(
+      published,
+      edit({ alternative_purls: ["pkg:npm/demo"] }),
+    ),
+    "purl",
+  );
+});
+
+test("PURL decisions remain separate from identity coverage", () => {
+  const cpeOnly = pkg({
+    status: "verified",
+    cpes: ["cpe:2.3:a:example:demo"],
+  });
+  assert.equal(coverage.needsPurlDecision(cpeOnly), true);
+  assert.equal(
+    coverage.needsPurlDecision({ ...cpeOnly, status: "unmapped", unmapped: true }),
+    false,
+  );
+  assert.equal(
+    coverage.needsPurlDecision(cpeOnly, edit({ unmapped: true })),
+    false,
+  );
+  assert.equal(
+    coverage.needsPurlDecision(cpeOnly, edit({ purl: "pkg:pypi/demo" })),
+    false,
+  );
+});
+
+test("drafts override package review status without conflating coverage", () => {
+  assert.equal(coverage.effectiveMappingStatus(pkg()), "auto-unverified");
+  assert.equal(
+    coverage.effectiveMappingStatus(
+      pkg({
+        status: "unmapped",
+        cpes: ["cpe:2.3:a:example:demo"],
+      }),
+    ),
+    "unmapped",
+  );
+  assert.equal(
+    coverage.effectiveMappingStatus(
+      pkg({ purl: "pkg:pypi/demo", status: "auto-unverified" }),
+      edit(),
+    ),
+    "edited",
+  );
+});

--- a/web/src/data/identityCoverage.ts
+++ b/web/src/data/identityCoverage.ts
@@ -1,0 +1,60 @@
+import type { Edit, PackageEntry, ReviewStatus } from "./types";
+
+export type IdentityCoverage = "none" | "purl" | "cpe" | "purl+cpe";
+
+type IdentityPackage = Pick<
+  PackageEntry,
+  "purl" | "alternative_purls" | "cpes" | "identities" | "status" | "unmapped"
+>;
+
+function publishedIdentityKinds(pkg: IdentityPackage): {
+  hasPurl: boolean;
+  hasCpe: boolean;
+} {
+  if (pkg.identities) {
+    return {
+      hasPurl: pkg.identities.some((identity) => identity.kind === "purl"),
+      hasCpe: pkg.identities.some((identity) => identity.kind === "cpe"),
+    };
+  }
+  return {
+    hasPurl: Boolean(pkg.purl || pkg.alternative_purls?.length),
+    hasCpe: Boolean(pkg.cpes?.length),
+  };
+}
+
+export function effectiveCpes(pkg: IdentityPackage, edit?: Edit): string[] {
+  return edit?.cpes ?? pkg.cpes ?? [];
+}
+
+export function packageIdentityCoverage(
+  pkg: IdentityPackage,
+  edit?: Edit,
+): IdentityCoverage {
+  const published = publishedIdentityKinds(pkg);
+  const hasPurl = edit
+    ? !edit.unmapped && Boolean(edit.purl || edit.alternative_purls?.length)
+    : published.hasPurl;
+  const hasCpe = edit ? effectiveCpes(pkg, edit).length > 0 : published.hasCpe;
+
+  if (hasPurl && hasCpe) return "purl+cpe";
+  if (hasPurl) return "purl";
+  if (hasCpe) return "cpe";
+  return "none";
+}
+
+export function needsPurlDecision(
+  pkg: IdentityPackage,
+  edit?: Edit,
+): boolean {
+  const coverage = packageIdentityCoverage(pkg, edit);
+  if (coverage === "purl" || coverage === "purl+cpe") return false;
+  return edit ? !edit.unmapped : pkg.unmapped !== true && pkg.status !== "unmapped";
+}
+
+export function effectiveMappingStatus(
+  pkg: IdentityPackage,
+  edit?: Edit,
+): ReviewStatus {
+  return edit ? "edited" : pkg.status;
+}

--- a/web/src/data/identityProvenance.ts
+++ b/web/src/data/identityProvenance.ts
@@ -89,9 +89,32 @@ export function describeIdentity(identity: PublishedIdentity): IdentityDisplay {
   } satisfies IdentityDisplay;
 
   if (identity.kind === "cpe") {
+    const provenance = identity.provenance;
+    if (provenance.availability === "unavailable") {
+      return {
+        ...base,
+        hint: "CPE prefix recorded without provenance in an older payload.",
+      };
+    }
+    if (provenance.source === "auto") {
+      return {
+        ...base,
+        source: provenance.source,
+        review: reviewDisplay(provenance.review.status, null, null),
+        hasProvenance: true,
+        hint: "CPE prefix recorded by the automatic mapping layer.",
+      };
+    }
     return {
       ...base,
-      hint: "CPE prefix recorded for downstream NVD matching. The payload publishes no provenance for CPEs.",
+      source: provenance.source,
+      review: reviewDisplay(
+        provenance.review.status,
+        provenance.review.reviewer,
+        dateOf(provenance.review.reviewed_at),
+      ),
+      hasProvenance: true,
+      hint: "CPE prefix set by a reviewer.",
     };
   }
 

--- a/web/src/data/loader.test.mjs
+++ b/web/src/data/loader.test.mjs
@@ -11,7 +11,7 @@ const realFetch = globalThis.fetch;
 
 before(async () => {
   server = await createServer({
-    server: { middlewareMode: true },
+    server: { middlewareMode: true, hmr: false },
     appType: "custom",
     logLevel: "error",
   });
@@ -94,7 +94,11 @@ function fixture(name, detailPath) {
       kind: "cpe",
       role: "associated",
       value: "cpe:2.3:a:example:demo",
-      provenance: { availability: "unavailable" },
+      provenance: {
+        availability: "available",
+        source: "auto",
+        review: { status: "auto-verified", reviewer: null },
+      },
     },
   ];
   const common = {
@@ -149,8 +153,8 @@ async function loadCurrentCase(mutateDetail = () => {}) {
   const detailPath = `hostile-detail-${id}.json`;
   const { index, detail } = fixture(name, detailPath);
   mutateDetail(detail);
-  responses.set(indexPath, metadata(3, { [name]: index }));
-  responses.set(`./${detailPath}`, { schema_version: 2, packages: { [name]: detail } });
+  responses.set(indexPath, metadata(4, { [name]: index }));
+  responses.set(`./${detailPath}`, { schema_version: 3, packages: { [name]: detail } });
   const decodedIndex = await loader.loadMappingsIndex(indexPath);
   return loader.loadMappingPackageDetail(decodedIndex.packages[name]);
 }
@@ -183,6 +187,17 @@ test("hostile current shards cannot replace an internally valid index identity c
       detail.cpes[0] = "cpe:2.3:a:attacker:demo";
       detail.identities.at(-1).value = detail.cpes[0];
     },
+    "CPE provenance": (detail) => {
+      detail.identities.at(-1).provenance = {
+        availability: "available",
+        source: "manual",
+        review: {
+          status: "verified",
+          reviewer: "attacker",
+          reviewed_at: "2026-01-02T03:04:05Z",
+        },
+      };
+    },
     status: (detail) => {
       detail.status = "auto-unverified";
     },
@@ -210,6 +225,26 @@ test("hostile current shards cannot replace an internally valid index identity c
       await assert.rejects(loadCurrentCase(mutate), /identity contract mismatch/);
     });
   }
+});
+
+test("previous identity schema accepts explicitly unavailable CPE provenance", async () => {
+  const id = sequence++;
+  const name = `previous-${id}`;
+  const { detail } = fixture(name, "unused.json");
+  detail.identities.at(-1).provenance = { availability: "unavailable" };
+  const bundlePath = `./previous-${id}.json`;
+  responses.set(bundlePath, metadata(2, { [name]: detail }));
+  const decoded = await loader.loadMappings(bundlePath);
+  assert.equal(decoded.packages[name].identities.at(-1).provenance.availability, "unavailable");
+});
+
+test("current identity schema requires attributed CPE provenance", async () => {
+  await assert.rejects(
+    loadCurrentCase((detail) => {
+      detail.identities.at(-1).provenance = { availability: "unavailable" };
+    }),
+    /CPE provenance/,
+  );
 });
 
 function legacyBundle(id) {

--- a/web/src/data/loader.ts
+++ b/web/src/data/loader.ts
@@ -9,9 +9,9 @@ import type {
 
 const DEFAULT_PATH = "./mappings.json";
 const DEFAULT_INDEX_PATH = "./mappings-index.json";
-const SUPPORTED_BUNDLE_SCHEMAS = new Set([1, 2]);
-const SUPPORTED_INDEX_SCHEMAS = new Set([2, 3]);
-const SUPPORTED_DETAIL_SCHEMAS = new Set([1, 2]);
+const SUPPORTED_BUNDLE_SCHEMAS = new Set([1, 2, 3]);
+const SUPPORTED_INDEX_SCHEMAS = new Set([2, 3, 4]);
+const SUPPORTED_DETAIL_SCHEMAS = new Set([1, 2, 3]);
 const PURL_PATTERN = /^pkg:[a-z][a-z0-9.+-]*\/[^\s?#]+(?:\?[^\s#]+)?(?:#[^\s]+)?$/;
 const CPE_PATTERN = /^cpe:2\.3:[aho*\-]:[^:]+:[^:]+(?::[^:]*){0,10}$/;
 const REVIEW_STATUSES = new Set([
@@ -293,7 +293,11 @@ function decodeAutoMapping(value: unknown, label: string): void {
   }
 }
 
-function decodeIdentity(value: unknown, label: string): void {
+function decodeIdentity(
+  value: unknown,
+  label: string,
+  cpeProvenance: "unavailable" | "available",
+): void {
   const identity = record(value, label);
   const identityValue = stringValue(identity.value, `${label}.value`, false);
   if (identity.kind === "purl" && !PURL_PATTERN.test(identityValue)) {
@@ -373,11 +377,38 @@ function decodeIdentity(value: unknown, label: string): void {
       throw new Error(`${label} has unsupported alternative provenance`);
     }
   } else if (identity.kind === "cpe" && identity.role === "associated") {
-    if (
-      provenance.availability !== "unavailable" ||
-      !hasOnlyKeys(provenance, ["availability"])
-    ) {
-      throw new Error(`${label} CPE provenance must be unavailable`);
+    if (cpeProvenance === "unavailable") {
+      if (
+        provenance.availability !== "unavailable" ||
+        !hasOnlyKeys(provenance, ["availability"])
+      ) {
+        throw new Error(`${label} CPE provenance must be unavailable`);
+      }
+    } else {
+      if (provenance.availability !== "available") {
+        throw new Error(`${label} CPE provenance must be available`);
+      }
+      const review = record(provenance.review, `${label}.provenance.review`);
+      const source = String(provenance.source);
+      const automatic =
+        source === "auto" &&
+        hasOnlyKeys(provenance, ["availability", "source", "review"]) &&
+        hasOnlyKeys(review, ["status", "reviewer"]) &&
+        ["auto-unverified", "auto-verified"].includes(String(review.status)) &&
+        review.reviewer === null;
+      const manual =
+        source === "manual" &&
+        hasOnlyKeys(provenance, ["availability", "source", "review"]) &&
+        hasOnlyKeys(review, ["status", "reviewer", "reviewed_at"]) &&
+        ["verified", "edited"].includes(String(review.status)) &&
+        typeof review.reviewer === "string" &&
+        review.reviewer.length > 0 &&
+        typeof review.reviewed_at === "string" &&
+        /(?:Z|[+-]\d{2}:\d{2})$/.test(review.reviewed_at) &&
+        Number.isFinite(Date.parse(review.reviewed_at));
+      if (!automatic && !manual) {
+        throw new Error(`${label} has malformed CPE provenance`);
+      }
     }
   } else {
     throw new Error(`${label} has unsupported identity kind/role`);
@@ -447,19 +478,19 @@ function decodeCommonEntry(
 function decodeIndexEntry(
   entry: Record<string, unknown>,
   name: string,
-  current: boolean,
+  identityContract: IdentityContract,
   label: string,
 ): void {
   requireOnlyKeys(entry, INDEX_ENTRY_KEYS, label);
   const expected = decodeCommonEntry(entry, name, label);
   stringValue(required(entry, "detail_path", label), `${label}.detail_path`, false);
-  decodeCurrentIdentities(entry, expected, current, label);
+  decodeCurrentIdentities(entry, expected, identityContract, label);
 }
 
 function decodeFullEntry(
   entry: Record<string, unknown>,
   name: string,
-  current: boolean,
+  identityContract: IdentityContract,
   label: string,
 ): void {
   requireOnlyKeys(entry, FULL_ENTRY_KEYS, label);
@@ -493,16 +524,18 @@ function decodeFullEntry(
   if (hasOwn(entry, "verification_sources") && entry.verification_sources !== null) {
     stringArray(entry.verification_sources, `${label}.verification_sources`);
   }
-  decodeCurrentIdentities(entry, expected, current, label);
+  decodeCurrentIdentities(entry, expected, identityContract, label);
 }
+
+type IdentityContract = "none" | "legacy" | "current";
 
 function decodeCurrentIdentities(
   entry: Record<string, unknown>,
   expected: IdentitySummary[],
-  current: boolean,
+  identityContract: IdentityContract,
   label: string,
 ): void {
-  if (!current) {
+  if (identityContract === "none") {
     if (hasOwn(entry, "identities")) {
       throw new Error(`${label}.identities is not supported by this schema`);
     }
@@ -514,7 +547,11 @@ function decodeCurrentIdentities(
   const seenValues = new Set<string>();
   const actual = entry.identities.map((identity, index) => {
     const identityLabel = `${label}.identities[${index}]`;
-    decodeIdentity(identity, identityLabel);
+    decodeIdentity(
+      identity,
+      identityLabel,
+      identityContract === "current" ? "available" : "unavailable",
+    );
     const decoded = record(identity, identityLabel);
     const value = decoded.value as string;
     if (seenValues.has(value)) {
@@ -571,13 +608,19 @@ function decodePackages(
   shape: PackageShape,
 ): void {
   const packages = record(payload.packages, `${label}.packages`);
-  const current = payload.schema_version === currentVersion;
+  const version = payload.schema_version as number;
+  const identityContract: IdentityContract =
+    version === currentVersion
+      ? "current"
+      : version === currentVersion - 1
+        ? "legacy"
+        : "none";
   for (const [name, rawEntry] of Object.entries(packages)) {
     if (name.length === 0) throw new Error(`${label} has an empty package name`);
     const entryLabel = `${label}.packages.${name}`;
     const entry = record(rawEntry, entryLabel);
-    if (shape === "index") decodeIndexEntry(entry, name, current, entryLabel);
-    else decodeFullEntry(entry, name, current, entryLabel);
+    if (shape === "index") decodeIndexEntry(entry, name, identityContract, entryLabel);
+    else decodeFullEntry(entry, name, identityContract, entryLabel);
   }
 }
 
@@ -611,7 +654,7 @@ export async function loadMappings(path = DEFAULT_PATH): Promise<MappingsPayload
     SUPPORTED_BUNDLE_SCHEMAS,
     true,
   );
-  decodePackages(payload, 2, "mapping bundle", "full");
+  decodePackages(payload, 3, "mapping bundle", "full");
   return payload as MappingsPayload;
 }
 
@@ -624,7 +667,7 @@ export async function loadMappingsIndex(
     SUPPORTED_INDEX_SCHEMAS,
     true,
   );
-  decodePackages(payload, 3, "mapping index", "index");
+  decodePackages(payload, 4, "mapping index", "index");
   const packages = record(payload.packages, "mapping index.packages");
   for (const [name, rawEntry] of Object.entries(packages)) {
     const entry = record(rawEntry, `mapping index.packages.${name}`);
@@ -671,8 +714,8 @@ export async function loadMappingPackageDetail(
     SUPPORTED_DETAIL_SCHEMAS,
     false,
   );
-  decodePackages(payload, 2, `mapping detail ${path}`, "full");
-  const expectedDetailVersion = decodedIndex.schemaVersion === 3 ? 2 : 1;
+  decodePackages(payload, 3, `mapping detail ${path}`, "full");
+  const expectedDetailVersion = decodedIndex.schemaVersion - 1;
   if (payload.schema_version !== expectedDetailVersion) {
     throw new Error(
       `mapping index/detail schema mismatch: index ${decodedIndex.schemaVersion} requires detail ${expectedDetailVersion}`,
@@ -682,7 +725,7 @@ export async function loadMappingPackageDetail(
   const detail = data.packages[decodedIndex.name];
   if (!detail) throw new Error(`Missing ${decodedIndex.name} in ${path}`);
   if (
-    decodedIndex.schemaVersion === 3 &&
+    decodedIndex.schemaVersion >= 3 &&
     normalizedIndexIdentityContract(
       detail as unknown as Record<string, unknown>,
       decodedIndex.includeAuto,
@@ -728,5 +771,5 @@ export const ECOSYSTEMS = [
   { id: "cran", label: "CRAN", color: "#1E63B5" },
   { id: "bioconductor", label: "Bioconductor", color: "#1A8744" },
   { id: "generic", label: "Generic", color: "#62656a" },
-  { id: "none", label: "Unmapped", color: "#b5b7ba" },
+  { id: "none", label: "No primary", color: "#b5b7ba" },
 ] as const;

--- a/web/src/data/types.ts
+++ b/web/src/data/types.ts
@@ -82,11 +82,35 @@ export type DetailedAlternativeIdentity = {
   };
 };
 
-export type CpeIdentity = {
+export type LegacyCpeIdentity = {
   kind: "cpe";
   role: "associated";
   value: string;
   provenance: { availability: "unavailable" };
+};
+
+export type CpeIdentity = {
+  kind: "cpe";
+  role: "associated";
+  value: string;
+  provenance:
+    | {
+        availability: "available";
+        source: "auto";
+        review: {
+          status: "auto-unverified" | "auto-verified";
+          reviewer: null;
+        };
+      }
+    | {
+        availability: "available";
+        source: "manual";
+        review: {
+          status: "verified" | "edited";
+          reviewer: string;
+          reviewed_at: string;
+        };
+      };
 };
 
 export type PublishedIdentity =
@@ -94,6 +118,7 @@ export type PublishedIdentity =
   | ManualPrimaryIdentity
   | BareAlternativeIdentity
   | DetailedAlternativeIdentity
+  | LegacyCpeIdentity
   | CpeIdentity;
 
 export type ManualOverride = {
@@ -177,31 +202,51 @@ export type LegacyMappingsPayload = MappingPayloadMetadata & {
   packages: Record<string, PackageEntry>;
 };
 
-export type CurrentMappingsPayload = MappingPayloadMetadata & {
+export type PreviousMappingsPayload = MappingPayloadMetadata & {
   schema_version: 2;
   packages: Record<string, PackageEntry & { identities: PublishedIdentity[] }>;
 };
 
-export type MappingsPayload = LegacyMappingsPayload | CurrentMappingsPayload;
+export type CurrentMappingsPayload = MappingPayloadMetadata & {
+  schema_version: 3;
+  packages: Record<string, PackageEntry & { identities: PublishedIdentity[] }>;
+};
+
+export type MappingsPayload =
+  | LegacyMappingsPayload
+  | PreviousMappingsPayload
+  | CurrentMappingsPayload;
 
 export type LegacyMappingsIndexPayload = MappingPayloadMetadata & {
   schema_version: 2;
   packages: Record<string, MappingPackageIndex>;
 };
 
-export type CurrentMappingsIndexPayload = MappingPayloadMetadata & {
+export type PreviousMappingsIndexPayload = MappingPayloadMetadata & {
   schema_version: 3;
-  packages: Record<MappingPackageIndex["name"], MappingPackageIndex & { identities: PublishedIdentity[] }>;
+  packages: Record<
+    MappingPackageIndex["name"],
+    MappingPackageIndex & { identities: PublishedIdentity[] }
+  >;
+};
+
+export type CurrentMappingsIndexPayload = MappingPayloadMetadata & {
+  schema_version: 4;
+  packages: Record<
+    MappingPackageIndex["name"],
+    MappingPackageIndex & { identities: PublishedIdentity[] }
+  >;
 };
 
 export type MappingsIndexPayload =
   | LegacyMappingsIndexPayload
+  | PreviousMappingsIndexPayload
   | CurrentMappingsIndexPayload;
 
 export type MappingDetailPayload =
   | { schema_version: 1; packages: Record<string, PackageEntry> }
   | {
-      schema_version: 2;
+      schema_version: 2 | 3;
       packages: Record<string, PackageEntry & { identities: PublishedIdentity[] }>;
     };
 


### PR DESCRIPTION
## Why

The app currently treats a package without a primary PURL as unmapped, even when it has a CPE identity. CPE identities also publish provenance as unavailable, which loses the source layer and review attribution that already exist during the merge.

This makes identity coverage counts misleading and prevents consumers from distinguishing automatic and reviewed CPE mappings.

## What changes

- Derives coverage from the complete identity set: no identity, PURL only, CPE only, or both.
- Keeps the no-PURL decision and package review state separate from coverage.
- Preserves source-level provenance when a merge layer replaces a CPE list.
- Publishes and displays CPE source, review status, reviewer, and review date.
- Bumps the bundle, index, and detail schemas to 3, 4, and 3 while retaining support for the immediately previous generation.

Generated payloads are not committed. The Pages workflow regenerates them atomically.

## Rollout

Do not merge this until [prefix-dev/basilisk#173](https://github.com/prefix-dev/basilisk/pull/173) is merged and deployed. A push to `main` republishes the Pages payload, while the current Basilisk deployment fails closed on schema 4 and its database constraint only permits unavailable CPE provenance.

## Testing

- `pixi run -e lite mappings:test` (18 passed, 1 expected legacy-snapshot skip)
- `pixi run ruff check scripts tests`
- `pixi run ruff format --check scripts tests`
- `npm test` in `web` (46 passed)
- `npm run build` in `web`
- Generated and validated the full 34,182-package payload with 923 CPE mappings
- Checked the coverage filters and CPE provenance in the browser