### PR TITLE
PFX-1962: measure and inspect primary-PURL coverage

### DIFF
--- a/.github/workflows/automap.yml
+++ b/.github/workflows/automap.yml
@@ -39,13 +39,15 @@ jobs:
           pixi-version: latest
           cache: true
 
-      - name: Snapshot baseline auto.json
+      - name: Snapshot baseline mappings and coverage
         # Capture HEAD's mappings before automap rewrites the file so the
-        # summary step can diff against it.
+        # package and coverage summaries describe this exact PR's delta.
         run: |
           mkdir -p /tmp/automap_baseline
           git show HEAD:mappings/auto.json > /tmp/automap_baseline/auto.json 2>/dev/null \
             || echo '{"packages":{}}' > /tmp/automap_baseline/auto.json
+          pixi run -e lite mappings:report
+          cp web/public/mappings-report.json /tmp/automap_baseline/mappings-report.json
 
       - name: Run automap
         run: |
@@ -56,8 +58,8 @@ jobs:
           if [ "${{ inputs.force }}" = "true" ]; then ARGS+=(--force); fi
           pixi run purl:automap "${ARGS[@]}"
 
-      - name: Merge mappings for the SPA
-        run: pixi run mappings:merge
+      - name: Merge mappings and refresh coverage report
+        run: pixi run -e lite mappings:report
 
       - name: Generate PR body
         run: |
@@ -65,6 +67,12 @@ jobs:
             --before /tmp/automap_baseline/auto.json \
             --after mappings/auto.json \
             > /tmp/automap_pr_body.md
+          printf '\n\n' >> /tmp/automap_pr_body.md
+          pixi run python -m scripts.mappings_report \
+            --input web/public/mappings.json \
+            --format markdown \
+            --baseline-report /tmp/automap_baseline/mappings-report.json \
+            >> /tmp/automap_pr_body.md
           echo "----- PR body preview -----"
           cat /tmp/automap_pr_body.md
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,6 +7,7 @@ on:
       - "web/**"
       - "mappings/**"
       - "scripts/merge_mappings.py"
+      - "scripts/mappings_report.py"
       - "scripts/validate.py"
       - "tests/**"
       - "pixi.toml"
@@ -41,8 +42,8 @@ jobs:
           cache: true
           environments: lite
 
-      - name: Refresh served identity mapping payload
-        run: pixi run -e lite mappings:merge
+      - name: Refresh served identity mappings and coverage report
+        run: pixi run -e lite mappings:report
 
       - name: Test identity mapping contract
         run: pixi run -e lite mappings:test

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,14 +34,27 @@ jobs:
           cache: true
           environments: lite
 
-      - name: Rebuild served identity mapping payload
-        run: pixi run -e lite mappings:merge
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
+
+      - name: Rebuild served identity mappings and coverage report
+        run: pixi run -e lite mappings:report
 
       - name: Test identity mapping contract
         run: pixi run -e lite mappings:test
 
       - name: Validate identity mapping payload
         run: pixi run -e lite mappings:validate
+
+      - name: Test and build GitHub Pages frontend
+        working-directory: web
+        run: |
+          npm ci
+          npm test
+          npm run build
 
       - name: Guard against mass removals in auto.json
         # A pipeline bug or an upstream source returning empty shows up as a

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 node_modules/
 web/dist/
 web/public/mappings.json
+web/public/mappings-report.json
 
 # Removed CVE/SBOM outputs are owned by downstream projects.
 

--- a/README.md
+++ b/README.md
@@ -188,9 +188,22 @@ The JSON report separates `primary_present`, `explicitly_unmapped`, and
 `unresolved`; these three counts sum to `total`. `primary_missing` is the sum of
 the latter two states. Alternative PURLs and CPEs do not count as primary PURLs.
 Each missing-primary package retains its recorded URLs, note, version, and download
-count for investigation. Missing evidence does not imply intentional exclusion,
-and notes can survive reviewed overrides. This initial report does not yet infer
-failure reasons or distinguish confirmed mapper bugs from unresolved cases.
+count for investigation.
+
+Every unresolved package has one conservative `diagnostic_reason`, summarized in
+`unresolved_by_diagnostic`:
+
+- `recorded_processing_error` — the persisted note starts with `fetch error:`;
+- `alternative_only` — a canonical alternative PURL exists without a primary;
+- `no_parseable_source_host` — no hostname can be parsed from the persisted source,
+  repository, or homepage URLs;
+- `no_primary_from_url_evidence` — URL-host evidence exists but no primary PURL was
+  produced.
+
+Diagnostics describe recorded evidence, not authoritative root causes. Notes can
+survive reviewed overrides, and missing evidence does not imply intentional
+exclusion. Only `unmapped: true` establishes an explicit no-PURL decision. The
+diagnostic counts are mutually exclusive and sum to `unresolved`.
 
 Reporting is offline and read-only. Package order is stable, and volatile bundle
 generation timestamps are omitted. Invalid contracts fail rather than producing

--- a/README.md
+++ b/README.md
@@ -167,6 +167,35 @@ pixi run -e lite mappings:validate
 pixi run purl:test
 ```
 
+### Primary-PURL coverage report
+
+Report effective primary-PURL coverage after automatic mappings, manual overrides,
+and contributions have been merged. The reporter requires the current full bundle
+schema; it does not accept the compact index or raw `auto.json`.
+
+To rebuild and report without changing the committed public payloads:
+
+```sh
+pixi run -e lite mappings:merge \
+  --out .tmp/coverage/mappings.json \
+  --index-out .tmp/coverage/mappings-index.json \
+  --detail-dir .tmp/coverage/mapping_packages
+pixi run -e lite python -m scripts.mappings_report \
+  --input .tmp/coverage/mappings.json > .tmp/coverage/report.json
+```
+
+The JSON report separates `primary_present`, `explicitly_unmapped`, and
+`unresolved`; these three counts sum to `total`. `primary_missing` is the sum of
+the latter two states. Alternative PURLs and CPEs do not count as primary PURLs.
+Each missing-primary package retains its recorded URLs, note, version, and download
+count for investigation. Missing evidence does not imply intentional exclusion,
+and notes can survive reviewed overrides. This initial report does not yet infer
+failure reasons or distinguish confirmed mapper bugs from unresolved cases.
+
+Reporting is offline and read-only. Package order is stable, and volatile bundle
+generation timestamps are omitted. Invalid contracts fail rather than producing
+apparently successful empty coverage.
+
 ## CPE flow
 
 CPE discovery is part of identity mapping, not CVE assignment. The retained CPE

--- a/README.md
+++ b/README.md
@@ -191,6 +191,21 @@ pixi run -e lite python -m scripts.mappings_report \
   --output .tmp/coverage/report.json
 ```
 
+Render a bounded Markdown summary, optionally compared with an earlier JSON
+report:
+
+```sh
+pixi run -e lite python -m scripts.mappings_report \
+  --input .tmp/coverage/mappings.json \
+  --format markdown \
+  --baseline-report /tmp/mappings-report-before.json
+```
+
+The scheduled automap workflow captures that baseline before refreshing mappings
+and appends the resulting coverage and diagnostic deltas to its PR body. The
+Markdown summary includes the top current unresolved source hosts but not the full
+missing-package list.
+
 The JSON report separates `primary_present`, `explicitly_unmapped`, and
 `unresolved`; these three counts sum to `total`. `primary_missing` is the sum of
 the latter two states. Alternative PURLs and CPEs do not count as primary PURLs.
@@ -211,6 +226,12 @@ Diagnostics describe recorded evidence, not authoritative root causes. Notes can
 survive reviewed overrides, and missing evidence does not imply intentional
 exclusion. Only `unmapped: true` establishes an explicit no-PURL decision. The
 diagnostic counts are mutually exclusive and sum to `unresolved`.
+
+Each missing-primary row includes normalized, sorted `source_hosts` derived from
+its persisted source, repository, and homepage URLs. `unresolved_by_source_host`
+counts each host at most once per unresolved package and is sorted by package
+count, then hostname. Host groups are non-exclusive because one package can cite
+multiple hosts, so their counts do not sum to `unresolved`.
 
 Reporting is offline and read-only. Package order is stable, and volatile bundle
 generation timestamps are omitted. Invalid contracts fail rather than producing

--- a/README.md
+++ b/README.md
@@ -173,7 +173,13 @@ Report effective primary-PURL coverage after automatic mappings, manual override
 and contributions have been merged. The reporter requires the current full bundle
 schema; it does not accept the compact index or raw `auto.json`.
 
-To rebuild and report without changing the committed public payloads:
+Generate the merged mappings and browser report used by the GitHub Pages app:
+
+```sh
+pixi run -e lite mappings:report
+```
+
+To rebuild and report without changing the generated public payloads:
 
 ```sh
 pixi run -e lite mappings:merge \
@@ -181,7 +187,8 @@ pixi run -e lite mappings:merge \
   --index-out .tmp/coverage/mappings-index.json \
   --detail-dir .tmp/coverage/mapping_packages
 pixi run -e lite python -m scripts.mappings_report \
-  --input .tmp/coverage/mappings.json > .tmp/coverage/report.json
+  --input .tmp/coverage/mappings.json \
+  --output .tmp/coverage/report.json
 ```
 
 The JSON report separates `primary_present`, `explicitly_unmapped`, and
@@ -246,14 +253,17 @@ pixi run -e lite mappings:validate
 
 ## Frontend behavior
 
-The GitHub Pages app is a PURL editing UI:
+The GitHub Pages app provides two identity-mapping views:
 
+- `index.html` is the PURL/CPE mapping editor;
+- `coverage.html` is a read-only inspector for missing primary PURLs, with state,
+  diagnostic, source-host, and text filters plus recorded evidence;
 - users can review, edit, approve, or mark PURL mappings as unmapped
 - staged identity edits are saved locally until submitted
 - submitted edits open PRs containing one new file under `mappings/contributions/`
 - CPEs can be reviewed and edited alongside PURL mappings
-- no CVE dashboard, OpenVEX review, AI CVE queue, or deep-inspection routes are
-  served from this repository
+- no CVE dashboard, OpenVEX review, AI CVE queue, or CVE deep-inspection routes
+  are served from this repository
 
 The Worker exposes only:
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -26,6 +26,7 @@ python = ">=3.13,<3.14"
 # (no ambiguity) yet runnable without installing py-rattler.
 [feature.lite.tasks]
 "mappings:merge" = "python -m scripts.merge_mappings"
+"mappings:report" = { cmd = "python -m scripts.mappings_report --input web/public/mappings.json --output web/public/mappings-report.json", depends-on = ["mappings:merge"] }
 "mappings:validate" = "python -m scripts.validate"
 "mappings:test" = "python -m unittest discover -s tests -v"
 
@@ -132,7 +133,7 @@ depends-on = ["web:install", "worker:install"]
 description = "Install web and Worker npm dependencies"
 
 [tasks."app:check"]
-cmd = "python -m unittest discover -s tests -v && npm --prefix web test && python -m scripts.merge_mappings && python -m scripts.validate && npm --prefix web run build && npm --prefix worker run typecheck"
+cmd = "python -m unittest discover -s tests -v && npm --prefix web test && python -m scripts.merge_mappings && python -m scripts.mappings_report --input web/public/mappings.json --output web/public/mappings-report.json && python -m scripts.validate && npm --prefix web run build && npm --prefix worker run typecheck"
 depends-on = ["app:install"]
 description = "Run contract tests, validate data, build the web app, and typecheck the Worker"
 
@@ -149,9 +150,9 @@ description = "Run browser payload decoder contract tests"
 
 [tasks."web:data"]
 depends-on = [
-  { task = "mappings:merge", environment = "lite" },
+  { task = "mappings:report", environment = "lite" },
 ]
-description = "Regenerate frontend identity mapping payloads from mappings/ source files"
+description = "Regenerate frontend identity mapping payloads and coverage report from mappings/ source files"
 
 [tasks."web:dev"]
 cmd = "npm run dev -- --host {{ host }} --port {{ port }}"

--- a/scripts/mappings_report.py
+++ b/scripts/mappings_report.py
@@ -11,11 +11,57 @@ import argparse
 import json
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 from scripts import merge_mappings, validate
 
 REPORT_SCHEMA_VERSION = 1
-EVIDENCE_FIELDS = ("version", "source_url", "repo", "homepage", "note")
+URL_EVIDENCE_FIELDS = ("source_url", "repo", "homepage")
+EVIDENCE_FIELDS = ("version", *URL_EVIDENCE_FIELDS, "note")
+UNRESOLVED_DIAGNOSTICS = (
+    "recorded_processing_error",
+    "alternative_only",
+    "no_parseable_source_host",
+    "no_primary_from_url_evidence",
+)
+
+
+def _source_hosts(entry: dict[str, Any]) -> tuple[str, ...]:
+    """Return normalized, unique hostnames from persisted URL evidence."""
+    hosts: set[str] = set()
+    for field in URL_EVIDENCE_FIELDS:
+        value = entry.get(field)
+        if not isinstance(value, str) or not value.strip():
+            continue
+        try:
+            hostname = urlsplit(value).hostname
+        except ValueError:
+            continue
+        if hostname:
+            normalized = hostname.lower().rstrip(".")
+            if normalized:
+                hosts.add(normalized)
+    return tuple(sorted(hosts))
+
+
+def _has_alternative_purl(entry: dict[str, Any]) -> bool:
+    """Use the canonical identity contract rather than legacy alternatives."""
+    return any(
+        identity["kind"] == "purl" and identity["role"] == "alternative"
+        for identity in entry["identities"]
+    )
+
+
+def _diagnose_unresolved(entry: dict[str, Any]) -> str:
+    """Classify persisted evidence without claiming an authoritative root cause."""
+    note = (entry.get("note") or "").strip()
+    if note.lower().startswith("fetch error:"):
+        return "recorded_processing_error"
+    if _has_alternative_purl(entry):
+        return "alternative_only"
+    if not _source_hosts(entry):
+        return "no_parseable_source_host"
+    return "no_primary_from_url_evidence"
 
 
 def build_report(payload: dict[str, Any]) -> dict[str, Any]:
@@ -50,6 +96,7 @@ def build_report(payload: dict[str, Any]) -> dict[str, Any]:
         raise ValueError("package names must be non-empty strings")
 
     counts = {"primary_present": 0, "explicitly_unmapped": 0, "unresolved": 0}
+    unresolved_by_diagnostic = {diagnostic: 0 for diagnostic in UNRESOLVED_DIAGNOSTICS}
     missing: list[dict[str, Any]] = []
     for name, entry in sorted(packages.items()):
         label = f"packages.{name}"
@@ -90,14 +137,24 @@ def build_report(payload: dict[str, Any]) -> dict[str, Any]:
         )
         counts[state] += 1
         if not has_primary:
+            diagnostic_reason = None
+            if state == "unresolved":
+                diagnostic_reason = _diagnose_unresolved(entry)
+                unresolved_by_diagnostic[diagnostic_reason] += 1
             missing.append(
                 {
                     "name": name,
                     "state": state,
+                    "diagnostic_reason": diagnostic_reason,
                     **{field: entry.get(field) for field in EVIDENCE_FIELDS},
                     "download_count": downloads,
                 }
             )
+
+    if sum(counts.values()) != len(packages):
+        raise RuntimeError("primary-PURL coverage counts do not reconcile")
+    if sum(unresolved_by_diagnostic.values()) != counts["unresolved"]:
+        raise RuntimeError("unresolved diagnostic counts do not reconcile")
 
     return {
         "schema_version": REPORT_SCHEMA_VERSION,
@@ -108,6 +165,7 @@ def build_report(payload: dict[str, Any]) -> dict[str, Any]:
             **counts,
             "primary_missing": counts["explicitly_unmapped"] + counts["unresolved"],
         },
+        "unresolved_by_diagnostic": unresolved_by_diagnostic,
         "missing_packages": missing,
     }
 

--- a/scripts/mappings_report.py
+++ b/scripts/mappings_report.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from collections import Counter
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
@@ -24,6 +25,19 @@ UNRESOLVED_DIAGNOSTICS = (
     "no_parseable_source_host",
     "no_primary_from_url_evidence",
 )
+COVERAGE_LABELS = (
+    ("total", "Total packages"),
+    ("primary_present", "Primary PURL present"),
+    ("explicitly_unmapped", "Explicitly unmapped"),
+    ("unresolved", "Unresolved"),
+    ("primary_missing", "Primary PURL missing"),
+)
+DIAGNOSTIC_LABELS = {
+    "recorded_processing_error": "Recorded processing error",
+    "alternative_only": "Alternative PURL only",
+    "no_parseable_source_host": "No parseable source host",
+    "no_primary_from_url_evidence": "URL evidence without primary PURL",
+}
 
 
 def _source_hosts(entry: dict[str, Any]) -> tuple[str, ...]:
@@ -52,14 +66,14 @@ def _has_alternative_purl(entry: dict[str, Any]) -> bool:
     )
 
 
-def _diagnose_unresolved(entry: dict[str, Any]) -> str:
+def _diagnose_unresolved(entry: dict[str, Any], source_hosts: tuple[str, ...]) -> str:
     """Classify persisted evidence without claiming an authoritative root cause."""
     note = (entry.get("note") or "").strip()
     if note.lower().startswith("fetch error:"):
         return "recorded_processing_error"
     if _has_alternative_purl(entry):
         return "alternative_only"
-    if not _source_hosts(entry):
+    if not source_hosts:
         return "no_parseable_source_host"
     return "no_primary_from_url_evidence"
 
@@ -97,6 +111,7 @@ def build_report(payload: dict[str, Any]) -> dict[str, Any]:
 
     counts = {"primary_present": 0, "explicitly_unmapped": 0, "unresolved": 0}
     unresolved_by_diagnostic = {diagnostic: 0 for diagnostic in UNRESOLVED_DIAGNOSTICS}
+    unresolved_source_hosts: Counter[str] = Counter()
     missing: list[dict[str, Any]] = []
     for name, entry in sorted(packages.items()):
         label = f"packages.{name}"
@@ -137,15 +152,18 @@ def build_report(payload: dict[str, Any]) -> dict[str, Any]:
         )
         counts[state] += 1
         if not has_primary:
+            source_hosts = _source_hosts(entry)
             diagnostic_reason = None
             if state == "unresolved":
-                diagnostic_reason = _diagnose_unresolved(entry)
+                diagnostic_reason = _diagnose_unresolved(entry, source_hosts)
                 unresolved_by_diagnostic[diagnostic_reason] += 1
+                unresolved_source_hosts.update(source_hosts)
             missing.append(
                 {
                     "name": name,
                     "state": state,
                     "diagnostic_reason": diagnostic_reason,
+                    "source_hosts": list(source_hosts),
                     **{field: entry.get(field) for field in EVIDENCE_FIELDS},
                     "download_count": downloads,
                 }
@@ -166,8 +184,165 @@ def build_report(payload: dict[str, Any]) -> dict[str, Any]:
             "primary_missing": counts["explicitly_unmapped"] + counts["unresolved"],
         },
         "unresolved_by_diagnostic": unresolved_by_diagnostic,
+        "unresolved_by_source_host": [
+            {"host": host, "package_count": package_count}
+            for host, package_count in sorted(
+                unresolved_source_hosts.items(), key=lambda item: (-item[1], item[0])
+            )
+        ],
         "missing_packages": missing,
     }
+
+
+def _non_negative_int(value: Any, label: str) -> int:
+    if type(value) is not int or value < 0:
+        raise ValueError(f"{label} must be a non-negative integer")
+    return value
+
+
+def _comparison_metrics(
+    report: Any, label: str
+) -> tuple[dict[str, int], dict[str, int]]:
+    """Validate and return stable aggregate metrics used for comparisons."""
+    if (
+        not isinstance(report, dict)
+        or report.get("schema_version") != REPORT_SCHEMA_VERSION
+    ):
+        raise ValueError(f"{label} must use report schema {REPORT_SCHEMA_VERSION}")
+    if type(report.get("input_schema_version")) is not int:
+        raise ValueError(f"{label}.input_schema_version must be an integer")
+    raw_counts = report.get("counts")
+    expected_counts = {key for key, _ in COVERAGE_LABELS}
+    if not isinstance(raw_counts, dict) or set(raw_counts) != expected_counts:
+        raise ValueError(f"{label}.counts has an unsupported shape")
+    counts = {
+        key: _non_negative_int(raw_counts[key], f"{label}.counts.{key}")
+        for key, _ in COVERAGE_LABELS
+    }
+    if (
+        counts["primary_present"] + counts["explicitly_unmapped"] + counts["unresolved"]
+        != counts["total"]
+        or counts["explicitly_unmapped"] + counts["unresolved"]
+        != counts["primary_missing"]
+    ):
+        raise ValueError(f"{label}.counts do not reconcile")
+
+    raw_diagnostics = report.get("unresolved_by_diagnostic")
+    if not isinstance(raw_diagnostics, dict) or set(raw_diagnostics) != set(
+        UNRESOLVED_DIAGNOSTICS
+    ):
+        raise ValueError(f"{label}.unresolved_by_diagnostic has an unsupported shape")
+    diagnostics = {
+        diagnostic: _non_negative_int(
+            raw_diagnostics[diagnostic],
+            f"{label}.unresolved_by_diagnostic.{diagnostic}",
+        )
+        for diagnostic in UNRESOLVED_DIAGNOSTICS
+    }
+    if sum(diagnostics.values()) != counts["unresolved"]:
+        raise ValueError(f"{label}.unresolved_by_diagnostic does not reconcile")
+    return counts, diagnostics
+
+
+def _delta(value: int) -> str:
+    return f"+{value:,}" if value > 0 else f"{value:,}"
+
+
+def render_markdown(
+    report: dict[str, Any],
+    *,
+    baseline: dict[str, Any] | None = None,
+    top_hosts: int = 15,
+) -> str:
+    """Render bounded, deterministic coverage Markdown for humans and PR bodies."""
+    if top_hosts < 0:
+        raise ValueError("top_hosts must be non-negative")
+    counts, diagnostics = _comparison_metrics(report, "report")
+    baseline_counts: dict[str, int] | None = None
+    baseline_diagnostics: dict[str, int] | None = None
+    if baseline is not None:
+        baseline_counts, baseline_diagnostics = _comparison_metrics(
+            baseline, "baseline report"
+        )
+        if baseline.get("input_schema_version") != report.get("input_schema_version"):
+            raise ValueError("baseline and current input schema versions differ")
+
+    out = ["## Primary-PURL coverage", ""]
+    if baseline_counts is None:
+        out.extend(["| Metric | Count |", "|---|---:|"])
+        out.extend(
+            f"| {metric_label} | {counts[key]:,} |"
+            for key, metric_label in COVERAGE_LABELS
+        )
+    else:
+        out.extend(["| Metric | Before | After | Delta |", "|---|---:|---:|---:|"])
+        out.extend(
+            f"| {metric_label} | {baseline_counts[key]:,} | {counts[key]:,} | "
+            f"{_delta(counts[key] - baseline_counts[key])} |"
+            for key, metric_label in COVERAGE_LABELS
+        )
+    coverage = (
+        100 * counts["primary_present"] / counts["total"] if counts["total"] else 0
+    )
+    out.extend(["", f"Primary-PURL coverage: **{coverage:.2f}%**.", ""])
+
+    out.extend(["### Unresolved diagnostics", ""])
+    if baseline_diagnostics is None:
+        out.extend(["| Diagnostic | Count |", "|---|---:|"])
+        out.extend(
+            f"| {DIAGNOSTIC_LABELS[diagnostic]} | {diagnostics[diagnostic]:,} |"
+            for diagnostic in UNRESOLVED_DIAGNOSTICS
+        )
+    else:
+        out.extend(["| Diagnostic | Before | After | Delta |", "|---|---:|---:|---:|"])
+        out.extend(
+            f"| {DIAGNOSTIC_LABELS[diagnostic]} | "
+            f"{baseline_diagnostics[diagnostic]:,} | {diagnostics[diagnostic]:,} | "
+            f"{_delta(diagnostics[diagnostic] - baseline_diagnostics[diagnostic])} |"
+            for diagnostic in UNRESOLVED_DIAGNOSTICS
+        )
+
+    raw_hosts = report.get("unresolved_by_source_host")
+    if not isinstance(raw_hosts, list):
+        raise ValueError("report.unresolved_by_source_host must be an array")
+    hosts: list[tuple[str, int]] = []
+    for index, raw_host in enumerate(raw_hosts):
+        if not isinstance(raw_host, dict) or set(raw_host) != {"host", "package_count"}:
+            raise ValueError(
+                f"report.unresolved_by_source_host[{index}] has an unsupported shape"
+            )
+        host = raw_host["host"]
+        if not isinstance(host, str) or not host:
+            raise ValueError(
+                f"report.unresolved_by_source_host[{index}].host must be non-empty"
+            )
+        hosts.append(
+            (
+                host,
+                _non_negative_int(
+                    raw_host["package_count"],
+                    f"report.unresolved_by_source_host[{index}].package_count",
+                ),
+            )
+        )
+    if hosts != sorted(hosts, key=lambda item: (-item[1], item[0])):
+        raise ValueError("report.unresolved_by_source_host is not sorted")
+
+    out.extend(
+        [
+            "",
+            f"### Top unresolved source hosts ({min(top_hosts, len(hosts)):,})",
+            "",
+            "Host counts are non-exclusive; each host is counted once per unresolved package.",
+            "",
+            "| Source host | Packages |",
+            "|---|---:|",
+        ]
+    )
+    out.extend(
+        f"| `{host}` | {package_count:,} |" for host, package_count in hosts[:top_hosts]
+    )
+    return "\n".join(out) + "\n"
 
 
 def main() -> None:
@@ -183,11 +358,39 @@ def main() -> None:
         type=Path,
         help="Write the report to this path instead of standard output",
     )
+    parser.add_argument(
+        "--format",
+        choices=("json", "markdown"),
+        default="json",
+        help="Output format (default: json)",
+    )
+    parser.add_argument(
+        "--baseline-report",
+        type=Path,
+        help="Earlier JSON report to compare in Markdown output",
+    )
+    parser.add_argument(
+        "--top-hosts",
+        type=int,
+        default=15,
+        help="Maximum source hosts in Markdown output (default: 15)",
+    )
     args = parser.parse_args()
+    if args.baseline_report and args.format != "markdown":
+        parser.error("--baseline-report requires --format markdown")
     try:
         # The shared loader rejects duplicate keys and non-finite JSON numbers.
         report = build_report(merge_mappings._load_json(args.input))
-        rendered = json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n"
+        baseline = (
+            merge_mappings._load_json(args.baseline_report)
+            if args.baseline_report
+            else None
+        )
+        rendered = (
+            json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n"
+            if args.format == "json"
+            else render_markdown(report, baseline=baseline, top_hosts=args.top_hosts)
+        )
         if args.output:
             args.output.parent.mkdir(parents=True, exist_ok=True)
             args.output.write_text(rendered)

--- a/scripts/mappings_report.py
+++ b/scripts/mappings_report.py
@@ -178,13 +178,23 @@ def main() -> None:
         required=True,
         help="Freshly merged full mappings.json bundle",
     )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Write the report to this path instead of standard output",
+    )
     args = parser.parse_args()
     try:
         # The shared loader rejects duplicate keys and non-finite JSON numbers.
         report = build_report(merge_mappings._load_json(args.input))
+        rendered = json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n"
+        if args.output:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(rendered)
+        else:
+            print(rendered, end="")
     except (OSError, ValueError) as exc:
         parser.exit(1, f"mappings report: {exc}\n")
-    print(json.dumps(report, indent=2, sort_keys=True, allow_nan=False))
 
 
 if __name__ == "__main__":

--- a/scripts/mappings_report.py
+++ b/scripts/mappings_report.py
@@ -1,0 +1,133 @@
+"""Report primary-PURL coverage from a freshly merged full mapping bundle.
+
+This is a read-only report, not a mapper or a source-layer merger. Rebuild older
+published bundles with scripts.merge_mappings first: the current identities
+contract is required. Alternative PURLs and CPEs do not count as primary PURLs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from scripts import merge_mappings, validate
+
+REPORT_SCHEMA_VERSION = 1
+EVIDENCE_FIELDS = ("version", "source_url", "repo", "homepage", "note")
+
+
+def build_report(payload: dict[str, Any]) -> dict[str, Any]:
+    """Summarize effective identities without inferring why a PURL is absent.
+
+    Explicit unmapped decisions are distinct from unresolved packages. Neither
+    missing URLs nor automatic diagnostic notes establish an intentional
+    no-PURL decision. Notes can survive reviewed overrides and are evidence,
+    not authoritative mapping state.
+    """
+    if not isinstance(payload, dict):
+        raise ValueError("bundle must be an object")
+    if (
+        type(payload.get("schema_version")) is not int
+        or payload["schema_version"] != validate.CURRENT_BUNDLE_SCHEMA
+    ):
+        raise ValueError(
+            f"report requires full bundle schema {validate.CURRENT_BUNDLE_SCHEMA}; "
+            "rebuild with scripts.merge_mappings"
+        )
+    packages = payload.get("packages")
+    if not isinstance(packages, dict):
+        raise ValueError("bundle.packages must be an object")
+    if type(payload.get("package_count")) is not int or payload["package_count"] != len(
+        packages
+    ):
+        raise ValueError("bundle.package_count must equal the number of packages")
+    channel = payload.get("channel")
+    if not isinstance(channel, str) or not channel:
+        raise ValueError("bundle.channel must be a non-empty string")
+    if any(not isinstance(name, str) or not name for name in packages):
+        raise ValueError("package names must be non-empty strings")
+
+    counts = {"primary_present": 0, "explicitly_unmapped": 0, "unresolved": 0}
+    missing: list[dict[str, Any]] = []
+    for name, entry in sorted(packages.items()):
+        label = f"packages.{name}"
+        if not isinstance(entry, dict):
+            raise ValueError(f"{label} must be an object")
+        if "unmapped" in entry and not isinstance(entry["unmapped"], bool):
+            raise ValueError(f"{label}.unmapped must be a boolean")
+        if entry.get("status") == "unmapped" and entry.get("unmapped") is not True:
+            raise ValueError(f"{label}.status unmapped requires unmapped: true")
+        if entry.get("purl") is not None and not isinstance(entry["purl"], str):
+            raise ValueError(f"{label}.purl must be a string or null")
+        for field in EVIDENCE_FIELDS:
+            if entry.get(field) is not None and not isinstance(entry[field], str):
+                raise ValueError(f"{label}.{field} must be a string or null")
+        downloads = entry.get("download_count")
+        if downloads is not None and (type(downloads) is not int or downloads < 0):
+            raise ValueError(
+                f"{label}.download_count must be a non-negative integer or null"
+            )
+
+        # Reuse the published contract, including legacy/identity consistency
+        # and reviewed-unmapped invariants, rather than accepting corrupt data
+        # as apparently successful empty coverage.
+        errors: list[str] = []
+        validate._validate_identity_contract(entry, label, errors)
+        if errors:
+            raise ValueError("\n".join(errors))
+        has_primary = any(
+            identity["kind"] == "purl" and identity["role"] == "primary"
+            for identity in entry["identities"]
+        )
+        state = (
+            "primary_present"
+            if has_primary
+            else "explicitly_unmapped"
+            if entry.get("unmapped") is True
+            else "unresolved"
+        )
+        counts[state] += 1
+        if not has_primary:
+            missing.append(
+                {
+                    "name": name,
+                    "state": state,
+                    **{field: entry.get(field) for field in EVIDENCE_FIELDS},
+                    "download_count": downloads,
+                }
+            )
+
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "input_schema_version": payload["schema_version"],
+        "channel": channel,
+        "counts": {
+            "total": len(packages),
+            **counts,
+            "primary_missing": counts["explicitly_unmapped"] + counts["unresolved"],
+        },
+        "missing_packages": missing,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        type=Path,
+        required=True,
+        help="Freshly merged full mappings.json bundle",
+    )
+    args = parser.parse_args()
+    try:
+        # The shared loader rejects duplicate keys and non-finite JSON numbers.
+        report = build_report(merge_mappings._load_json(args.input))
+    except (OSError, ValueError) as exc:
+        parser.exit(1, f"mappings report: {exc}\n")
+    print(json.dumps(report, indent=2, sort_keys=True, allow_nan=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mappings_report.py
+++ b/tests/test_mappings_report.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import contextlib
+import copy
+import io
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import mappings_report, merge_mappings
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class MappingsReportTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.root = Path(self.tempdir.name)
+        self.bundle = self.root / "out" / "mappings.json"
+        auto_entry = {
+            "purl": None,
+            "confidence": 0.0,
+            "sources": [],
+            "note": "No automatic match — heuristics did not recognise any source URL.",
+        }
+        self._write(
+            "auto.json",
+            {
+                "schema_version": 1,
+                "channel": "conda-forge",
+                "packages": {
+                    "mapped": {**auto_entry, "purl": "pkg:pypi/mapped"},
+                    "reviewed": auto_entry,
+                    "rejected": {**auto_entry, "purl": "pkg:pypi/rejected"},
+                    "alternative-only": {
+                        **auto_entry,
+                        "alternative_purls": ["pkg:pypi/alternative"],
+                    },
+                    "cpe-only": {**auto_entry, "cpes": ["cpe:2.3:a:vendor:product"]},
+                    "no-evidence": auto_entry,
+                    "error": {
+                        **auto_entry,
+                        "note": "fetch error: RecipeFacts missing summary",
+                        "source_url": "https://example.org/archive.tar.gz",
+                        "repo": "https://example.org/repo",
+                        "homepage": "https://example.org",
+                        "version": "1.0",
+                        "download_count": 42,
+                    },
+                },
+            },
+        )
+        self._write(
+            "manual.json",
+            {
+                "schema_version": 1,
+                "updated_by": "reviewer",
+                "updated_at": "2026-01-01T00:00:00Z",
+                "packages": {"reviewed": {"purl": "pkg:pypi/reviewed"}},
+            },
+        )
+        self._write(
+            "contributions/review.json",
+            {
+                "schema_version": 1,
+                "author": "contributor",
+                "timestamp": "2026-01-02T00:00:00Z",
+                "packages": {
+                    "rejected": {"unmapped": True},
+                    "contributed": {"purl": "pkg:pypi/contributed"},
+                },
+            },
+        )
+        self._write("downloads.json", {"packages": []})
+        with contextlib.redirect_stdout(io.StringIO()):
+            merge_mappings.main(
+                self.root / "auto.json",
+                self.root / "manual.json",
+                self.root / "contributions",
+                self.root / "downloads.json",
+                self.bundle,
+                self.root / "out" / "mappings-index.json",
+                self.root / "out" / "mapping_packages",
+                generated_at="2026-01-03T00:00:00Z",
+            )
+        self.payload = json.loads(self.bundle.read_text())
+
+    def _write(self, path: str, payload: object) -> None:
+        target = self.root / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(payload))
+
+    def _cli(self, path: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, "-m", "scripts.mappings_report", "--input", str(path)],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_counts_effective_merged_primary_identities(self) -> None:
+        report = mappings_report.build_report(self.payload)
+        self.assertEqual(
+            report["counts"],
+            {
+                "total": 8,
+                "primary_present": 3,
+                "explicitly_unmapped": 1,
+                "unresolved": 4,
+                "primary_missing": 5,
+            },
+        )
+        states = {row["name"]: row["state"] for row in report["missing_packages"]}
+        self.assertEqual(
+            states,
+            {
+                "alternative-only": "unresolved",
+                "cpe-only": "unresolved",
+                "error": "unresolved",
+                "no-evidence": "unresolved",
+                "rejected": "explicitly_unmapped",
+            },
+        )
+        self.assertEqual(report["counts"]["primary_missing"], len(states))
+
+    def test_preserves_evidence_without_treating_notes_as_mapping_state(self) -> None:
+        report = mappings_report.build_report(self.payload)
+        rows = {row["name"]: row for row in report["missing_packages"]}
+        for field in (*mappings_report.EVIDENCE_FIELDS, "download_count"):
+            self.assertEqual(
+                rows["error"][field], self.payload["packages"]["error"][field]
+            )
+        self.assertIsNone(rows["no-evidence"]["source_url"])
+        # A stale auto failure note survives both positive and negative review.
+        self.assertNotIn("reviewed", rows)
+        self.assertEqual(rows["rejected"]["state"], "explicitly_unmapped")
+
+    def test_deterministic_and_read_only(self) -> None:
+        original = copy.deepcopy(self.payload)
+        first = mappings_report.build_report(self.payload)
+        self.assertEqual(self.payload, original)
+        reordered = copy.deepcopy(self.payload)
+        reordered["packages"] = dict(reversed(list(reordered["packages"].items())))
+        reordered["generated_at"] = "2026-02-01T00:00:00Z"
+        self.assertEqual(first, mappings_report.build_report(reordered))
+        before_bytes = self.bundle.read_bytes()
+        a, b = self._cli(self.bundle), self._cli(self.bundle)
+        self.assertEqual(a.returncode, 0, a.stderr)
+        self.assertEqual(a.stdout, b.stdout)
+        self.assertEqual(json.loads(a.stdout), first)
+        self.assertEqual(self.bundle.read_bytes(), before_bytes)
+
+    def test_empty_bundle(self) -> None:
+        self.payload.update(packages={}, package_count=0)
+        report = mappings_report.build_report(self.payload)
+        self.assertTrue(all(count == 0 for count in report["counts"].values()))
+        self.assertEqual(report["missing_packages"], [])
+
+    def test_rejects_invalid_envelope(self) -> None:
+        for patch in (
+            {"schema_version": 1},
+            {"schema_version": 4},  # Compact index is not a full bundle.
+            {"schema_version": True},
+            {"packages": []},
+            {"package_count": 0},
+            {"package_count": True},
+            {"channel": None},
+        ):
+            with self.subTest(patch=patch), self.assertRaises(ValueError):
+                mappings_report.build_report({**self.payload, **patch})
+
+    def test_rejects_invalid_package_contract(self) -> None:
+        for patch in (
+            {"identities": None},
+            {"identities": []},  # Must not silently ignore a missing canonical primary.
+            {"purl": 123},
+            {"unmapped": "true"},
+            {"unmapped": True},  # Contradicts the published primary.
+            {"status": "unmapped"},
+            {"source_url": []},
+            {"download_count": True},
+            {"download_count": -1},
+        ):
+            payload = copy.deepcopy(self.payload)
+            payload["packages"]["mapped"].update(patch)
+            with self.subTest(patch=patch), self.assertRaises(ValueError):
+                mappings_report.build_report(payload)
+
+    def test_cli_rejects_missing_or_invalid_json_without_success_output(self) -> None:
+        paths = [self.root / "missing.json"]
+        for index, text in enumerate(
+            ("{", '{"packages":{},"packages":{}}', '{"x":NaN}')
+        ):
+            path = self.root / f"invalid-{index}.json"
+            path.write_text(text)
+            paths.append(path)
+        for path in paths:
+            with self.subTest(path=path):
+                result = self._cli(path)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(result.stdout, "")
+                self.assertIn("mappings report:", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mappings_report.py
+++ b/tests/test_mappings_report.py
@@ -127,6 +127,94 @@ class MappingsReportTest(unittest.TestCase):
         )
         self.assertEqual(report["counts"]["primary_missing"], len(states))
 
+    def test_assigns_exclusive_unresolved_diagnostics(self) -> None:
+        report = mappings_report.build_report(self.payload)
+        self.assertEqual(
+            report["unresolved_by_diagnostic"],
+            {
+                "recorded_processing_error": 1,
+                "alternative_only": 1,
+                "no_parseable_source_host": 2,
+                "no_primary_from_url_evidence": 0,
+            },
+        )
+        rows = {row["name"]: row for row in report["missing_packages"]}
+        self.assertEqual(
+            rows["error"]["diagnostic_reason"], "recorded_processing_error"
+        )
+        self.assertEqual(
+            rows["alternative-only"]["diagnostic_reason"], "alternative_only"
+        )
+        self.assertEqual(
+            rows["cpe-only"]["diagnostic_reason"], "no_parseable_source_host"
+        )
+        self.assertEqual(
+            rows["no-evidence"]["diagnostic_reason"], "no_parseable_source_host"
+        )
+        self.assertIsNone(rows["rejected"]["diagnostic_reason"])
+        self.assertEqual(
+            sum(report["unresolved_by_diagnostic"].values()),
+            report["counts"]["unresolved"],
+        )
+
+    def test_diagnostic_precedence_is_conservative(self) -> None:
+        payload = copy.deepcopy(self.payload)
+        payload["packages"]["alternative-only"]["note"] = "  FETCH ERROR: stale"
+        payload["packages"]["rejected"]["note"] = "fetch error: stale"
+        report = mappings_report.build_report(payload)
+        rows = {row["name"]: row for row in report["missing_packages"]}
+        self.assertEqual(
+            rows["alternative-only"]["diagnostic_reason"],
+            "recorded_processing_error",
+        )
+        self.assertIsNone(rows["rejected"]["diagnostic_reason"])
+        self.assertEqual(
+            report["unresolved_by_diagnostic"],
+            {
+                "recorded_processing_error": 2,
+                "alternative_only": 0,
+                "no_parseable_source_host": 2,
+                "no_primary_from_url_evidence": 0,
+            },
+        )
+
+    def test_url_evidence_classification_normalizes_and_deduplicates_hosts(
+        self,
+    ) -> None:
+        payload = copy.deepcopy(self.payload)
+        entry = payload["packages"]["cpe-only"]
+        entry.update(
+            {
+                "source_url": "https://GitLab.COM./group/project/archive.tar.gz",
+                "repo": "HTTPS://gitlab.com/group/project",
+                "homepage": "https://gitlab.com:443/group/project",
+            }
+        )
+        report = mappings_report.build_report(payload)
+        rows = {row["name"]: row for row in report["missing_packages"]}
+        self.assertEqual(
+            rows["cpe-only"]["diagnostic_reason"],
+            "no_primary_from_url_evidence",
+        )
+        self.assertEqual(mappings_report._source_hosts(entry), ("gitlab.com",))
+        self.assertEqual(
+            report["unresolved_by_diagnostic"],
+            {
+                "recorded_processing_error": 1,
+                "alternative_only": 1,
+                "no_parseable_source_host": 1,
+                "no_primary_from_url_evidence": 1,
+            },
+        )
+
+    def test_relative_empty_and_malformed_urls_have_no_parseable_host(self) -> None:
+        entry = {
+            "source_url": "",
+            "repo": "group/project",
+            "homepage": "https://[invalid",
+        }
+        self.assertEqual(mappings_report._source_hosts(entry), ())
+
     def test_preserves_evidence_without_treating_notes_as_mapping_state(self) -> None:
         report = mappings_report.build_report(self.payload)
         rows = {row["name"]: row for row in report["missing_packages"]}
@@ -158,6 +246,9 @@ class MappingsReportTest(unittest.TestCase):
         self.payload.update(packages={}, package_count=0)
         report = mappings_report.build_report(self.payload)
         self.assertTrue(all(count == 0 for count in report["counts"].values()))
+        self.assertTrue(
+            all(count == 0 for count in report["unresolved_by_diagnostic"].values())
+        )
         self.assertEqual(report["missing_packages"], [])
 
     def test_rejects_invalid_envelope(self) -> None:

--- a/tests/test_mappings_report.py
+++ b/tests/test_mappings_report.py
@@ -281,6 +281,29 @@ class MappingsReportTest(unittest.TestCase):
             with self.subTest(patch=patch), self.assertRaises(ValueError):
                 mappings_report.build_report(payload)
 
+    def test_cli_writes_an_explicit_output_file(self) -> None:
+        output = self.root / "reports" / "coverage.json"
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "scripts.mappings_report",
+                "--input",
+                str(self.bundle),
+                "--output",
+                str(output),
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(
+            json.loads(output.read_text()), mappings_report.build_report(self.payload)
+        )
+        self.assertTrue(output.read_text().endswith("\n"))
+
     def test_cli_rejects_missing_or_invalid_json_without_success_output(self) -> None:
         paths = [self.root / "missing.json"]
         for index, text in enumerate(

--- a/tests/test_mappings_report.py
+++ b/tests/test_mappings_report.py
@@ -156,6 +156,12 @@ class MappingsReportTest(unittest.TestCase):
             sum(report["unresolved_by_diagnostic"].values()),
             report["counts"]["unresolved"],
         )
+        self.assertEqual(
+            report["unresolved_by_source_host"],
+            [{"host": "example.org", "package_count": 1}],
+        )
+        self.assertEqual(rows["error"]["source_hosts"], ["example.org"])
+        self.assertEqual(rows["no-evidence"]["source_hosts"], [])
 
     def test_diagnostic_precedence_is_conservative(self) -> None:
         payload = copy.deepcopy(self.payload)
@@ -190,6 +196,9 @@ class MappingsReportTest(unittest.TestCase):
                 "homepage": "https://gitlab.com:443/group/project",
             }
         )
+        # Explicit no-PURL decisions retain evidence but are excluded from the
+        # unresolved host aggregate.
+        payload["packages"]["rejected"]["homepage"] = "https://gitlab.com/rejected"
         report = mappings_report.build_report(payload)
         rows = {row["name"]: row for row in report["missing_packages"]}
         self.assertEqual(
@@ -205,6 +214,31 @@ class MappingsReportTest(unittest.TestCase):
                 "no_parseable_source_host": 1,
                 "no_primary_from_url_evidence": 1,
             },
+        )
+        self.assertEqual(rows["cpe-only"]["source_hosts"], ["gitlab.com"])
+        self.assertEqual(rows["rejected"]["source_hosts"], ["gitlab.com"])
+        self.assertEqual(
+            report["unresolved_by_source_host"],
+            [
+                {"host": "example.org", "package_count": 1},
+                {"host": "gitlab.com", "package_count": 1},
+            ],
+        )
+
+    def test_source_host_aggregate_sorts_by_count_then_hostname(self) -> None:
+        payload = copy.deepcopy(self.payload)
+        payload["packages"]["alternative-only"].update(
+            source_url="https://z.example/source", repo="https://a.example/repo"
+        )
+        payload["packages"]["cpe-only"]["homepage"] = "https://z.example/home"
+        report = mappings_report.build_report(payload)
+        self.assertEqual(
+            report["unresolved_by_source_host"],
+            [
+                {"host": "z.example", "package_count": 2},
+                {"host": "a.example", "package_count": 1},
+                {"host": "example.org", "package_count": 1},
+            ],
         )
 
     def test_relative_empty_and_malformed_urls_have_no_parseable_host(self) -> None:
@@ -242,6 +276,88 @@ class MappingsReportTest(unittest.TestCase):
         self.assertEqual(json.loads(a.stdout), first)
         self.assertEqual(self.bundle.read_bytes(), before_bytes)
 
+    def test_markdown_renders_current_counts_and_bounded_hosts(self) -> None:
+        report = mappings_report.build_report(self.payload)
+        rendered = mappings_report.render_markdown(report, top_hosts=1)
+        self.assertIn("## Primary-PURL coverage", rendered)
+        self.assertIn("| Primary PURL present | 3 |", rendered)
+        self.assertIn("Primary-PURL coverage: **37.50%**.", rendered)
+        self.assertIn("| Recorded processing error | 1 |", rendered)
+        self.assertIn("### Top unresolved source hosts (1)", rendered)
+        self.assertIn("| `example.org` | 1 |", rendered)
+        self.assertEqual(rendered, mappings_report.render_markdown(report, top_hosts=1))
+
+    def test_markdown_compares_coverage_and_diagnostic_deltas(self) -> None:
+        baseline = mappings_report.build_report(self.payload)
+        current = copy.deepcopy(baseline)
+        current["counts"].update(
+            primary_present=4,
+            unresolved=3,
+            primary_missing=4,
+        )
+        current["unresolved_by_diagnostic"]["no_parseable_source_host"] = 1
+        rendered = mappings_report.render_markdown(current, baseline=baseline)
+        self.assertIn("| Primary PURL present | 3 | 4 | +1 |", rendered)
+        self.assertIn("| Explicitly unmapped | 1 | 1 | 0 |", rendered)
+        self.assertIn("| Unresolved | 4 | 3 | -1 |", rendered)
+        self.assertIn("| No parseable source host | 2 | 1 | -1 |", rendered)
+
+    def test_markdown_rejects_invalid_or_incompatible_baselines(self) -> None:
+        report = mappings_report.build_report(self.payload)
+        for patch in (
+            {"schema_version": 2},
+            {"input_schema_version": report["input_schema_version"] + 1},
+            {"counts": {**report["counts"], "unresolved": 3}},
+            {
+                "unresolved_by_diagnostic": {
+                    **report["unresolved_by_diagnostic"],
+                    "no_parseable_source_host": 1,
+                }
+            },
+        ):
+            baseline = {**report, **patch}
+            with self.subTest(patch=patch), self.assertRaises(ValueError):
+                mappings_report.render_markdown(report, baseline=baseline)
+
+    def test_cli_renders_markdown_comparison(self) -> None:
+        baseline = self.root / "baseline.json"
+        baseline.write_text(json.dumps(mappings_report.build_report(self.payload)))
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "scripts.mappings_report",
+                "--input",
+                str(self.bundle),
+                "--format",
+                "markdown",
+                "--baseline-report",
+                str(baseline),
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("| Total packages | 8 | 8 | 0 |", result.stdout)
+
+        invalid = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "scripts.mappings_report",
+                "--input",
+                str(self.bundle),
+                "--baseline-report",
+                str(baseline),
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(invalid.returncode, 0)
+        self.assertIn("requires --format markdown", invalid.stderr)
+
     def test_empty_bundle(self) -> None:
         self.payload.update(packages={}, package_count=0)
         report = mappings_report.build_report(self.payload)
@@ -249,6 +365,7 @@ class MappingsReportTest(unittest.TestCase):
         self.assertTrue(
             all(count == 0 for count in report["unresolved_by_diagnostic"].values())
         )
+        self.assertEqual(report["unresolved_by_source_host"], [])
         self.assertEqual(report["missing_packages"], [])
 
     def test_rejects_invalid_envelope(self) -> None:

--- a/web/coverage.html
+++ b/web/coverage.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Prefix.dev — PURL Coverage</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" href="./assets/favicon.png" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/coverage-main.tsx"></script>
+  </body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
-    "test": "node --test --test-concurrency=1 src/data/loader.test.mjs src/data/identityCoverage.test.mjs src/components/identityProvenance.test.mjs",
+    "test": "node --test --test-concurrency=1 src/data/loader.test.mjs src/data/identityCoverage.test.mjs src/data/mappingsReport.test.mjs src/components/identityProvenance.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -219,16 +219,29 @@ export function App() {
               paddingLeft: 14,
             }}
           >
-            <span
+            <a
+              href="./index.html"
               style={{
                 color: t.fg1,
                 padding: "4px 8px",
                 borderRadius: 6,
                 background: t.inset,
+                textDecoration: "none",
               }}
             >
               Package Identity Mapper
-            </span>
+            </a>
+            <a
+              href="./coverage.html"
+              style={{
+                color: t.fg2,
+                padding: "4px 8px",
+                borderRadius: 6,
+                textDecoration: "none",
+              }}
+            >
+              PURL Coverage
+            </a>
           </nav>
           <div
             style={{

--- a/web/src/CoverageApp.tsx
+++ b/web/src/CoverageApp.tsx
@@ -4,7 +4,6 @@ import { LoadingToast } from "./components/LoadingToast";
 import { Glyph, useTheme } from "./components/Primitives";
 import {
   loadMappingsReport,
-  sourceHosts,
   UNRESOLVED_DIAGNOSTICS,
   type MissingPrimaryPackage,
   type MissingPrimaryState,
@@ -87,7 +86,7 @@ export function CoverageApp() {
     () =>
       (report?.missing_packages ?? []).map((pkg) => ({
         ...pkg,
-        hosts: sourceHosts(pkg),
+        hosts: pkg.source_hosts,
       })),
     [report],
   );

--- a/web/src/CoverageApp.tsx
+++ b/web/src/CoverageApp.tsx
@@ -1,0 +1,411 @@
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import { repoFullName } from "./config";
+import { LoadingToast } from "./components/LoadingToast";
+import { Glyph, useTheme } from "./components/Primitives";
+import {
+  loadMappingsReport,
+  sourceHosts,
+  UNRESOLVED_DIAGNOSTICS,
+  type MissingPrimaryPackage,
+  type MissingPrimaryState,
+  type MappingsReport,
+  type UnresolvedDiagnostic,
+} from "./data/mappingsReport";
+
+type StateFilter = "all" | MissingPrimaryState;
+type DiagnosticFilter = "all" | UnresolvedDiagnostic;
+type CoverageRow = MissingPrimaryPackage & { hosts: string[] };
+
+const DIAGNOSTIC_META: Record<
+  UnresolvedDiagnostic,
+  { label: string; short: string; description: string }
+> = {
+  recorded_processing_error: {
+    label: "Recorded processing error",
+    short: "Processing error",
+    description: "The persisted automap note starts with “fetch error:”.",
+  },
+  alternative_only: {
+    label: "Alternative PURL only",
+    short: "Alternative only",
+    description: "A canonical alternative PURL exists, but no primary PURL does.",
+  },
+  no_parseable_source_host: {
+    label: "No parseable source host",
+    short: "No source host",
+    description: "No hostname can be parsed from the persisted source URLs.",
+  },
+  no_primary_from_url_evidence: {
+    label: "URL evidence without primary PURL",
+    short: "URL evidence",
+    description: "A source hostname exists, but automap did not produce a primary PURL.",
+  },
+};
+
+function number(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function safeExternalUrl(value: string): string | null {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:" ? url.href : null;
+  } catch {
+    return null;
+  }
+}
+
+function urlLabel(value: string): string {
+  try {
+    const url = new URL(value);
+    return `${url.hostname}${url.pathname === "/" ? "" : url.pathname}`;
+  } catch {
+    return value;
+  }
+}
+
+export function CoverageApp() {
+  const theme = useTheme();
+  const { t } = theme;
+  const [report, setReport] = useState<MappingsReport | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const [state, setState] = useState<StateFilter>("unresolved");
+  const [diagnostic, setDiagnostic] = useState<DiagnosticFilter>("all");
+  const [host, setHost] = useState("all");
+  const [selectedName, setSelectedName] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadMappingsReport().then(setReport).catch((error) => setLoadError(errorMessage(error)));
+  }, []);
+
+  const rows = useMemo<CoverageRow[]>(
+    () =>
+      (report?.missing_packages ?? []).map((pkg) => ({
+        ...pkg,
+        hosts: sourceHosts(pkg),
+      })),
+    [report],
+  );
+
+  const hostOptions = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const row of rows) {
+      for (const sourceHost of row.hosts) {
+        counts.set(sourceHost, (counts.get(sourceHost) ?? 0) + 1);
+      }
+    }
+    return [...counts.entries()].sort(
+      ([hostA, countA], [hostB, countB]) => countB - countA || hostA.localeCompare(hostB),
+    );
+  }, [rows]);
+
+  const filtered = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    return rows
+      .filter((row) => state === "all" || row.state === state)
+      .filter(
+        (row) =>
+          diagnostic === "all" ||
+          (row.state === "unresolved" && row.diagnostic_reason === diagnostic),
+      )
+      .filter((row) => host === "all" || row.hosts.includes(host))
+      .filter((row) => {
+        if (!normalizedQuery) return true;
+        return [
+          row.name,
+          row.version,
+          row.note,
+          row.source_url,
+          row.repo,
+          row.homepage,
+          ...row.hosts,
+        ].some((value) => value?.toLowerCase().includes(normalizedQuery));
+      })
+      .sort(
+        (a, b) =>
+          (b.download_count ?? -1) - (a.download_count ?? -1) ||
+          a.name.localeCompare(b.name),
+      );
+  }, [diagnostic, host, query, rows, state]);
+
+  useEffect(() => {
+    if (filtered.length === 0) {
+      setSelectedName(null);
+    } else if (!selectedName || !filtered.some((row) => row.name === selectedName)) {
+      setSelectedName(filtered[0].name);
+    }
+  }, [filtered, selectedName]);
+
+  const selected = selectedName
+    ? filtered.find((row) => row.name === selectedName) ?? null
+    : null;
+
+  const controlStyle: CSSProperties = {
+    height: 34,
+    border: `1px solid ${t.borderStrong}`,
+    borderRadius: 7,
+    background: t.surface,
+    color: t.fg1,
+    fontSize: 12,
+    padding: "0 10px",
+    outline: "none",
+  };
+
+  return (
+    <div className={theme.dark ? "dark-scope coverage-page" : "coverage-page"} style={{ background: t.page, color: t.fg1 }}>
+      <header className="coverage-header" style={{ background: t.surface, borderColor: t.border }}>
+        <div className="coverage-header-left">
+          <img
+            src={theme.dark ? "./assets/logo_dark.svg" : "./assets/logo_light.svg"}
+            alt="prefix.dev"
+            style={{ height: 22 }}
+          />
+          <nav className="coverage-nav" style={{ borderColor: t.border }}>
+            <a href="./index.html" style={{ color: t.fg2 }}>Mapper</a>
+            <a href="./coverage.html" className="active" style={{ color: t.fg1, background: t.inset }}>
+              PURL coverage
+            </a>
+          </nav>
+          <span className="coverage-repo" style={{ background: t.inset, color: t.fg2 }}>
+            <Glyph name="branch" size={11} />
+            {repoFullName}
+          </span>
+        </div>
+        <button
+          onClick={() => theme.setDark(!theme.dark)}
+          className="coverage-theme"
+          style={{ background: t.surface2, borderColor: t.border, color: t.fg1 }}
+          title="Toggle theme"
+        >
+          {theme.dark ? "☀" : "☾"}
+        </button>
+      </header>
+
+      <main className="coverage-main">
+        <section className="coverage-intro">
+          <div>
+            <p className="coverage-eyebrow" style={{ color: t.fg3 }}>PRIMARY-PURL OBSERVABILITY</p>
+            <h1>Missing primary PURLs</h1>
+            <p style={{ color: t.fg2 }}>
+              Inspect packages without a primary PURL. Diagnostics describe recorded evidence,
+              not authoritative root causes.
+            </p>
+          </div>
+          {report && (
+            <div className="coverage-contract" style={{ color: t.fg3 }}>
+              report schema {report.schema_version} · mapping schema {report.input_schema_version} · {report.channel}
+            </div>
+          )}
+        </section>
+
+        {loadError ? (
+          <div className="coverage-error" style={{ color: t.bad, background: t.surface, borderColor: t.border }}>
+            Failed to load coverage report: {loadError}
+          </div>
+        ) : !report ? (
+          <div className="coverage-loading" style={{ color: t.fg2 }}>Loading coverage report…</div>
+        ) : (
+          <>
+            <section className="coverage-summary">
+              <SummaryCard label="All packages" value={report.counts.total} theme={theme} />
+              <SummaryCard label="Primary PURL" value={report.counts.primary_present} theme={theme} tone="good" />
+              <SummaryCard label="Explicitly unmapped" value={report.counts.explicitly_unmapped} theme={theme} tone="warn" />
+              <SummaryCard label="Unresolved" value={report.counts.unresolved} theme={theme} tone="bad" />
+            </section>
+
+            <section className="coverage-workspace" style={{ background: t.surface, borderColor: t.border }}>
+              <div className="coverage-toolbar" style={{ borderColor: t.border }}>
+                <label className="coverage-search" style={{ background: t.surface2, borderColor: t.borderStrong }}>
+                  <Glyph name="search" size={14} />
+                  <input
+                    value={query}
+                    onChange={(event) => setQuery(event.target.value)}
+                    placeholder="Search package, host, URL, or note"
+                    style={{ color: t.fg1 }}
+                  />
+                </label>
+                <select
+                  value={state}
+                  onChange={(event) => {
+                    const nextState = event.target.value as StateFilter;
+                    setState(nextState);
+                    if (nextState === "explicitly_unmapped") setDiagnostic("all");
+                  }}
+                  style={controlStyle}
+                >
+                  <option value="all">All missing-primary states</option>
+                  <option value="unresolved">Unresolved</option>
+                  <option value="explicitly_unmapped">Explicitly unmapped</option>
+                </select>
+                <select
+                  value={diagnostic}
+                  onChange={(event) => setDiagnostic(event.target.value as DiagnosticFilter)}
+                  disabled={state === "explicitly_unmapped"}
+                  style={{ ...controlStyle, opacity: state === "explicitly_unmapped" ? 0.5 : 1 }}
+                >
+                  <option value="all">All diagnostics</option>
+                  {UNRESOLVED_DIAGNOSTICS.map((value) => (
+                    <option key={value} value={value}>{DIAGNOSTIC_META[value].label}</option>
+                  ))}
+                </select>
+                <select value={host} onChange={(event) => setHost(event.target.value)} style={controlStyle}>
+                  <option value="all">All source hosts</option>
+                  {hostOptions.map(([value, count]) => (
+                    <option key={value} value={value}>{value} ({number(count)})</option>
+                  ))}
+                </select>
+                <span className="coverage-result-count" style={{ color: t.fg3 }}>
+                  {number(filtered.length)} result{filtered.length === 1 ? "" : "s"}
+                </span>
+              </div>
+
+              <div className="coverage-browser">
+                <div className="coverage-table-wrap">
+                  <table className="coverage-table">
+                    <thead style={{ background: t.surface2, color: t.fg3 }}>
+                      <tr>
+                        <th>Package</th>
+                        <th>Diagnostic</th>
+                        <th>Version</th>
+                        <th>Downloads</th>
+                        <th>Source hosts</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {filtered.map((row) => (
+                        <tr
+                          key={row.name}
+                          onClick={() => setSelectedName(row.name)}
+                          className={row.name === selectedName ? "selected" : ""}
+                          style={{
+                            borderColor: t.border,
+                            background: row.name === selectedName ? t.rowSelected : undefined,
+                          }}
+                        >
+                          <td><strong>{row.name}</strong></td>
+                          <td>
+                            {row.diagnostic_reason ? (
+                              <DiagnosticPill diagnostic={row.diagnostic_reason} theme={theme} />
+                            ) : (
+                              <span style={{ color: t.warn }}>Explicit no-PURL</span>
+                            )}
+                          </td>
+                          <td className="mono" style={{ color: t.fg2 }}>{row.version || "—"}</td>
+                          <td className="mono" style={{ color: t.fg2 }}>
+                            {row.download_count === null ? "—" : number(row.download_count)}
+                          </td>
+                          <td style={{ color: t.fg2 }}>{row.hosts.join(", ") || "—"}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                  {filtered.length === 0 && (
+                    <div className="coverage-empty" style={{ color: t.fg2 }}>No packages match these filters.</div>
+                  )}
+                </div>
+
+                <aside className="coverage-detail" style={{ background: t.surface2, borderColor: t.border }}>
+                  {selected ? <PackageEvidence row={selected} theme={theme} /> : <span style={{ color: t.fg2 }}>Select a package to inspect its evidence.</span>}
+                </aside>
+              </div>
+            </section>
+          </>
+        )}
+      </main>
+      <LoadingToast theme={theme} />
+    </div>
+  );
+}
+
+function SummaryCard({
+  label,
+  value,
+  theme,
+  tone,
+}: {
+  label: string;
+  value: number;
+  theme: ReturnType<typeof useTheme>;
+  tone?: "good" | "warn" | "bad";
+}) {
+  const color = tone ? theme.t[tone] : theme.t.fg1;
+  return (
+    <div className="coverage-summary-card" style={{ background: theme.t.surface, borderColor: theme.t.border }}>
+      <span style={{ color: theme.t.fg3 }}>{label}</span>
+      <strong style={{ color }}>{number(value)}</strong>
+    </div>
+  );
+}
+
+function DiagnosticPill({ diagnostic, theme }: { diagnostic: UnresolvedDiagnostic; theme: ReturnType<typeof useTheme> }) {
+  const urgent = diagnostic === "recorded_processing_error";
+  return (
+    <span
+      className="coverage-diagnostic-pill"
+      title={DIAGNOSTIC_META[diagnostic].description}
+      style={{
+        background: urgent ? (theme.dark ? "#3a1f1f" : "#ffe5dc") : theme.t.inset,
+        color: urgent ? theme.t.bad : theme.t.fg2,
+      }}
+    >
+      {DIAGNOSTIC_META[diagnostic].short}
+    </span>
+  );
+}
+
+function PackageEvidence({ row, theme }: { row: CoverageRow; theme: ReturnType<typeof useTheme> }) {
+  const links = [
+    ["Source", row.source_url],
+    ["Repository", row.repo],
+    ["Homepage", row.homepage],
+  ] as const;
+  return (
+    <div>
+      <p className="coverage-eyebrow" style={{ color: theme.t.fg3 }}>PACKAGE EVIDENCE</p>
+      <h2>{row.name}</h2>
+      <dl className="coverage-facts">
+        <dt style={{ color: theme.t.fg3 }}>State</dt>
+        <dd>{row.state === "unresolved" ? "Unresolved" : "Explicitly unmapped"}</dd>
+        <dt style={{ color: theme.t.fg3 }}>Version</dt>
+        <dd className="mono">{row.version || "—"}</dd>
+        <dt style={{ color: theme.t.fg3 }}>Downloads</dt>
+        <dd className="mono">{row.download_count === null ? "—" : number(row.download_count)}</dd>
+      </dl>
+      {row.diagnostic_reason && (
+        <div className="coverage-diagnostic-box" style={{ background: theme.t.surface, borderColor: theme.t.border }}>
+          <DiagnosticPill diagnostic={row.diagnostic_reason} theme={theme} />
+          <p style={{ color: theme.t.fg2 }}>{DIAGNOSTIC_META[row.diagnostic_reason].description}</p>
+        </div>
+      )}
+      <h3>Recorded URLs</h3>
+      <div className="coverage-links">
+        {links.map(([label, value]) => {
+          const href = value ? safeExternalUrl(value) : null;
+          return (
+            <div key={label}>
+              <span style={{ color: theme.t.fg3 }}>{label}</span>
+              {href && value ? (
+                <a href={href} target="_blank" rel="noreferrer" style={{ color: theme.t.link }} title={value}>
+                  {urlLabel(value)}
+                </a>
+              ) : value ? (
+                <code style={{ color: theme.t.fg2 }}>{value}</code>
+              ) : (
+                <em style={{ color: theme.t.fg3 }}>Not recorded</em>
+              )}
+            </div>
+          );
+        })}
+      </div>
+      <h3>Recorded note</h3>
+      <pre className="coverage-note" style={{ background: theme.t.surface, borderColor: theme.t.border, color: theme.t.fg2 }}>
+        {row.note || "No note recorded."}
+      </pre>
+    </div>
+  );
+}

--- a/web/src/config.ts
+++ b/web/src/config.ts
@@ -15,6 +15,8 @@ export type RuntimeConfig = {
   mappingsUrl: string;
   /** Optional: where mappings-index.json lives relative to the site root. */
   mappingsIndexUrl: string;
+  /** Optional: where the generated primary-PURL coverage report lives. */
+  mappingsReportUrl: string;
   /** Cloudflare Worker URL handling GitHub OAuth code-exchange. */
   oauthWorkerUrl: string | null;
   /** OAuth app's public client_id. */
@@ -35,6 +37,7 @@ const fromEnv: Partial<RuntimeConfig> = {
   defaultBranch: env.VITE_REPO_BRANCH,
   mappingsUrl: env.VITE_MAPPINGS_URL,
   mappingsIndexUrl: env.VITE_MAPPINGS_INDEX_URL,
+  mappingsReportUrl: env.VITE_MAPPINGS_REPORT_URL,
   oauthWorkerUrl: env.VITE_OAUTH_WORKER_URL,
   githubClientId: env.VITE_GITHUB_CLIENT_ID,
 };
@@ -48,6 +51,8 @@ export const config: RuntimeConfig = {
   mappingsUrl: injected.mappingsUrl ?? fromEnv.mappingsUrl ?? "./mappings.json",
   mappingsIndexUrl:
     injected.mappingsIndexUrl ?? fromEnv.mappingsIndexUrl ?? "./mappings-index.json",
+  mappingsReportUrl:
+    injected.mappingsReportUrl ?? fromEnv.mappingsReportUrl ?? "./mappings-report.json",
   oauthWorkerUrl: injected.oauthWorkerUrl ?? fromEnv.oauthWorkerUrl ?? null,
   githubClientId: injected.githubClientId ?? fromEnv.githubClientId ?? null,
 };

--- a/web/src/coverage-main.tsx
+++ b/web/src/coverage-main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { CoverageApp } from "./CoverageApp";
+import "./styles/colors_and_type.css";
+import "./styles/app.css";
+
+const rootElement = document.getElementById("root");
+if (!rootElement) throw new Error("#root not found");
+createRoot(rootElement).render(
+  <StrictMode>
+    <CoverageApp />
+  </StrictMode>,
+);

--- a/web/src/data/mappingsReport.test.mjs
+++ b/web/src/data/mappingsReport.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+import { createServer } from "vite";
+
+let server;
+let reports;
+
+before(async () => {
+  server = await createServer({
+    server: { middlewareMode: true, hmr: false },
+    appType: "custom",
+    logLevel: "error",
+  });
+  reports = await server.ssrLoadModule("/src/data/mappingsReport.ts");
+});
+
+after(async () => {
+  await server?.close();
+});
+
+function missing(fields = {}) {
+  return {
+    name: "missing",
+    state: "unresolved",
+    diagnostic_reason: "no_parseable_source_host",
+    version: "1.0",
+    source_url: null,
+    repo: null,
+    homepage: null,
+    note: null,
+    download_count: 10,
+    ...fields,
+  };
+}
+
+function report() {
+  return {
+    schema_version: 1,
+    input_schema_version: 3,
+    channel: "conda-forge",
+    counts: {
+      total: 3,
+      primary_present: 1,
+      explicitly_unmapped: 1,
+      unresolved: 1,
+      primary_missing: 2,
+    },
+    unresolved_by_diagnostic: {
+      recorded_processing_error: 0,
+      alternative_only: 0,
+      no_parseable_source_host: 1,
+      no_primary_from_url_evidence: 0,
+    },
+    missing_packages: [
+      missing(),
+      missing({
+        name: "rejected",
+        state: "explicitly_unmapped",
+        diagnostic_reason: null,
+        download_count: null,
+      }),
+    ],
+  };
+}
+
+test("decodes a reconciled coverage report", () => {
+  assert.deepEqual(reports.decodeMappingsReport(report()), report());
+});
+
+test("rejects inconsistent aggregate and package diagnostics", () => {
+  const aggregate = report();
+  aggregate.unresolved_by_diagnostic.no_parseable_source_host = 0;
+  assert.throws(() => reports.decodeMappingsReport(aggregate), /do not reconcile/);
+
+  const row = report();
+  row.missing_packages[0].diagnostic_reason = "alternative_only";
+  assert.throws(() => reports.decodeMappingsReport(row), /package rows do not reconcile/);
+
+  const explicit = report();
+  explicit.missing_packages[1].diagnostic_reason = "recorded_processing_error";
+  assert.throws(() => reports.decodeMappingsReport(explicit), /must be null/);
+});
+
+test("normalizes and deduplicates source hosts", () => {
+  const pkg = missing({
+    source_url: "https://GitLab.COM./group/project/archive.tar.gz",
+    repo: "https://gitlab.com:443/group/project",
+    homepage: "not an absolute URL",
+  });
+  assert.deepEqual(reports.sourceHosts(pkg), ["gitlab.com"]);
+});

--- a/web/src/data/mappingsReport.test.mjs
+++ b/web/src/data/mappingsReport.test.mjs
@@ -23,6 +23,7 @@ function missing(fields = {}) {
     name: "missing",
     state: "unresolved",
     diagnostic_reason: "no_parseable_source_host",
+    source_hosts: [],
     version: "1.0",
     source_url: null,
     repo: null,
@@ -51,6 +52,7 @@ function report() {
       no_parseable_source_host: 1,
       no_primary_from_url_evidence: 0,
     },
+    unresolved_by_source_host: [],
     missing_packages: [
       missing(),
       missing({
@@ -81,11 +83,32 @@ test("rejects inconsistent aggregate and package diagnostics", () => {
   assert.throws(() => reports.decodeMappingsReport(explicit), /must be null/);
 });
 
-test("normalizes and deduplicates source hosts", () => {
-  const pkg = missing({
+test("accepts canonical source hosts and reconciles their aggregate", () => {
+  const value = report();
+  value.unresolved_by_diagnostic.no_parseable_source_host = 0;
+  value.unresolved_by_diagnostic.no_primary_from_url_evidence = 1;
+  value.unresolved_by_source_host = [{ host: "gitlab.com", package_count: 1 }];
+  Object.assign(value.missing_packages[0], {
+    diagnostic_reason: "no_primary_from_url_evidence",
+    source_hosts: ["gitlab.com"],
     source_url: "https://GitLab.COM./group/project/archive.tar.gz",
-    repo: "https://gitlab.com:443/group/project",
-    homepage: "not an absolute URL",
   });
-  assert.deepEqual(reports.sourceHosts(pkg), ["gitlab.com"]);
+  assert.deepEqual(reports.decodeMappingsReport(value), value);
+});
+
+test("rejects noncanonical or inconsistent source hosts", () => {
+  for (const source_hosts of [
+    ["GitLab.com"],
+    ["gitlab.com."],
+    ["z.example", "a.example"],
+    ["gitlab.com", "gitlab.com"],
+  ]) {
+    const value = report();
+    value.missing_packages[0].source_hosts = source_hosts;
+    assert.throws(() => reports.decodeMappingsReport(value), /normalized, unique, sorted/);
+  }
+
+  const mismatch = report();
+  mismatch.missing_packages[0].source_hosts = ["gitlab.com"];
+  assert.throws(() => reports.decodeMappingsReport(mismatch), /package rows do not reconcile/);
 });

--- a/web/src/data/mappingsReport.ts
+++ b/web/src/data/mappingsReport.ts
@@ -1,0 +1,221 @@
+import { config } from "../config";
+import { fetchJsonWithProgress } from "./progressFetch";
+
+export const UNRESOLVED_DIAGNOSTICS = [
+  "recorded_processing_error",
+  "alternative_only",
+  "no_parseable_source_host",
+  "no_primary_from_url_evidence",
+] as const;
+
+export type UnresolvedDiagnostic = (typeof UNRESOLVED_DIAGNOSTICS)[number];
+export type MissingPrimaryState = "explicitly_unmapped" | "unresolved";
+
+export type MissingPrimaryPackage = {
+  name: string;
+  state: MissingPrimaryState;
+  diagnostic_reason: UnresolvedDiagnostic | null;
+  version: string | null;
+  source_url: string | null;
+  repo: string | null;
+  homepage: string | null;
+  note: string | null;
+  download_count: number | null;
+};
+
+export type MappingsReport = {
+  schema_version: 1;
+  input_schema_version: number;
+  channel: string;
+  counts: {
+    total: number;
+    primary_present: number;
+    explicitly_unmapped: number;
+    unresolved: number;
+    primary_missing: number;
+  };
+  unresolved_by_diagnostic: Record<UnresolvedDiagnostic, number>;
+  missing_packages: MissingPrimaryPackage[];
+};
+
+const DIAGNOSTIC_SET = new Set<string>(UNRESOLVED_DIAGNOSTICS);
+const URL_FIELDS = ["source_url", "repo", "homepage"] as const;
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be a JSON object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function integer(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function nullableString(value: unknown, label: string): string | null {
+  if (value === null) return null;
+  if (typeof value !== "string") throw new Error(`${label} must be a string or null`);
+  return value;
+}
+
+export function sourceHosts(pkg: MissingPrimaryPackage): string[] {
+  const hosts = new Set<string>();
+  for (const field of URL_FIELDS) {
+    const value = pkg[field];
+    if (!value?.trim()) continue;
+    try {
+      const hostname = new URL(value).hostname.toLowerCase().replace(/\.$/, "");
+      if (hostname) hosts.add(hostname);
+    } catch {
+      // The report intentionally keeps malformed evidence; it is not a host.
+    }
+  }
+  return [...hosts].sort();
+}
+
+export function decodeMappingsReport(value: unknown): MappingsReport {
+  const report = record(value, "mappings report");
+  if (report.schema_version !== 1) {
+    throw new Error(
+      `mappings report has unsupported schema_version ${String(report.schema_version)}`,
+    );
+  }
+  const inputSchemaVersion = integer(
+    report.input_schema_version,
+    "mappings report.input_schema_version",
+  );
+  if (typeof report.channel !== "string" || !report.channel) {
+    throw new Error("mappings report.channel must be a non-empty string");
+  }
+
+  const rawCounts = record(report.counts, "mappings report.counts");
+  const counts = {
+    total: integer(rawCounts.total, "mappings report.counts.total"),
+    primary_present: integer(
+      rawCounts.primary_present,
+      "mappings report.counts.primary_present",
+    ),
+    explicitly_unmapped: integer(
+      rawCounts.explicitly_unmapped,
+      "mappings report.counts.explicitly_unmapped",
+    ),
+    unresolved: integer(rawCounts.unresolved, "mappings report.counts.unresolved"),
+    primary_missing: integer(
+      rawCounts.primary_missing,
+      "mappings report.counts.primary_missing",
+    ),
+  };
+  if (
+    counts.primary_present + counts.explicitly_unmapped + counts.unresolved !==
+      counts.total ||
+    counts.explicitly_unmapped + counts.unresolved !== counts.primary_missing
+  ) {
+    throw new Error("mappings report coverage counts do not reconcile");
+  }
+
+  const rawDiagnostics = record(
+    report.unresolved_by_diagnostic,
+    "mappings report.unresolved_by_diagnostic",
+  );
+  if (
+    Object.keys(rawDiagnostics).length !== UNRESOLVED_DIAGNOSTICS.length ||
+    Object.keys(rawDiagnostics).some((key) => !DIAGNOSTIC_SET.has(key))
+  ) {
+    throw new Error("mappings report has unsupported unresolved diagnostics");
+  }
+  const unresolvedByDiagnostic = Object.fromEntries(
+    UNRESOLVED_DIAGNOSTICS.map((diagnostic) => [
+      diagnostic,
+      integer(
+        rawDiagnostics[diagnostic],
+        `mappings report.unresolved_by_diagnostic.${diagnostic}`,
+      ),
+    ]),
+  ) as Record<UnresolvedDiagnostic, number>;
+  if (
+    Object.values(unresolvedByDiagnostic).reduce((sum, count) => sum + count, 0) !==
+    counts.unresolved
+  ) {
+    throw new Error("mappings report unresolved diagnostics do not reconcile");
+  }
+
+  if (!Array.isArray(report.missing_packages)) {
+    throw new Error("mappings report.missing_packages must be an array");
+  }
+  const seenNames = new Set<string>();
+  const observedDiagnostics = Object.fromEntries(
+    UNRESOLVED_DIAGNOSTICS.map((diagnostic) => [diagnostic, 0]),
+  ) as Record<UnresolvedDiagnostic, number>;
+  let explicitlyUnmapped = 0;
+  let unresolved = 0;
+  const packages = report.missing_packages.map((raw, index): MissingPrimaryPackage => {
+    const label = `mappings report.missing_packages[${index}]`;
+    const pkg = record(raw, label);
+    if (typeof pkg.name !== "string" || !pkg.name || seenNames.has(pkg.name)) {
+      throw new Error(`${label}.name must be a unique non-empty string`);
+    }
+    seenNames.add(pkg.name);
+    if (pkg.state !== "explicitly_unmapped" && pkg.state !== "unresolved") {
+      throw new Error(`${label}.state is unsupported`);
+    }
+    let diagnostic: UnresolvedDiagnostic | null = null;
+    if (pkg.state === "unresolved") {
+      if (typeof pkg.diagnostic_reason !== "string" || !DIAGNOSTIC_SET.has(pkg.diagnostic_reason)) {
+        throw new Error(`${label}.diagnostic_reason is required for unresolved packages`);
+      }
+      diagnostic = pkg.diagnostic_reason as UnresolvedDiagnostic;
+      observedDiagnostics[diagnostic]++;
+      unresolved++;
+    } else {
+      if (pkg.diagnostic_reason !== null) {
+        throw new Error(`${label}.diagnostic_reason must be null when explicitly unmapped`);
+      }
+      explicitlyUnmapped++;
+    }
+    const downloads = pkg.download_count;
+    if (downloads !== null && (typeof downloads !== "number" || !Number.isInteger(downloads) || downloads < 0)) {
+      throw new Error(`${label}.download_count must be a non-negative integer or null`);
+    }
+    return {
+      name: pkg.name,
+      state: pkg.state,
+      diagnostic_reason: diagnostic,
+      version: nullableString(pkg.version, `${label}.version`),
+      source_url: nullableString(pkg.source_url, `${label}.source_url`),
+      repo: nullableString(pkg.repo, `${label}.repo`),
+      homepage: nullableString(pkg.homepage, `${label}.homepage`),
+      note: nullableString(pkg.note, `${label}.note`),
+      download_count: downloads as number | null,
+    };
+  });
+  if (
+    packages.length !== counts.primary_missing ||
+    explicitlyUnmapped !== counts.explicitly_unmapped ||
+    unresolved !== counts.unresolved ||
+    UNRESOLVED_DIAGNOSTICS.some(
+      (diagnostic) => observedDiagnostics[diagnostic] !== unresolvedByDiagnostic[diagnostic],
+    )
+  ) {
+    throw new Error("mappings report package rows do not reconcile with aggregate counts");
+  }
+
+  return {
+    schema_version: 1,
+    input_schema_version: inputSchemaVersion,
+    channel: report.channel,
+    counts,
+    unresolved_by_diagnostic: unresolvedByDiagnostic,
+    missing_packages: packages,
+  };
+}
+
+export async function loadMappingsReport(
+  path = config.mappingsReportUrl,
+): Promise<MappingsReport> {
+  return decodeMappingsReport(
+    await fetchJsonWithProgress<unknown>(path, { cache: "no-cache" }),
+  );
+}

--- a/web/src/data/mappingsReport.ts
+++ b/web/src/data/mappingsReport.ts
@@ -15,6 +15,7 @@ export type MissingPrimaryPackage = {
   name: string;
   state: MissingPrimaryState;
   diagnostic_reason: UnresolvedDiagnostic | null;
+  source_hosts: string[];
   version: string | null;
   source_url: string | null;
   repo: string | null;
@@ -35,11 +36,11 @@ export type MappingsReport = {
     primary_missing: number;
   };
   unresolved_by_diagnostic: Record<UnresolvedDiagnostic, number>;
+  unresolved_by_source_host: Array<{ host: string; package_count: number }>;
   missing_packages: MissingPrimaryPackage[];
 };
 
 const DIAGNOSTIC_SET = new Set<string>(UNRESOLVED_DIAGNOSTICS);
-const URL_FIELDS = ["source_url", "repo", "homepage"] as const;
 
 function record(value: unknown, label: string): Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
@@ -61,19 +62,22 @@ function nullableString(value: unknown, label: string): string | null {
   return value;
 }
 
-export function sourceHosts(pkg: MissingPrimaryPackage): string[] {
-  const hosts = new Set<string>();
-  for (const field of URL_FIELDS) {
-    const value = pkg[field];
-    if (!value?.trim()) continue;
-    try {
-      const hostname = new URL(value).hostname.toLowerCase().replace(/\.$/, "");
-      if (hostname) hosts.add(hostname);
-    } catch {
-      // The report intentionally keeps malformed evidence; it is not a host.
+function sourceHostArray(value: unknown, label: string): string[] {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  let previous: string | null = null;
+  return value.map((item, index) => {
+    if (
+      typeof item !== "string" ||
+      !item ||
+      item !== item.toLowerCase() ||
+      item.endsWith(".") ||
+      (previous !== null && item <= previous)
+    ) {
+      throw new Error(`${label}[${index}] must be a normalized, unique, sorted host`);
     }
-  }
-  return [...hosts].sort();
+    previous = item;
+    return item;
+  });
 }
 
 export function decodeMappingsReport(value: unknown): MappingsReport {
@@ -142,6 +146,37 @@ export function decodeMappingsReport(value: unknown): MappingsReport {
     throw new Error("mappings report unresolved diagnostics do not reconcile");
   }
 
+  if (!Array.isArray(report.unresolved_by_source_host)) {
+    throw new Error("mappings report.unresolved_by_source_host must be an array");
+  }
+  const unresolvedBySourceHost = report.unresolved_by_source_host.map(
+    (raw, index) => {
+      const label = `mappings report.unresolved_by_source_host[${index}]`;
+      const item = record(raw, label);
+      if (typeof item.host !== "string" || !item.host) {
+        throw new Error(`${label}.host must be a non-empty string`);
+      }
+      return {
+        host: item.host,
+        package_count: integer(item.package_count, `${label}.package_count`),
+      };
+    },
+  );
+  for (let index = 0; index < unresolvedBySourceHost.length; index++) {
+    const current = unresolvedBySourceHost[index];
+    const previous = unresolvedBySourceHost[index - 1];
+    if (
+      current.host !== current.host.toLowerCase() ||
+      current.host.endsWith(".") ||
+      current.package_count === 0 ||
+      (previous &&
+        (current.package_count > previous.package_count ||
+          (current.package_count === previous.package_count && current.host <= previous.host)))
+    ) {
+      throw new Error("mappings report unresolved source hosts are not normalized and sorted");
+    }
+  }
+
   if (!Array.isArray(report.missing_packages)) {
     throw new Error("mappings report.missing_packages must be an array");
   }
@@ -149,6 +184,7 @@ export function decodeMappingsReport(value: unknown): MappingsReport {
   const observedDiagnostics = Object.fromEntries(
     UNRESOLVED_DIAGNOSTICS.map((diagnostic) => [diagnostic, 0]),
   ) as Record<UnresolvedDiagnostic, number>;
+  const observedSourceHosts = new Map<string, number>();
   let explicitlyUnmapped = 0;
   let unresolved = 0;
   const packages = report.missing_packages.map((raw, index): MissingPrimaryPackage => {
@@ -175,6 +211,12 @@ export function decodeMappingsReport(value: unknown): MappingsReport {
       }
       explicitlyUnmapped++;
     }
+    const sourceHosts = sourceHostArray(pkg.source_hosts, `${label}.source_hosts`);
+    if (pkg.state === "unresolved") {
+      for (const host of sourceHosts) {
+        observedSourceHosts.set(host, (observedSourceHosts.get(host) ?? 0) + 1);
+      }
+    }
     const downloads = pkg.download_count;
     if (downloads !== null && (typeof downloads !== "number" || !Number.isInteger(downloads) || downloads < 0)) {
       throw new Error(`${label}.download_count must be a non-negative integer or null`);
@@ -183,6 +225,7 @@ export function decodeMappingsReport(value: unknown): MappingsReport {
       name: pkg.name,
       state: pkg.state,
       diagnostic_reason: diagnostic,
+      source_hosts: sourceHosts,
       version: nullableString(pkg.version, `${label}.version`),
       source_url: nullableString(pkg.source_url, `${label}.source_url`),
       repo: nullableString(pkg.repo, `${label}.repo`),
@@ -197,6 +240,10 @@ export function decodeMappingsReport(value: unknown): MappingsReport {
     unresolved !== counts.unresolved ||
     UNRESOLVED_DIAGNOSTICS.some(
       (diagnostic) => observedDiagnostics[diagnostic] !== unresolvedByDiagnostic[diagnostic],
+    ) ||
+    unresolvedBySourceHost.length !== observedSourceHosts.size ||
+    unresolvedBySourceHost.some(
+      ({ host, package_count }) => observedSourceHosts.get(host) !== package_count,
     )
   ) {
     throw new Error("mappings report package rows do not reconcile with aggregate counts");
@@ -208,6 +255,7 @@ export function decodeMappingsReport(value: unknown): MappingsReport {
     channel: report.channel,
     counts,
     unresolved_by_diagnostic: unresolvedByDiagnostic,
+    unresolved_by_source_host: unresolvedBySourceHost,
     missing_packages: packages,
   };
 }

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -17,3 +17,96 @@ input[type="checkbox"] { accent-color: #ffd432; }
 
 @keyframes slideIn { from { transform: translateX(100%); } to { transform: translateX(0); } }
 @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+
+.coverage-page { width: 100%; min-height: 100vh; overflow-x: hidden; }
+.coverage-header {
+  min-height: 52px;
+  padding: 10px 18px;
+  border-bottom: 1px solid;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+.coverage-header-left, .coverage-nav, .coverage-repo {
+  display: flex;
+  align-items: center;
+}
+.coverage-header-left { gap: 14px; min-width: 0; }
+.coverage-nav {
+  gap: 6px;
+  border-left: 1px solid;
+  padding-left: 14px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+}
+.coverage-nav a { padding: 4px 8px; border-radius: 6px; text-decoration: none; white-space: nowrap; }
+.coverage-repo { gap: 6px; padding: 3px 8px; border-radius: 4px; font: 11px "JetBrains Mono", monospace; }
+.coverage-theme { width: 30px; height: 30px; border: 1px solid; border-radius: 8px; cursor: pointer; }
+.coverage-main { width: 100%; max-width: 1600px; margin: 0 auto; padding: 28px; }
+.coverage-intro { display: flex; align-items: end; justify-content: space-between; gap: 24px; margin-bottom: 20px; }
+.coverage-intro > div { min-width: 0; }
+.coverage-intro h1 { margin: 3px 0 6px; font-size: clamp(26px, 4vw, 42px); line-height: 1; }
+.coverage-intro p { margin: 0; max-width: 760px; font-size: 13px; line-height: 1.5; }
+.coverage-eyebrow { margin: 0; font-size: 10px; font-weight: 700; letter-spacing: .12em; }
+.coverage-contract { font: 11px "JetBrains Mono", monospace; white-space: nowrap; }
+.coverage-summary { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; margin-bottom: 14px; }
+.coverage-summary-card { min-width: 0; border: 1px solid; border-radius: 10px; padding: 14px 16px; display: flex; flex-direction: column; gap: 4px; }
+.coverage-summary-card span { font-size: 11px; text-transform: uppercase; letter-spacing: .06em; }
+.coverage-summary-card strong { font: 700 24px "JetBrains Mono", monospace; }
+.coverage-workspace { width: 100%; min-width: 0; border: 1px solid; border-radius: 12px; overflow: hidden; }
+.coverage-toolbar { padding: 10px; border-bottom: 1px solid; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.coverage-search { height: 34px; min-width: 280px; flex: 1; border: 1px solid; border-radius: 7px; display: flex; align-items: center; gap: 7px; padding: 0 10px; }
+.coverage-search input { width: 100%; border: 0; outline: 0; background: transparent; font-size: 12px; }
+.coverage-result-count { margin-left: auto; font-size: 11px; white-space: nowrap; }
+.coverage-browser { width: 100%; min-width: 0; display: grid; grid-template-columns: minmax(0, 1fr) 360px; min-height: 580px; height: calc(100vh - 290px); }
+.coverage-table-wrap { width: 100%; max-width: 100%; overflow: auto; min-width: 0; }
+.coverage-table { width: 100%; border-collapse: collapse; table-layout: fixed; font-size: 12px; }
+.coverage-table th { position: sticky; top: 0; z-index: 1; padding: 9px 10px; text-align: left; font-size: 10px; text-transform: uppercase; letter-spacing: .06em; }
+.coverage-table th:nth-child(1) { width: 20%; }
+.coverage-table th:nth-child(2) { width: 20%; }
+.coverage-table th:nth-child(3) { width: 12%; }
+.coverage-table th:nth-child(4) { width: 13%; }
+.coverage-table th:nth-child(5) { width: 35%; }
+.coverage-table td { padding: 8px 10px; border-top: 1px solid; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.coverage-table tbody tr { cursor: pointer; }
+.coverage-table tbody tr:hover { filter: brightness(.98); }
+.coverage-diagnostic-pill { display: inline-flex; max-width: 100%; padding: 3px 7px; border-radius: 999px; font-size: 10px; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.coverage-detail { border-left: 1px solid; padding: 20px; overflow: auto; }
+.coverage-detail h2 { margin: 4px 0 18px; font-size: 24px; overflow-wrap: anywhere; }
+.coverage-detail h3 { margin: 22px 0 8px; font-size: 11px; text-transform: uppercase; letter-spacing: .06em; }
+.coverage-facts { display: grid; grid-template-columns: 82px minmax(0, 1fr); gap: 8px; margin: 0; font-size: 12px; }
+.coverage-facts dt, .coverage-facts dd { margin: 0; }
+.coverage-diagnostic-box, .coverage-note { border: 1px solid; border-radius: 8px; }
+.coverage-diagnostic-box { margin-top: 18px; padding: 12px; }
+.coverage-diagnostic-box p { margin: 8px 0 0; font-size: 12px; line-height: 1.5; }
+.coverage-links { display: grid; gap: 10px; }
+.coverage-links div { display: grid; gap: 3px; min-width: 0; }
+.coverage-links span { font-size: 10px; text-transform: uppercase; }
+.coverage-links a { font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.coverage-links em { font-size: 12px; }
+.coverage-note { margin: 0; padding: 10px; font: 11px/1.5 "JetBrains Mono", monospace; white-space: pre-wrap; overflow-wrap: anywhere; }
+.coverage-empty, .coverage-loading, .coverage-error { padding: 40px; text-align: center; font-size: 13px; }
+.coverage-error { border: 1px solid; border-radius: 10px; }
+.mono { font-family: "JetBrains Mono", monospace; }
+
+@media (max-width: 1000px) {
+  .coverage-main { padding: 18px; }
+  .coverage-browser { grid-template-columns: 1fr; height: auto; }
+  .coverage-table-wrap { max-height: 560px; }
+  .coverage-detail { border-left: 0; border-top: 1px solid; }
+}
+@media (max-width: 720px) {
+  .coverage-repo, .coverage-contract { display: none; }
+  .coverage-header { align-items: flex-start; }
+  .coverage-header-left { align-items: flex-start; flex-wrap: wrap; }
+  .coverage-nav { order: 3; width: 100%; border-left: 0; padding-left: 0; }
+  .coverage-main { padding: 14px; }
+  .coverage-summary { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .coverage-toolbar { align-items: stretch; }
+  .coverage-search, .coverage-toolbar select { width: 100%; min-width: 0; }
+  .coverage-result-count { margin-left: 0; padding: 4px; }
+  .coverage-table { min-width: 850px; }
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     rollupOptions: {
       input: {
         main: resolve(__dirname, "index.html"),
+        coverage: resolve(__dirname, "coverage.html"),
       },
     },
   },


### PR DESCRIPTION
## Summary

Completes [PFX-1962 — Measure and categorize missing PURL identities](https://linear.app/prefix-dev/issue/PFX-1962/measure-and-categorize-missing-purl-identities).

- Adds a read-only, deterministic report over the freshly merged mapping bundle.
- Separates packages with a primary PURL, explicit no-PURL decisions, and unresolved packages.
- Assigns every unresolved package one conservative recorded-evidence diagnostic.
- Publishes canonical per-package source hosts and a non-exclusive source-host breakdown.
- Adds a GitHub Pages inspector with state, diagnostic, host, and text filters.
- Adds before/after coverage and diagnostic deltas to recurring automap PR bodies.

This PR changes observability only. It does not add mapper heuristics, create identities, or automatically declare packages unmappable.

## Report contract

The JSON report is generated with:

```bash
pixi run -e lite mappings:report
```

Top-level states reconcile exactly:

```text
primary_present + explicitly_unmapped + unresolved = total
```

Unresolved diagnostics also reconcile exactly:

- `recorded_processing_error`
- `alternative_only`
- `no_parseable_source_host`
- `no_primary_from_url_evidence`

Diagnostics describe persisted evidence, not authoritative root causes. Only `unmapped: true` records an intentional no-PURL decision.

Each missing-primary row includes normalized, sorted `source_hosts`. The `unresolved_by_source_host` aggregate counts a host once per unresolved package. Host groups are non-exclusive because one package may cite multiple hosts.

## GitHub Pages inspector

After merge and Pages deployment:

https://prefix-dev.github.io/purl-associator/coverage.html

The read-only page provides:

- reconciled coverage totals;
- state, diagnostic, source-host, and text filters;
- download-prioritized missing packages;
- recorded source, repository, homepage, and diagnostic-note evidence;
- navigation from the existing mapping editor.

The generated report is approximately 1.3 MB, is rebuilt during Pages deployment, and is not committed.

## Automap PR deltas

The automap workflow now captures a baseline report before refreshing mappings and appends deterministic Markdown to its PR body showing:

- total, primary-present, explicitly-unmapped, unresolved, and primary-missing deltas;
- per-diagnostic deltas;
- the top current unresolved source hosts.

## Current baseline

Reproduced from the effective merged payload. Coverage is unchanged because this PR only measures existing data.

| State | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Total packages | 34,225 | 34,225 | 0 |
| Primary PURL present | 31,265 | 31,265 | 0 |
| Explicitly unmapped | 6 | 6 | 0 |
| Unresolved | 2,954 | 2,954 | 0 |
| Primary PURL missing | 2,960 | 2,960 | 0 |

| Unresolved diagnostic | Count |
| --- | ---: |
| Recorded processing error | 91 |
| Alternative PURL only | 0 |
| No parseable source host | 7 |
| URL evidence without a primary PURL | 2,856 |

The report currently identifies 748 distinct source hosts across unresolved packages.

## Validation

- `pixi run -e lite mappings:test` — 38 passed, 1 expected skip.
- Browser decoder/UI data tests — 50 passed.
- Ruff lint and formatting pass.
- Mapping bundle/index/shard validation passes.
- TypeScript and Vite multipage production build pass.
- The real report decodes all 2,960 missing-primary rows and 748 host groups.
- A local no-change automap simulation renders reconciled zero deltas.
- Desktop and narrow-viewport smoke renders pass.
- Required GitHub `validate` check passes.

## Deliberately deferred

Input fingerprints are not included. The report already validates the current mapping schema, omits volatile generation timestamps, and is byte-deterministic for identical effective inputs. Fingerprints are not required by PFX-1962’s acceptance criteria.

